### PR TITLE
QPID and MAC Updates

### DIFF
--- a/common/c_cpp/src/c/darwin/port.h
+++ b/common/c_cpp/src/c/darwin/port.h
@@ -45,6 +45,7 @@
 #include <inttypes.h>
 #include <pwd.h>
 #include <stdlib.h>
+#include <AvailabilityMacros.h>
 
 #include "wConfig.h"
 
@@ -66,6 +67,7 @@ typedef void*       LIB_HANDLE;
 #define LIB_EXTENSION ".dylib"
 
 /* Network conversion function */
+#if MAC_OS_X_VERSION_MAX_ALLOWED <= MAC_OS_X_VERSION_10_9
 #if __BYTE_ORDER == __LITTLE_ENDIAN
 #define htonll(x) \
     ((uint64_t)htonl((uint32_t)((x)>>32)) | (uint64_t)htonl((uint32_t)(x))<<32)
@@ -74,6 +76,7 @@ typedef void*       LIB_HANDLE;
 #else
 #define htonll(x) ((uint64_t)(x))
 #define ntohll(x) ((uint64_t)(x))
+#endif
 #endif
 
 /* For delimiting multiple paths in env variables properties */

--- a/mama/c_cpp/src/c/bridge/qpid/transport.c
+++ b/mama/c_cpp/src/c/bridge/qpid/transport.c
@@ -942,7 +942,7 @@ qpidBridgeMamaTransportImpl_start (qpidTransportBridge* impl)
                           "Error Subscribing to %s : %s",
                           impl->mIncomingAddress,
                           PN_MESSENGER_ERROR(impl->mIncoming));
-                (impl->mIncoming);
+                qpidBridgeMamaTransportImpl_stopProtonMessenger(impl->mIncoming);
                 return MAMA_STATUS_PLATFORM;
             }
         }

--- a/mama/c_cpp/src/c/payload/qpidmsg/field.c
+++ b/mama/c_cpp/src/c/payload/qpidmsg/field.c
@@ -1238,7 +1238,7 @@ qpidmsgFieldPayload_getAsString       (const msgFieldPayload   field,
     }
     case MAMA_FIELD_TYPE_VECTOR_STRING:
     {
-        EXPAND_PRINT_VECTOR_MACROS (const char*, String, "%s", const char*);
+        EXPAND_PRINT_VECTOR_MACROS (char*, String, "%s", const char*);
         break;
     }
     case MAMA_FIELD_TYPE_VECTOR_U8:

--- a/mama/c_cpp/src/c/payload/qpidmsg/payload.c
+++ b/mama/c_cpp/src/c/payload/qpidmsg/payload.c
@@ -3783,7 +3783,7 @@ qpidmsgPayloadImpl_addFieldToPayload (msgPayload                 msg,
         ADD_VECTOR_FIELD_VALUE_TO_MESSAGE(F64, mama_f64_t);
         break;
     case MAMA_FIELD_TYPE_VECTOR_STRING:
-        ADD_VECTOR_FIELD_VALUE_TO_MESSAGE(String, const char*);
+        ADD_VECTOR_FIELD_VALUE_TO_MESSAGE(String, char*);
         break;
     case MAMA_FIELD_TYPE_VECTOR_MSG:
     {

--- a/site_scons/community/command_line.py
+++ b/site_scons/community/command_line.py
@@ -82,7 +82,7 @@ def get_command_line_opts( host, products, VERSIONS ):
             EnumVariable( 'compiler', 'Compiler to use for building OpenMAMA',
                          'default', allowed_values=('default', 'clang', 'clang-analyzer')),
             EnumVariable('osx_version', 'OS X Version to target build at', 'current',
-                         allowed_values=('current','10.8','10.9')),
+                         allowed_values=('current','10.8','10.9','10.10')),
             )
 
     return opts

--- a/site_scons/community/command_line.py
+++ b/site_scons/community/command_line.py
@@ -82,7 +82,7 @@ def get_command_line_opts( host, products, VERSIONS ):
             EnumVariable( 'compiler', 'Compiler to use for building OpenMAMA',
                          'default', allowed_values=('default', 'clang', 'clang-analyzer')),
             EnumVariable('osx_version', 'OS X Version to target build at', 'current',
-                         allowed_values=('current','10.8','10.9','10.10')),
+                         allowed_values=('current','10.8','10.9','10.10','10.11')),
             )
 
     return opts


### PR DESCRIPTION
As per email chain, minor changes to allow compiling with clang

* QPID - Fix for missing method name in transport.c
* QPID - Fix for double const in Vector macro calls
* COMMON - Port update in Darwin for macros added in Yosemite for htonll
* SCONS - Added 10.11 build flag for Xcode 7 support

Pub / Sub working + Unit Tests passing on Mac OS X 10.10

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/24)
<!-- Reviewable:end -->
