### PR TITLE
Adding mempool and memnode for managing elastic buffers

### DIFF
--- a/common/c_cpp/src/c/SConscript.win
+++ b/common/c_cpp/src/c/SConscript.win
@@ -19,6 +19,8 @@ property.c
 wMessageStats.c
 libyywrap.c
 fileparser.c
+mempool.c
+memnode.c
 windows/strpcasecmp.c
 windows/strptime.c
 windows/platform.c

--- a/common/c_cpp/src/c/commonc.vcproj
+++ b/common/c_cpp/src/c/commonc.vcproj
@@ -417,6 +417,14 @@
 				>
 			</File>
 			<File
+				RelativePath=".\memnode.c"
+				>
+			</File>
+			<File
+				RelativePath=".\mempool.c"
+				>
+			</File>
+			<File
 				RelativePath=".\windows\network.c"
 				>
 			</File>

--- a/common/c_cpp/src/c/memnode.c
+++ b/common/c_cpp/src/c/memnode.c
@@ -1,0 +1,131 @@
+/* $Id$
+ *
+ * OpenMAMA: The open middleware agnostic messaging API
+ * Copyright (C) 2011 NYSE Technologies, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <errno.h>
+
+#include <wombat/memnode.h>
+
+
+memoryNode*
+memoryNode_create        (size_t              size)
+{
+    memoryNode* newNode = NULL;
+    newNode = (memoryNode*) calloc (1, sizeof(memoryNode));
+    if (NULL == newNode)
+    {
+        errno = ENOMEM;
+        return NULL;
+    }
+    if (size > 0)
+    {
+        if (0 != allocateBufferMemory ((void**)&newNode->mNodeBuffer,
+                                       &newNode->mNodeCapacity,
+                                       size))
+        {
+            errno = ENOMEM;
+            free (newNode);
+            return NULL;
+        }
+    }
+
+    return newNode;
+}
+
+int
+memoryNode_stretch       (memoryNode*         node,
+                          size_t              size)
+{
+    return allocateBufferMemory ((void**)&node->mNodeBuffer,
+                                 &node->mNodeCapacity,
+                                 size);
+}
+
+void
+memoryNode_empty         (memoryNode*          node)
+{
+    if (NULL != node->mNodeBuffer)
+    {
+        free (node->mNodeBuffer);
+        node->mNodeBuffer = NULL;
+        node->mNodeCapacity = 0;
+        node->mNodeSize = 0;
+    }
+}
+
+void
+memoryNode_destroy       (memoryNode*         node)
+{
+    memoryNode_empty (node);
+    free (node);
+}
+
+int
+allocateBufferMemory     (void**       buffer,
+                          size_t*      size,
+                          size_t       newSize)
+{
+    void* newbuf = NULL;
+
+    if (0 == *size || NULL == *buffer)
+    {
+        newbuf = calloc (newSize, 1);
+
+        if (newbuf == NULL)
+        {
+            errno = ENOMEM;
+            return -1;
+        }
+        else
+        {
+            *buffer = newbuf;
+            *size   = newSize;
+            return 0;
+        }
+    }
+    else if (newSize > *size)
+    {
+        newbuf = realloc (*buffer, newSize);
+
+        if (newbuf == NULL)
+        {
+            errno = ENOMEM;
+            return -1;
+        }
+        else
+        {
+            /* set newly added bytes to 0 */
+            memset ((uint8_t*) newbuf + *size, 0, newSize - *size);
+
+            *buffer = newbuf;
+            *size   = newSize;
+            return 0;
+        }
+    }
+    else
+    {
+        /* No allocation / reallocation required */
+        return 0;
+    }
+}

