### PR TITLE
QPID: Added several fixed for unit tests under qpid

### DIFF
--- a/mama/c_cpp/src/c/bridge/qpid/publisher.c
+++ b/mama/c_cpp/src/c/bridge/qpid/publisher.c
@@ -174,14 +174,16 @@ qpidBridgeMamaPublisher_createByIndex (publisherBridge*     result,
                                       &impl->mTopic,
                                       (transportBridge) impl->mTransport);
 
-
-    /* Generate subject URI based on standardized values */
-    qpidBridgeCommon_generateSubjectUri (outgoingAddress,
-                                         impl->mRoot,
-                                         impl->mSource,
-                                         impl->mTopic,
-                                         uuid,
-                                         &impl->mUri);
+    if (NULL != outgoingAddress)
+    {
+        /* Generate subject URI based on standardized values */
+        qpidBridgeCommon_generateSubjectUri (outgoingAddress,
+                                             impl->mRoot,
+                                             impl->mSource,
+                                             impl->mTopic,
+                                             uuid,
+                                             &impl->mUri);
+    }
 
     /* Create a reusable proton message */
     impl->mQpidRawMsg = pn_message ();

--- a/mama/c_cpp/src/c/bridge/qpid/subscription.c
+++ b/mama/c_cpp/src/c/bridge/qpid/subscription.c
@@ -112,13 +112,16 @@ qpidBridgeMamaSubscription_create (subscriptionBridge* subscriber,
                                       &impl->mTopic,
                                       impl->mTransport);
 
-    /* Generate subject URI based on standardized values */
-    qpidBridgeCommon_generateSubjectUri (outgoingAddress,
-                                         impl->mRoot,
-                                         impl->mSource,
-                                         impl->mTopic,
-                                         uuid,
-                                         &impl->mUri);
+    if (NULL != outgoingAddress)
+    {
+        /* Generate subject URI based on standardized values */
+        qpidBridgeCommon_generateSubjectUri (outgoingAddress,
+                                             impl->mRoot,
+                                             impl->mSource,
+                                             impl->mTopic,
+                                             uuid,
+                                             &impl->mUri);
+    }
 
     /* Register the endpoint */
     endpointPool_registerWithoutIdentifier (transport->mSubEndpoints,
@@ -155,15 +158,17 @@ qpidBridgeMamaSubscription_create (subscriptionBridge* subscriber,
         /* Send out the subscription registration of interest message */
         if (NULL != transport->mOutgoingAddress)
         {
+            int ret = 0;
             pn_messenger_put    (transport->mOutgoing, transport->mMsg);
 
-            if (0 != pn_messenger_send (transport->mOutgoing,
-                    QPID_MESSENGER_SEND_TIMEOUT))
+
+            if (0 != (ret = pn_messenger_send (transport->mOutgoing,
+                    QPID_MESSENGER_SEND_TIMEOUT)))
             {
                 const char* qpid_error = PN_MESSENGER_ERROR (transport->mOutgoing);
                 mama_log (MAMA_LOG_LEVEL_SEVERE,
                           "qpidBridgeMamaSubscription_create(): "
-                          "pn_messenger_send Error:[%s]", qpid_error);
+                          "pn_messenger_send Error:[%d:%s]", ret, qpid_error);
                 return MAMA_STATUS_PLATFORM;
             }
         }

--- a/mama/c_cpp/src/c/payload/qpidmsg/qpidcommon.h
+++ b/mama/c_cpp/src/c/payload/qpidmsg/qpidcommon.h
@@ -45,7 +45,6 @@ extern "C" {
   =                              Macros                                   =
   =========================================================================*/
 
-#define PN_OK                           0
 #define QPID_FIELDS_PER_MAMA_FIELD      4
 #define QPID_BYTE_BUFFER_SIZE           102400
 #define QPID_FIELD_BUFFER_POOL_SIZE     64

--- a/mama/c_cpp/src/examples/mama.properties
+++ b/mama/c_cpp/src/examples/mama.properties
@@ -58,8 +58,6 @@ mama.qpid.transport.broker.incoming_url=topic://127.0.0.1/MAMA/%r/%S/%s
 # This is where we listen for replies during request / reply
 mama.qpid.transport.broker.reply_url=topic://127.0.0.1/MAMA/%u
 
-# Source which you are going to consume from
-mama.qpid.transport.pub.outgoing_url=amqp://127.0.0.1:6666
 # Where qpid is going to listen to for data to be pushed to
 mama.qpid.transport.pub.incoming_url=amqp://~127.0.0.1:7777
 # Where qpid publisher is to send data to once subscription is created


### PR DESCRIPTION
There were some unit tests that failed when using brokerless
communication. This patch corrects this. Also works around
a pn_messenger_stop crash.

Signed-off-by: Frank Quinn <fquinn.ni@gmail.com>