### PR TITLE
[BZ-109/110] OSX compatibility fixes

### DIFF
--- a/common/c_cpp/src/c/SConscript
+++ b/common/c_cpp/src/c/SConscript
@@ -52,6 +52,8 @@ elif env['host']['os'] == 'Darwin':
          'common/c_cpp/src/c/linux/platform.c'),
         ('common/c_cpp/src/c/wSemaphore.c',
          'common/c_cpp/src/c/darwin/wSemaphore.c'),
+        ('common/c_cpp/src/c/clock.c',
+         'common/c_cpp/src/c/darwin/clock.c'),
         ('common/c_cpp/src/c/network.c',
          'common/c_cpp/src/c/linux/network.c'),
         ('common/c_cpp/src/c/environment.c',

--- a/common/c_cpp/src/c/darwin/clock.c
+++ b/common/c_cpp/src/c/darwin/clock.c
@@ -1,0 +1,122 @@
+/*
+ * OpenMAMA: The open middleware agnostic messaging API
+ * Copyright (C) 2011 NYSE Technologies, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+#include "wombat/port.h"
+
+#include <mach/mach.h>
+#include <mach/mach_time.h>
+#include <mach/clock.h>
+#include <sys/time.h>
+#include <sys/resource.h>
+#include <sys/errno.h>
+
+#define CHECK_MACH_INITIALISED()                        \
+do {                                                    \
+    if (!clock_gettime_initialised)                     \
+    {                                                   \
+        if(GETTIME_SUCCESS != clock_gettime_init ())    \
+            return GETTIME_FAIL;                        \
+    }                                                   \
+}                                                       \
+while (0)                                               \
+
+#define NANOS_IN_SEC     1000000000L
+
+// Private function declarations
+static int clock_gettime_init ();
+static int clock_gettime_internal ();
+static int clock_gettime_process_cputime_id (struct timespec * ts);
+
+// Timer variables
+static mach_timebase_info_data_t    timebase_info;
+static uint64_t                     init_clock;         // ticks boot   --> initialised
+static uint8_t                      clock_gettime_initialised = 0;
+
+int clock_gettime (int type, struct timespec * ts)
+{
+    switch (type)
+    {
+        case CLOCK_MONOTONIC:
+            return clock_gettime_internal(ts, SYSTEM_CLOCK);
+            break;
+        case CLOCK_REALTIME:
+            return clock_gettime_internal(ts, CALENDAR_CLOCK);
+            break;
+        case CLOCK_PROCESS_CPUTIME_ID:
+            return clock_gettime_process_cputime_id (ts);
+            break;
+        default:
+            errno = EINVAL;
+            return GETTIME_FAIL;
+    }
+}
+
+int clock_gettime_init()
+{
+
+    // Initialise the timebase
+    if (0 != mach_timebase_info (&timebase_info))
+    {
+        return GETTIME_FAIL;
+    }
+
+    // Ticks since boot
+    init_clock = mach_absolute_time ();
+
+    // Only do once
+    clock_gettime_initialised = 1;
+
+    return GETTIME_SUCCESS;
+}
+
+int clock_gettime_internal(struct timespec * ts, int type)
+{
+    clock_serv_t cclock;
+    mach_timespec_t mts;
+    kern_return_t retval;
+
+    // Get the time
+    host_get_clock_service(mach_host_self(), type, &cclock);
+    retval = clock_get_time(cclock, &mts);
+    mach_port_deallocate(mach_task_self(), cclock);
+
+    ts->tv_sec = mts.tv_sec;
+    ts->tv_nsec = mts.tv_nsec;
+
+    return (retval == KERN_SUCCESS) ? GETTIME_SUCCESS : GETTIME_FAIL;
+}
+
+int clock_gettime_process_cputime_id (struct timespec * ts)
+{
+    CHECK_MACH_INITIALISED ();
+
+    // Get the time
+    uint64_t time;      // ticks since mach initialised --> now
+    time = mach_absolute_time () - init_clock;
+
+    // Convert to timespec
+    uint64_t nanos;     // nanos since mach initialised --> now
+    nanos = time * (uint64_t)timebase_info.numer / (uint64_t)timebase_info.denom;
+
+    ts->tv_sec = nanos / NANOS_IN_SEC;
+    ts->tv_nsec = nanos % NANOS_IN_SEC;
+
+    return GETTIME_SUCCESS;
+}

--- a/common/c_cpp/src/c/darwin/port.h
+++ b/common/c_cpp/src/c/darwin/port.h
@@ -180,6 +180,14 @@ struct wtimespec
     long tv_nsec;
 };
 
+/* Add fake clock_gettime function */
+#define CLOCK_REALTIME              0
+#define CLOCK_MONOTONIC             1
+#define CLOCK_PROCESS_CPUTIME_ID    2
+#define GETTIME_SUCCESS             0
+#define GETTIME_FAIL                1
+int clock_gettime (int type, struct timespec * ts);
+
 #define wnanosleep(ts, remain)      nanosleep(((struct timespec*)(ts)),(remain))
 
 /* Macro for managing the printing of mama_size_t values. */

--- a/mama/c_cpp/src/testtools/performance/c/mamaproducerc_v2.c
+++ b/mama/c_cpp/src/testtools/performance/c/mamaproducerc_v2.c
@@ -26,7 +26,14 @@
 #include <signal.h>
 #include <unistd.h>
 #include <sys/mman.h>   /* Needed for mlockall() */
+
+#ifndef __APPLE__
 #include <malloc.h>
+#else
+#include <malloc/malloc.h>
+#include <sys/sysctl.h>
+#endif
+
 #include <limits.h>
 #include <sys/time.h>   /* needed for getrusage */
 #include <sys/resource.h>    /* needed for getrusage */
@@ -90,6 +97,8 @@
 #ifndef CLOCK_PROCESS_CPUTIME_ID
 #define CLOCK_PROCESS_CPUTIME_ID CLOCK_HIGHRES
 #endif
+
+#define HZ_TO_MHZ  1000000
 
 typedef struct {
     uint32_t      mMsgNum;
@@ -443,6 +452,7 @@ static  int     gSched      =   0;
 static  int     gLock       =   0;
 static  int     gPriority   =   40;
 
+#ifndef __APPLE__
 static void setprio(int prio, int sched)
 {
     struct sched_param param;
@@ -460,6 +470,7 @@ static void configure_malloc_behavior(void)
 
     mallopt(M_MMAP_MAX, 0);
 }
+#endif
 
 static void reserve_process_memory(int size)
 {
@@ -567,7 +578,7 @@ int main (int argc, const char **argv)
                       &middleware,
                       &msgSize,
                       &msgVar);
-
+#ifndef __APPLE__
     /*
      * Real time priorities
      */
@@ -598,6 +609,7 @@ int main (int argc, const char **argv)
         }
         setprio(gPriority,gSched);
     }
