### PR TITLE
Windows issue with setting date.

### DIFF
--- a/common/c_cpp/src/c/windows/port.c
+++ b/common/c_cpp/src/c/windows/port.c
@@ -269,7 +269,7 @@ time_t wtimegm (struct tm *tm)
     char *tz;
     
     tz = environment_getVariable("TZ");
-    environment_setVariable("TZ", "");
+    environment_setVariable("TZ", "UTC");
     tzset();
     ret = mktime(tm);
     if (tz)

--- a/mama/c_cpp/src/gunittest/cpp/MamaDateTimeTest.cpp
+++ b/mama/c_cpp/src/gunittest/cpp/MamaDateTimeTest.cpp
@@ -134,7 +134,7 @@ TEST_F(MamaDateTimeTest, CompareDates)
 	ASSERT_EQ(completeDateSeconds, timeSeconds);
 }
 
-TEST_F(MamaDateTimeTest, SetDateWindowsBug)
+TEST_F(MamaDateTimeTest, SetDateTimezoneCheck)
 {
     // Test for Windows bug where setting date used localtime
     // This was in port.c where the TZ env var was set to "" rather than "UTC"

--- a/mama/c_cpp/src/gunittest/cpp/MamaDateTimeTest.cpp
+++ b/mama/c_cpp/src/gunittest/cpp/MamaDateTimeTest.cpp
@@ -144,8 +144,6 @@ TEST_F(MamaDateTimeTest, SetDateWindowsBug)
     MamaDateTime dt2;
     dt2.setDate(2015, 8, 23);
 
-    // mama_log(MAMA_LOG_LEVEL_NORMAL, "win bug %04d-%02d-%02d %02d:%02d:%02d", dt1.getYear(), dt1.getMonth(), dt1.getDay(), dt1.getHour(), dt1.getMinute(), dt1.getSecond());
-    // mama_log(MAMA_LOG_LEVEL_NORMAL, "win bug %04d-%02d-%02d %02d:%02d:%02d", dt2.getYear(), dt2.getMonth(), dt2.getDay(), dt2.getHour(), dt2.getMinute(), dt2.getSecond());
     ASSERT_EQ(dt1.getEpochTimeMicroseconds(), dt2.getEpochTimeMicroseconds());
 }
 

--- a/mama/c_cpp/src/gunittest/cpp/MamaDateTimeTest.cpp
+++ b/mama/c_cpp/src/gunittest/cpp/MamaDateTimeTest.cpp
@@ -134,3 +134,18 @@ TEST_F(MamaDateTimeTest, CompareDates)
 	ASSERT_EQ(completeDateSeconds, timeSeconds);
 }
 
+TEST_F(MamaDateTimeTest, SetDateWindowsBug)
+{
+    // Test for Windows bug where setting date used localtime
+    // This was in port.c where the TZ env var was set to "" rather than "UTC"
+    MamaDateTime dt1;
+    dt1.set(2015, 8, 23, 0, 0, 0, 0, MAMA_DATE_TIME_PREC_UNKNOWN, NULL);
+
+    MamaDateTime dt2;
+    dt2.setDate(2015, 8, 23);
+
+    // mama_log(MAMA_LOG_LEVEL_NORMAL, "win bug %04d-%02d-%02d %02d:%02d:%02d", dt1.getYear(), dt1.getMonth(), dt1.getDay(), dt1.getHour(), dt1.getMinute(), dt1.getSecond());
+    // mama_log(MAMA_LOG_LEVEL_NORMAL, "win bug %04d-%02d-%02d %02d:%02d:%02d", dt2.getYear(), dt2.getMonth(), dt2.getDay(), dt2.getHour(), dt2.getMinute(), dt2.getSecond());
+    ASSERT_EQ(dt1.getEpochTimeMicroseconds(), dt2.getEpochTimeMicroseconds());
+}
+


### PR DESCRIPTION
putenv() works differently on Windows - if the value is empty it removes the key from the env.
When gmtime is called it works differently if the TZ var is empty or missing.
Solution is to set TZ to UTC rather than empty in port.c.
Also add unit test for this bug.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/31)
<!-- Reviewable:end -->