--- a/common/c_cpp/src/c/mempool.c
+++ b/common/c_cpp/src/c/mempool.c
@@ -1,0 +1,212 @@
+/* $Id$
+ *
+ * OpenMAMA: The open middleware agnostic messaging API
+ * Copyright (C) 2011 NYSE Technologies, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <errno.h>
+
+#include <wombat/mempool.h>
+#include <wombat/memnode.h>
+
+#define POOL_ALLOCATE_BLOCK_SIZE 256
+#define POOL_ALLOCATE_BLOCK_MASK 0xff
+
+
+memoryPool*
+memoryPool_create (size_t poolSize, size_t nodeSize)
+{
+    memoryPool* newPool = NULL;
+    memoryNode* newNode = NULL;
+    size_t i = 0;
+
+    if (poolSize < 2)
+    {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    newPool = (memoryPool*) calloc (1, sizeof(memoryPool));
+    if (NULL == newPool)
+    {
+        errno = ENOMEM;
+        return NULL;
+    }
+
+    newPool->mAllocateBlockSize = poolSize;
+
+    wthread_mutex_init(&newPool->mLock, NULL);
+
+    /* Extend the message pool */
+    for (i = 0; i < poolSize; i++)
+    {
+        newNode = memoryPool_addNode (newPool, nodeSize);
+        /* If a node allocation failed, abort whole operation */
+        if (NULL == newNode)
+        {
+            /* Nodes don't get linked until allocation so this is safe */
+            memoryPool_destroy (newPool, NULL);
+            errno = ENOMEM;
+            return NULL;
+        }
+    }
+    return newPool;
+}
+
+memoryNode*
+memoryPool_addNode (memoryPool* pool, size_t nodeSize)
+{
+    memoryNode* newNode = memoryNode_create (nodeSize);
+
+    if (NULL == newNode)
+    {
+        return NULL;
+    }
+
+    /* Only allocate the tracker array every POOL_ALLOCATE_BLOCK_SIZE */
+    if ((pool->mNumNodesTotal & POOL_ALLOCATE_BLOCK_MASK) == 0)
+    {
+        size_t newSize = sizeof(memoryNode*) *
+                (POOL_ALLOCATE_BLOCK_SIZE + pool->mNumNodesTotal);
+        /* If we can't track this node, put it back */
+        if (0 != memoryNode_stretch (&pool->mAllocatedNodes, newSize))
+        {
+            memoryNode_destroy(newNode);
+            return NULL;
+        }
+    }
+
+    memoryNode** tracker = (memoryNode**)pool->mAllocatedNodes.mNodeBuffer;
+
+    /* Update tracker array with newly created node */
+    tracker[pool->mNumNodesTotal] = newNode;
+
+    /*
+     * For the first message in the pool, we point the freelist
+     * value to it. We then assign the currentNode to this value.
+     */
+    if (pool->mNumNodesTotal != 0)
+    {
+        newNode->mNext = pool->mFreeList;
+    }
+    pool->mFreeList = newNode;
+
+    newNode->mPool = pool;
+
+    /* Increment the free count for the message pool */
+    pool->mNumNodesTotal++;
+    pool->mNumNodesFree++;
+
+    return newNode;
+}
+
+memoryNode*
+memoryPool_getNode (memoryPool* pool, size_t nodeSize)
+{
+    memoryNode*  newNode  = NULL;
+
+    wthread_mutex_lock(&pool->mLock);
+
+    /*
+     * Check if any buffers remain in the freeList, and if not extend the buffer
+     */
+    if (1 == pool->mNumNodesFree)
+    {
+        memoryPool_addNode (pool, nodeSize);
+    }
+
+    /*
+     * Remove the next available node from the pool free list: get the node
+     * pointer then assign the pool free list pointer to the next available free
+     * node. Reduce the pool free message count by one.
+     */
+    newNode = pool->mFreeList;
+    pool->mFreeList = newNode->mNext;
+    pool->mNumNodesFree--;
+
+    wthread_mutex_unlock(&pool->mLock);
+
+    memoryNode_stretch (newNode, nodeSize);
+
+    return newNode;
+}
+
+
+void
+memoryPool_returnNode (memoryPool* pool, memoryNode* node)
+{
+    wthread_mutex_lock(&pool->mLock);
+
+    /* Move returned node to the front of the freelist */
+    node->mNext     = pool->mFreeList;
+    pool->mFreeList = node;
+    pool->mNumNodesFree++;
+
+    wthread_mutex_unlock(&pool->mLock);
+    return;
+}
+
+void
+memoryPool_iterate (memoryPool* pool, memoryPoolIteratorCb callback)
+{
+    size_t      i = 0;
+    memoryNode* node = NULL;
+    wthread_mutex_lock(&pool->mLock);
+    memoryNode** tracker = (memoryNode**)pool->mAllocatedNodes.mNodeBuffer;
+    for (i = 0; i < pool->mNumNodesTotal; i++)
+    {
+        node = tracker[pool->mNumNodesTotal];
+        if (NULL != node)
+        {
+            if (NULL != callback)
+            {
+                callback (pool, node);
+            }
+        }
+    }
+    wthread_mutex_unlock(&pool->mLock);
+}
+
+void
+memoryPool_destroy (memoryPool* pool, memoryPoolIteratorCb callback)
+{
+    size_t      i = 0;
+    memoryNode* node = NULL;
+    wthread_mutex_lock(&pool->mLock);
+    memoryNode** tracker = (memoryNode**)pool->mAllocatedNodes.mNodeBuffer;
+    for (i = 0; i < pool->mNumNodesTotal; i++)
+    {
+        node = tracker[pool->mNumNodesTotal];
+        if (NULL != node)
+        {
+            if (NULL != callback)
+            {
+                callback (pool, node);
+            }
+            memoryNode_empty(node);
+        }
+    }
+    wthread_mutex_unlock(&pool->mLock);
+    wthread_mutex_destroy(&pool->mLock);
+    free (pool);
+}
+