+#endif
 
     initializeMama (middleware,
                     transportName);
@@ -1063,6 +1075,19 @@ static void producerShutdown
 
 static double getClock()
 {
+#ifdef __APPLE__
+    int mib[2];
+    unsigned int freq;
+    size_t len;
+
+    mib[0] = CTL_HW;
+    mib[1] = HW_CPU_FREQ;
+    len = sizeof(freq);
+    if(0 == sysctl(mib, 2, &freq, &len, NULL, 0))
+    {
+        return (double)(freq / HZ_TO_MHZ);
+    }
+#else
     FILE *cpuInfo;
     if ((cpuInfo = fopen ("/proc/cpuinfo", "rb"))!=NULL)
     {
@@ -1083,6 +1108,7 @@ static double getClock()
         fclose(cpuInfo);
         return atof (freq);
     }
+#endif
     PRINT_ERROR("Could not get CPU Frequency");
     exit (1);
 }


### PR DESCRIPTION
Replacing [bz-109](http://bugs.openmama.org/show_bug.cgi?id=109) and [bz-110](http://bugs.openmama.org/show_bug.cgi?id=110).
Comments the original tickets:

[bz-109](http://bugs.openmama.org/show_bug.cgi?id=109):
> Mac OS X does not support the clock_gettime function that is used in a number of the performance testing applications, but does have equivalient fucntions..
> This change wraps the time functions from the mac behind clock_gettime function
> Tested on
> * Mac OS X 10.9.2 x86_64
> * Ubuntu 12.04 x86_64
> With
> * Mamapublisherc / MamaSubscriberc
> * Mamainboxc
> * Mamalistenc / Capturereplay
> * Mamaproducerc_v2 / Mamaconsumerc_v2
> * Unit Tests


[bz-110](http://bugs.openmama.org/show_bug.cgi?id=110)
> Added support for compiling and running on Mac OS X.
> Excludes support for setting the scheduler and malloc options which are put behind macros for Mac.
> Tested on
> * Mac OS X 10.9.2 x86_64
> * Ubuntu 12.04 x86_64

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/78)
<!-- Reviewable:end -->
