### PR TITLE
QPID: Updated qpid bridge to make use of common memory pool

### DIFF
--- a/mama/c_cpp/src/c/bridge/qpid/codec.c
+++ b/mama/c_cpp/src/c/bridge/qpid/codec.c
@@ -101,6 +101,9 @@ qpidBridgeMsgCodec_pack (msgBridge      bridgeMessage,
     /* Get the properties from the message */
     properties = pn_message_properties (*protonMessage);
 
+    /* Ensure the properties are cleared first before populating */
+    pn_data_clear (properties);
+
     /* Ensure position is at the start */
     pn_data_rewind (properties);
 

--- a/mama/c_cpp/src/c/bridge/qpid/qpiddefs.h
+++ b/mama/c_cpp/src/c/bridge/qpid/qpiddefs.h
@@ -30,6 +30,7 @@
 #include <wombat/wSemaphore.h>
 #include <wombat/wtable.h>
 #include <list.h>
+#include <wombat/mempool.h>
 
 /* Qpid include files */
 #include <proton/version.h>
@@ -125,7 +126,7 @@ typedef struct qpidTransportBridge_
     pn_message_t*       mMsg;
     pn_messenger_t*     mIncoming;
     pn_messenger_t*     mOutgoing;
-    qpidMsgPool*        mQpidMsgPool;
+    memoryPool*         mQpidMsgPool;
     unsigned int        mQpidMsgPoolIncSize;
     const char*         mIncomingAddress;
     const char*         mOutgoingAddress;
@@ -144,21 +145,9 @@ typedef struct qpidTransportBridge_
 struct qpidMsgNode_
 {
   pn_message_t*         mMsg;
-  qpidMsgNode*          mNext;
-  qpidMsgNode*          mPrev;
-  qpidMsgPool*          mMsgPool;
   qpidMsgType           mMsgType;
   qpidSubscription*     mQpidSubscription;
-};
-
-struct qpidMsgPool_
-{
   qpidTransportBridge*  mQpidTransportBridge;
-  qpidMsgNode*          mFreeList;      /* Linked list of free Messages */
-  qpidMsgNode*          mOpenList;      /* Linked list of open Messages */
-  unsigned int          mNumMsgs;       /* Number of buffer in the pool */
-  unsigned int          mNumFree;       /* Number of free buffers */
-  wthread_mutex_t       mLock;
 };
 
 #if defined(__cplusplus)


### PR DESCRIPTION
Qpid always used a memory pool to manage inter-thread message
passing. This set of changes modifies qpid to use the common
memory pool instead of the custom one which was originally
bespoke to the qpid bridge.

Signed-off-by: Frank Quinn <fquinn.ni@gmail.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/8)
<!-- Reviewable:end -->