--- a/common/c_cpp/src/c/wombat/memdefs.h
+++ b/common/c_cpp/src/c/wombat/memdefs.h
@@ -1,0 +1,65 @@
+/* $Id$
+ *
+ * OpenMAMA: The open middleware agnostic messaging API
+ * Copyright (C) 2011 NYSE Technologies, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+#include <wombat/wSemaphore.h>
+
+#ifndef WOMBAT_MEMDEFS_H__
+#define WOMBAT_MEMDEFS_H__
+
+/*=========================================================================
+  =                             Includes                                  =
+  =========================================================================*/
+
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+typedef struct memoryNode_ memoryNode;
+typedef struct memoryPool_ memoryPool;
+
+struct memoryNode_
+{
+
+    size_t          mNodeSize;          /* The size of data in buffer */
+    size_t          mNodeCapacity;      /* Total bytes in buffer */
+    uint8_t*        mNodeBuffer;        /* The data itself */
+    memoryNode*     mNext;              /* If part of pool, this is next node */
+    memoryPool*     mPool;              /* If part of pool, this is the pool */
+};
+
+struct memoryPool_
+{
+    memoryNode*     mFreeList;          /* Linked list of avail nodes */
+    size_t          mAllocateBlockSize; /* mAllocatedNodes buffer will be
+                                           extended in blocks of this size */
+    memoryNode      mAllocatedNodes;    /* Node containing tracker array */
+    size_t          mNumNodesTotal;     /* Number of nodes in the pool */
+    size_t          mNumNodesFree;      /* Number of free nodes in the pool */
+    wthread_mutex_t mLock;
+};
+
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* WOMBAT_MEMDEFS_H__ */

--- a/common/c_cpp/src/c/wombat/memnode.h
+++ b/common/c_cpp/src/c/wombat/memnode.h
@@ -1,0 +1,111 @@
+/* $Id$
+ *
+ * OpenMAMA: The open middleware agnostic messaging API
+ * Copyright (C) 2011 NYSE Technologies, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+#ifndef WOMBAT_MEMNODE_H__
+#define WOMBAT_MEMNODE_H__
+
+#include <wombat/memdefs.h>
+
+/*=========================================================================
+  =                             Includes                                  =
+  =========================================================================*/
+
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/**
+ * A memory node is a data structure which manages an underlying elastic buffer.
+ * This method will attempt to allocate a new instance of a memory node.
+ *
+ * @param size        Size of the underlying buffer to allocate when creating
+ *                    this memory node.
+ *
+ * @return Will return a pointer to the new node on success and NULL on failure,
+ *         setting errno appropriately.
+ */
+memoryNode*
+memoryNode_create        (size_t              size);
+
+/**
+ * This function will set the size of the underlying buffer to the requested
+ * size. If this is smaller than the existing size, no action will be taken. If
+ * this is larger, the buffer will be reallocated.
+ *
+ * @param node        The memory node to update.
+ * @param size        Size of the underlying buffer to allocate when creating
+ *                    this memory node.
+ *
+ * @return Will return 0 on success and -1 on failure, setting errno
+ *         appropriately.
+ */
+int
+memoryNode_stretch       (memoryNode*         node,
+                          size_t              size);
+
+/**
+ * This will empty the underlying buffer and set its size to zero without
+ * destroying the node itself.
+ *
+ * @param node        The memory node to empty.
+ */
+void
+memoryNode_empty         (memoryNode*         node);
+
+/**
+ * This will destroy the memory node provided and empty the underlying buffer.
+ * Note this will not remove the node from any parent memory pools - that needs
+ * to be handled separately.
+ *
+ * @param node        The memory node to empty.
+ */
+void
+memoryNode_destroy       (memoryNode*         node);
+
+/**
+ * This function exists to centralize the allocation of buffer memory. When
+ * called for the first time with an empty buffer, it will calloc the requested
+ * memory. When requesting a size smaller than the current size, it will do
+ * nothing. When requesting a size larger than the current size, it will perform
+ * a realloc. On success, 0 will be returned, and if necessary, the buffer
+ * pointer will be written back to reflect the new value. The currentSize
+ * pointer will also be modified to reflect the new size. On failure, -1
+ * will be returned indicating an error, errno will be set and the buffer and
+ * current size will remain unchanged.
+ *
+ * @param buffer      Pointer to the buffer to examine and resize if necessary.
+ * @param size        Current size of the buffer. Will be updated with the newly
+ *                    requested newSize on success.
+ * @param newSize     The newly requested buffer size.
+ *
+ * @return Will return 0 on success and -1 on failure.
+ */
+int
+allocateBufferMemory     (void**       buffer,
+                          size_t*      size,
+                          size_t       newSize);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* WOMBAT_MEMNODE_H__ */

