### PR TITLE
COMMON: Fixed bug with unsynchronized access to qpid mTimerElement.

### DIFF
--- a/common/c_cpp/src/c/timers.h
+++ b/common/c_cpp/src/c/timers.h
@@ -40,6 +40,7 @@ COMMONExpDLL int destroyHeap (timerHeap heap);
 
 COMMONExpDLL int createTimer (timerElement* timer, timerHeap heap, timerFireCb cb, struct timeval* timeout, void* closure);
 COMMONExpDLL int destroyTimer (timerHeap heap, timerElement timer);
+COMMONExpDLL int resetTimer (timerHeap heap, timerElement timer, struct timeval* timeout);
 
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
Submitted in relation to http://bugs.openmama.org/show_bug.cgi?id=220

Signed-off-by: Duane Pauls <Duane.Pauls@SolaceSystems.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/14)
<!-- Reviewable:end -->