--- a/common/c_cpp/src/c/wombat/mempool.h
+++ b/common/c_cpp/src/c/wombat/mempool.h
@@ -1,0 +1,109 @@
+/* $Id$
+ *
+ * OpenMAMA: The open middleware agnostic messaging API
+ * Copyright (C) 2011 NYSE Technologies, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+#include <wombat/wSemaphore.h>
+
+#ifndef WOMBAT_MEMPOOL_H__
+#define WOMBAT_MEMPOOL_H__
+
+#include <wombat/memdefs.h>
+
+/*=========================================================================
+  =                             Includes                                  =
+  =========================================================================*/
+
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+typedef void (*memoryPoolIteratorCb)(memoryPool* pool, memoryNode* node);
+
+/**
+ * This function will create a new memory pool containing a number of nodes. The
+ * number of nodes is growable so new nodes will be allocated and added to the
+ * pool even after the initial pool size has been filled. This implementation is
+ * thread safe.
+ *
+ * @param poolSize      This is the initial number of nodes to be created in the
+ *                      pool at create time.
+ * @param nodeSize      This is the size of each node which is to be created at
+ *                      create time.
+ *
+ * @return Newly created memory pool.
+ */
+memoryPool* memoryPool_create       (size_t poolSize, size_t nodeSize);
+
+/**
+ * This function will add a single node of the provided size to the memory pool
+ *
+ * @param pool          The pool to add a new node to.
+ * @param nodeSize      The size of the new node to be created before adding to
+ *                      the pool.
+ *
+ * @return Returns newly created node on success and NULL on failure.
+ */
+memoryNode* memoryPool_addNode      (memoryPool* pool, size_t nodeSize);
+
+/**
+ * This function will return a node from the provided memory pool and will
+ * ensure that it will be the requested size before it's handed to the caller.
+ *
+ * @param pool          The pool to get the node from.
+ * @param nodeSize      The size of the new node to be pulled out of the pool.
+ *
+ * @return Next available memory node of the requested size.
+ */
+memoryNode* memoryPool_getNode      (memoryPool* pool, size_t nodeSize);
+
+/**
+ * This function will return the provided node back into the pool provided.
+ *
+ * @param pool          The pool to return the node to.
+ * @param node          The node to be returned.
+ */
+void        memoryPool_returnNode   (memoryPool* pool, memoryNode* node);
+
+/**
+ * This function will call the iterator callback for every allocated node.
+ *
+ * @param pool          The pool to return the node to.
+ * @param node          The callback to be triggered
+ */
+void        memoryPool_iterate      (memoryPool*            pool,
+                                     memoryPoolIteratorCb   callback);
+/**
+ * This function will destroy the pool and all members within it in a non-thread
+ * safe manner as it assumes all nodes have been returned before this function
+ * is called.
+ *
+ * @param pool          The pool to return the node to.
+ * @param callback      This callback will be triggered before each node is
+ *                      destroyed to let the caller do any cleanup required.
+ */
+void        memoryPool_destroy      (memoryPool*            pool,
+                                     memoryPoolIteratorCb   callback);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* WOMBAT_MEMPOOL_H__ */


### PR DESCRIPTION
This moves some code which was used in the qpid proton bridge for memory pool management into the common library as well as the allocateBufferMemory utility function. Once the qpid broker functionality is merged, the relevant changes for qpid to use the new common functions will be merged in too.