### PR TITLE
[BZ-70] MAMA: Expose open/close reference counting + tidyup reserved fields.

### DIFF
--- a/mama/c_cpp/src/c/mama.c
+++ b/mama/c_cpp/src/c/mama.c
@@ -642,7 +642,7 @@ mamaInternal_getAllowMsgModify (void)
     return gAllowMsgModify;
 }
 
-static mama_status
+mama_status
 mama_openWithPropertiesCount (const char* path,
                               const char* filename,
                               unsigned int* count)
@@ -694,8 +694,7 @@ mama_openWithPropertiesCount (const char* path,
 
     if (0 != gImpl.myRefCount)
     {
-        if (MAMA_STATUS_OK == result)
-            gImpl.myRefCount++;
+        gImpl.myRefCount++;
         
         if (count)
             *count = gImpl.myRefCount;
@@ -771,6 +770,8 @@ mama_openWithPropertiesCount (const char* path,
 
     if (0 == numBridges)
     {
+        cleanupReservedFields();
+
         mama_log (MAMA_LOG_LEVEL_SEVERE,
                   "mama_openWithProperties(): "
                   "At least one bridge must be specified");
@@ -783,6 +784,8 @@ mama_openWithPropertiesCount (const char* path,
 
     if (!gDefaultPayload)
     {
+        cleanupReservedFields();
+
         mama_log (MAMA_LOG_LEVEL_SEVERE,
                   "mama_openWithProperties(): "
                   "At least one payload must be specified");
@@ -981,6 +984,14 @@ mama_open ()
 }
 
 mama_status
+mama_openCount (unsigned int* count)
+{
+    /*Passing NULL as path and filename will result in the
+     default behaviour - mama.properties on $WOMBAT_PATH*/
+    return mama_openWithPropertiesCount (NULL, NULL, count);
+}
+
+mama_status
 mama_openWithProperties (const char* path,
                          const char* filename)
 {
@@ -1092,7 +1103,7 @@ mama_getVersion (mamaBridge bridgeImpl)
     return mama_ver_string;
 }
 
-static mama_status
+mama_status
 mama_closeCount (unsigned int* count)
 {
     mama_status    result     = MAMA_STATUS_OK;

--- a/mama/c_cpp/src/c/mama/mama.h
+++ b/mama/c_cpp/src/c/mama/mama.h
@@ -180,8 +180,6 @@ extern "C"
      */
 
     /**
-     * mama_status mama_open (void)
-     *
      * Initialize MAMA.
      *
      * MAMA employs a reference count to track multiple
@@ -193,6 +191,23 @@ extern "C"
     MAMAExpDLL
     extern mama_status
     mama_open (void);
+
+    /**
+     * Initialize MAMA.
+     *
+     * MAMA employs a reference count to track multiple
+     * calls to mama_open() and mama_close(). The count is incremented every time
+     * mama_open() is called and decremented when mama_close() is called. The
+     * resources are not actually released until the count reaches zero.
+     *
+     * @param[out] count The reference count for the MAMA library after opening 
+     * once. This will be non-zero and will match the amount of times a
+     * mama_open() variant has been called.
+     *
+     */
+    MAMAExpDLL
+    extern mama_status
+    mama_openCount (unsigned int* count);
 
     /**
      * Initialize MAMA.
@@ -210,6 +225,11 @@ extern "C"
      * If null is passed as the filename the API will look for the default
      * filename of mama.properties.
      *
+     * MAMA employs a reference count to track multiple
+     * calls to mama_open() and mama_close(). The count is incremented every time
+     * mama_open() is called and decremented when mama_close() is called. The
+     * resources are not actually released until the count reaches zero.
+     *
      * @param path Fully qualified path to the directory containing the properties
      * file
      * @param filename The name of the file containing MAMA properties.
@@ -220,6 +240,42 @@ extern "C"
     extern mama_status
     mama_openWithProperties (const char*    path,
                              const char*    filename);
+
+    /**
+     * Initialize MAMA.
+     *
+     * Allows users of the API to override the default behavior of mama_open()
+     * where a file mama.properties is required to be located in the directory
+     * specified by \$WOMBAT_PATH.
+     *
+     * The properties file must have the same structure as a standard
+     * mama.properties file.
+     *
+     * If null is passed as the path the API will look for the properties file on
+     * the \$WOMBAT_PATH.
+     *
+     * If null is passed as the filename the API will look for the default
+     * filename of mama.properties.
+     *
+     * MAMA employs a reference count to track multiple
+     * calls to mama_open() and mama_close(). The count is incremented every time
+     * mama_open() is called and decremented when mama_close() is called. The
+     * resources are not actually released until the count reaches zero.
+     *
+     * @param path Fully qualified path to the directory containing the properties
+     * file
+     * @param filename The name of the file containing MAMA properties.
+     * @param[out] count The reference count for the MAMA library after opening 
+     * once. This will be non-zero and will match the amount of times a
+     * mama_open() variant has been called.
+     *
+     * @return mama_status Whether the call was successful or not.
+     */
+    MAMAExpDLL
+    extern mama_status
+    mama_openWithPropertiesCount (const char*    path,
+                                  const char*    filename,
+                                  unsigned int*  count);
 
     /**
      * Set a specific property for the API.
@@ -285,12 +341,29 @@ extern "C"
     mama_getProperty (const char* name);
 
     /**
-     * Close MAMA and free all associated resource.
+     * Close MAMA and free all associated resources if no more references exist
+     * (e.g.if open has been called 3 times then it will require 3 calls to 
+     * close in order for all resources to be freed).
      *
+     * @return mama_status Whether the call was successful or not.
      */
     MAMAExpDLL
     extern mama_status
     mama_close (void);
+
+    /**
+     * Close MAMA and free all associated resources if no more references exist
+     * (e.g.if open has been called 3 times then it will require 3 calls to 
+     * close in order for all resources to be freed).
+     *
+     * @param[out] count The reference count for the MAMA library after closing 
+     * once.  If this is zero then MAMA and all resources will have been freed.
+     *
+     * @return mama_status Whether the call was successful or not.
+     */
+    MAMAExpDLL
+    extern mama_status
+    mama_closeCount (unsigned int* count);
 
     /**
     * Return the version information for the library.

--- a/mama/c_cpp/src/c/reservedfields.c
+++ b/mama/c_cpp/src/c/reservedfields.c
@@ -22,6 +22,22 @@
 #include <mama/mama.h>
 #include "reservedfieldsimpl.h"
 
+#define CREATE_FIELD(x, type) do {\
+    if (!MamaReservedField ## x) {\
+        mamaFieldDescriptor_create (&MamaReservedField ## x,\
+                                    MamaField ## x.mFid,\
+                                    MAMA_FIELD_TYPE_ ## type,\
+                                    MamaField ## x.mName);\
+    }\
+} while (0)
+
+#define DESTROY_FIELD(x) do {\
+    if (MamaReservedField ## x) {\
+        mamaFieldDescriptor_destroy (MamaReservedField ## x);\
+        MamaReservedField ## x = NULL;\
+    }\
+} while (0)
+
 const long WOMBAT_MAX_RESERVED_FID = 100;
 
 const MamaReservedField MamaFieldMsgType          = { "MdMsgType",          1 };
@@ -96,116 +112,44 @@ mamaFieldDescriptor MamaReservedFieldEntitleCode        = NULL;
 
 void initReservedFields (void)
 {
-    mamaFieldDescriptor_create (&MamaReservedFieldMsgType,
-                                1,
-                                MAMA_FIELD_TYPE_U8,
-                                "MdMsgType");
-    mamaFieldDescriptor_create (&MamaReservedFieldMsgStatus,
-                                2,
-                                MAMA_FIELD_TYPE_U8,
-                                "MdMsgStatus");
-    mamaFieldDescriptor_create (&MamaReservedFieldFieldIndex,
-                                3,
-                                MAMA_FIELD_TYPE_VECTOR_U16,
-                                "MdFieldIndex");
-    mamaFieldDescriptor_create (&MamaReservedFieldMsgNum,
-                                7,
-                                MAMA_FIELD_TYPE_U8,
-                                "MdMsgNum");
-    mamaFieldDescriptor_create (&MamaReservedFieldMsgTotal,
-                                8,
-                                MAMA_FIELD_TYPE_U8,
-                                "MdMsgTotal");
-    mamaFieldDescriptor_create (&MamaReservedFieldSeqNum,
-                                10,
-                                MAMA_FIELD_TYPE_U32,
-                                "MdSeqNum");
-    mamaFieldDescriptor_create (&MamaReservedFieldFeedName,
-                                11,
-                                MAMA_FIELD_TYPE_STRING,
-                                "MdFeedName");
-    mamaFieldDescriptor_create (&MamaReservedFieldFeedHost,
-                                12,
-                                MAMA_FIELD_TYPE_STRING,
-                                "MdFeedHost");
-    mamaFieldDescriptor_create (&MamaReservedFieldFeedGroup,
-                                13,
-                                MAMA_FIELD_TYPE_STRING,
-                                "MdFeedGroup");
-    mamaFieldDescriptor_create (&MamaReservedFieldItemSeqNum,
-                                15,
-                                MAMA_FIELD_TYPE_U32,
-                                "MdItemSeq");
-    mamaFieldDescriptor_create (&MamaReservedFieldSendTime,
-                                16,
-                                MAMA_FIELD_TYPE_TIME,
-                                "MamaSendTime");
-    mamaFieldDescriptor_create (&MamaReservedFieldAppDataType,
-                                17,
-                                MAMA_FIELD_TYPE_U8,
-                                "MamaAppDataType");
-    mamaFieldDescriptor_create (&MamaReservedFieldAppMsgType,
-                                18,
-                                MAMA_FIELD_TYPE_U8,
-                                "MamaAppMsgType");
-    mamaFieldDescriptor_create (&MamaReservedFieldSenderId,
-                                20,
-                                MAMA_FIELD_TYPE_U64,
-                                "MamaSenderId");
-    mamaFieldDescriptor_create (&MamaReservedFieldMsgQual,
-                                21,
-                                MAMA_FIELD_TYPE_U8,
-                                "wMsgQual");
-    mamaFieldDescriptor_create (&MamaReservedFieldConflateQuoteCount,
-                                23,
-                                MAMA_FIELD_TYPE_U32,
-                                "wConflateQuoteCount");
-    mamaFieldDescriptor_create (&MamaReservedFieldSymbolList,
-                                81,
-                                MAMA_FIELD_TYPE_VECTOR_STRING,
-                                "MamaSymbolList");    
-    mamaFieldDescriptor_create (&MamaReservedFieldEntitleCode,
-                                496,
-                                MAMA_FIELD_TYPE_U32,
-                                "wEntitleCode");
+    CREATE_FIELD (MsgType,            U8);
+    CREATE_FIELD (MsgStatus,          U8);
+    CREATE_FIELD (FieldIndex,         U16);
+    CREATE_FIELD (MsgNum,             U8);
+    CREATE_FIELD (MsgTotal,           U8);
+    CREATE_FIELD (SeqNum,             U32);
+    CREATE_FIELD (FeedName,           STRING);
+    CREATE_FIELD (FeedHost,           STRING);
+    CREATE_FIELD (FeedGroup,          STRING);
+    CREATE_FIELD (ItemSeqNum,         U32);
+    CREATE_FIELD (SendTime,           TIME);
+    CREATE_FIELD (AppDataType,        U8);
+    CREATE_FIELD (AppMsgType,         U8);
+    CREATE_FIELD (SenderId,           U64);
+    CREATE_FIELD (MsgQual,            U8);
+    CREATE_FIELD (ConflateQuoteCount, U32);
+    CREATE_FIELD (SymbolList,         VECTOR_STRING);
+    CREATE_FIELD (EntitleCode,        U32);
 }
 
 void cleanupReservedFields (void)
 {
-    if (MamaReservedFieldMsgType)
-        mamaFieldDescriptor_destroy (MamaReservedFieldMsgType);
-    if (MamaReservedFieldMsgStatus)
-        mamaFieldDescriptor_destroy (MamaReservedFieldMsgStatus);
-    if (MamaReservedFieldFieldIndex)
-        mamaFieldDescriptor_destroy (MamaReservedFieldFieldIndex);
-    if (MamaReservedFieldMsgNum)
-        mamaFieldDescriptor_destroy (MamaReservedFieldMsgNum);
-    if (MamaReservedFieldMsgTotal)
-        mamaFieldDescriptor_destroy (MamaReservedFieldMsgTotal);
-    if (MamaReservedFieldSeqNum)
-        mamaFieldDescriptor_destroy (MamaReservedFieldSeqNum);
-    if (MamaReservedFieldFeedName)
-        mamaFieldDescriptor_destroy (MamaReservedFieldFeedName);
-    if (MamaReservedFieldFeedHost)
-        mamaFieldDescriptor_destroy (MamaReservedFieldFeedHost);
-    if (MamaReservedFieldFeedGroup)
-        mamaFieldDescriptor_destroy (MamaReservedFieldFeedGroup);
-    if (MamaReservedFieldItemSeqNum)
-        mamaFieldDescriptor_destroy (MamaReservedFieldItemSeqNum);
-    if (MamaReservedFieldSendTime)
-        mamaFieldDescriptor_destroy (MamaReservedFieldSendTime);
-    if (MamaReservedFieldAppDataType)
-        mamaFieldDescriptor_destroy (MamaReservedFieldAppDataType);
-    if (MamaReservedFieldAppMsgType)
-        mamaFieldDescriptor_destroy (MamaReservedFieldAppMsgType);
-    if (MamaReservedFieldSenderId)
-        mamaFieldDescriptor_destroy (MamaReservedFieldSenderId);
-    if (MamaReservedFieldMsgQual)
-        mamaFieldDescriptor_destroy (MamaReservedFieldMsgQual);
-    if (MamaReservedFieldSymbolList)
-        mamaFieldDescriptor_destroy (MamaReservedFieldSymbolList);    
-    if (MamaReservedFieldEntitleCode)
-        mamaFieldDescriptor_destroy (MamaReservedFieldEntitleCode);
-    if (MamaReservedFieldConflateQuoteCount)
-        mamaFieldDescriptor_destroy (MamaReservedFieldConflateQuoteCount);
+    DESTROY_FIELD (MsgType);
+    DESTROY_FIELD (MsgStatus);
+    DESTROY_FIELD (FieldIndex);
+    DESTROY_FIELD (MsgNum);
+    DESTROY_FIELD (MsgTotal);
+    DESTROY_FIELD (SeqNum);
+    DESTROY_FIELD (FeedName);
+    DESTROY_FIELD (FeedHost);
+    DESTROY_FIELD (FeedGroup);
+    DESTROY_FIELD (ItemSeqNum);
+    DESTROY_FIELD (SendTime);
+    DESTROY_FIELD (AppDataType);
+    DESTROY_FIELD (AppMsgType);
+    DESTROY_FIELD (SenderId);
+    DESTROY_FIELD (MsgQual);
+    DESTROY_FIELD (ConflateQuoteCount);
+    DESTROY_FIELD (SymbolList);
+    DESTROY_FIELD (EntitleCode);
 }

--- a/mama/c_cpp/src/cpp/MamaReservedFields.cpp
+++ b/mama/c_cpp/src/cpp/MamaReservedFields.cpp
@@ -23,9 +23,18 @@
 #include <mama/MamaReservedFields.h>
 #include <mama/MamaFieldDescriptor.h>
 
+#define CREATE_FIELD(x) do {\
+    if (!x) {\
+        x = new MamaFieldDescriptor (MamaReservedField ## x);\
+    }\
+} while (0)
+
+#define DESTROY_FIELD(x) do {\
+    delete x; x = NULL;\
+} while (0)
+
 namespace Wombat
 {
-
     const MamaFieldDescriptor*  MamaReservedFields::MsgType            = NULL;
     const MamaFieldDescriptor*  MamaReservedFields::MsgStatus          = NULL;
     const MamaFieldDescriptor*  MamaReservedFields::FieldIndex         = NULL;
@@ -45,51 +54,48 @@ namespace Wombat
     const MamaFieldDescriptor*  MamaReservedFields::EntitleCode        = NULL;
     const MamaFieldDescriptor*  MamaReservedFields::SymbolList         = NULL;
 
-
-
     void MamaReservedFields::initReservedFields()
     {
-        MsgType             = new MamaFieldDescriptor (MamaReservedFieldMsgType);
-        MsgStatus           = new MamaFieldDescriptor (MamaReservedFieldMsgStatus);
-        FieldIndex          = new MamaFieldDescriptor (MamaReservedFieldFieldIndex);
-        MsgNum              = new MamaFieldDescriptor (MamaReservedFieldMsgNum);
-        MsgTotal            = new MamaFieldDescriptor (MamaReservedFieldMsgTotal);
-        SeqNum              = new MamaFieldDescriptor (MamaReservedFieldSeqNum);
-        FeedName            = new MamaFieldDescriptor (MamaReservedFieldFeedName);
-        FeedHost            = new MamaFieldDescriptor (MamaReservedFieldFeedHost);
-        FeedGroup           = new MamaFieldDescriptor (MamaReservedFieldFeedGroup);
-        ItemSeqNum          = new MamaFieldDescriptor (MamaReservedFieldItemSeqNum);
-        SendTime            = new MamaFieldDescriptor (MamaReservedFieldSendTime);
-        AppDataType         = new MamaFieldDescriptor (MamaReservedFieldAppDataType);
-        AppMsgType          = new MamaFieldDescriptor (MamaReservedFieldAppMsgType);
-        SenderId            = new MamaFieldDescriptor (MamaReservedFieldSenderId);
-        MsgQual             = new MamaFieldDescriptor (MamaReservedFieldMsgQual);
-        ConflateQuoteCount  = new MamaFieldDescriptor (MamaReservedFieldConflateQuoteCount);
-        EntitleCode         = new MamaFieldDescriptor (MamaReservedFieldEntitleCode);
-        SymbolList          = new MamaFieldDescriptor (MamaReservedFieldSymbolList);
-
+        CREATE_FIELD (MsgType);
+        CREATE_FIELD (MsgStatus);
+        CREATE_FIELD (FieldIndex);
+        CREATE_FIELD (MsgNum);
+        CREATE_FIELD (MsgTotal);
+        CREATE_FIELD (SeqNum);
+        CREATE_FIELD (FeedName);
+        CREATE_FIELD (FeedHost);
+        CREATE_FIELD (FeedGroup);
+        CREATE_FIELD (ItemSeqNum);
+        CREATE_FIELD (SendTime);
+        CREATE_FIELD (AppDataType);
+        CREATE_FIELD (AppMsgType);
+        CREATE_FIELD (SenderId);
+        CREATE_FIELD (MsgQual);
+        CREATE_FIELD (ConflateQuoteCount);
+        CREATE_FIELD (EntitleCode);
+        CREATE_FIELD (SymbolList);
     }
 
     void MamaReservedFields::uninitReservedFields()
     {    
-        if(NULL != MsgType)             delete MsgType;
-        if(NULL != MsgStatus)           delete MsgStatus;
-        if(NULL != FieldIndex)          delete FieldIndex;
-        if(NULL != MsgNum)              delete MsgNum;
-        if(NULL != MsgTotal)            delete MsgTotal;
-        if(NULL != SeqNum)              delete SeqNum;
-        if(NULL != FeedName)            delete FeedName;
-        if(NULL != FeedHost)            delete FeedHost;
-        if(NULL != FeedGroup)           delete FeedGroup;
-        if(NULL != ItemSeqNum)          delete ItemSeqNum;
-        if(NULL != SendTime)            delete SendTime;
-        if(NULL != AppDataType)         delete AppDataType;
-        if(NULL != AppMsgType)          delete AppMsgType;
-        if(NULL != SenderId)            delete SenderId;
-        if(NULL != MsgQual)             delete MsgQual;
-        if(NULL != ConflateQuoteCount)  delete ConflateQuoteCount;
-        if(NULL != EntitleCode)         delete EntitleCode;
-        if(NULL != SymbolList)          delete SymbolList;     
+        DESTROY_FIELD (MsgType);
+        DESTROY_FIELD (MsgStatus);
+        DESTROY_FIELD (FieldIndex);
+        DESTROY_FIELD (MsgNum);
+        DESTROY_FIELD (MsgTotal);
+        DESTROY_FIELD (SeqNum);
+        DESTROY_FIELD (FeedName);
+        DESTROY_FIELD (FeedHost);
+        DESTROY_FIELD (FeedGroup);
+        DESTROY_FIELD (ItemSeqNum);
+        DESTROY_FIELD (SendTime);
+        DESTROY_FIELD (AppDataType);
+        DESTROY_FIELD (AppMsgType);
+        DESTROY_FIELD (SenderId);
+        DESTROY_FIELD (MsgQual);
+        DESTROY_FIELD (ConflateQuoteCount);
+        DESTROY_FIELD (EntitleCode);
+        DESTROY_FIELD (SymbolList);
     } 
 
 }

--- a/mama/c_cpp/src/cpp/mama/mamacpp.h
+++ b/mama/c_cpp/src/cpp/mama/mamacpp.h
@@ -215,7 +215,6 @@ public:
     static const char* getVersion (mamaBridge bridgeImpl);
 
     /**
-     *
      * Initialize MAMA. 
      *
      * MAMA employs a reference count to track multiple
@@ -223,16 +222,29 @@ public:
      * Mama::open() is called and decremented when Mama::close() is called. The
      * resources are not actually released until the count reaches zero. 
      *
-     * If entitlements are enabled for the library, the available entitlement
-     * server names are read from the entitlement.servers property in the
-     * mama.properties file located in the \$WOMBAT_PATH directory.
-     *
      * This function is thread safe.
      */
     static void open ();
 
     /**
+     * Initialize MAMA. 
+     *
+     * MAMA employs a reference count to track multiple
+     * calls to Mama::open() and Mama::close(). The count is incremented every time
+     * Mama::open() is called and decremented when Mama::close() is called. The
+     * resources are not actually released until the count reaches zero. 
+     *
+     * This function is thread safe.
+     *
+     * @return The reference count for the MAMA library after opening 
+     * once. This will be non-zero and will match the amount of times a
+     * Mama::open() variant has been called.
+     */
+    static unsigned int openCount ();
+
+    /**
      * Initialize MAMA.
+     *
      * Allows users of the API to override the default behaviour of Mama.open()
      * where a file mama.properties is required to be located in the directory
      * specified by \$WOMBAT_PATH.
@@ -246,6 +258,46 @@ public:
      *
      * If null is passed as the filename the API will look for the default
      * filename of mama.properties.
+     *
+     * MAMA employs a reference count to track multiple
+     * calls to Mama::open() and Mama::close(). The count is incremented every time
+     * Mama::open() is called and decremented when Mama::close() is called. The
+     * resources are not actually released until the count reaches zero. 
+     *
+     * @param[in] path Fully qualified path to the directory containing the
+     * properties
+     * file
+     *
+     * @param[in] filename The name of the file containing MAMA properties.
+     *
+     * @return The reference count for the MAMA library after opening 
+     * once. This will be non-zero and will match the amount of times a
+     * Mama::open() variant has been called.
+     */
+    static unsigned int openCount (const char*   path,
+                                   const char*   filename);
+
+    /**
+     * Initialize MAMA.
+     *
+     * Allows users of the API to override the default behaviour of Mama.open()
+     * where a file mama.properties is required to be located in the directory
+     * specified by \$WOMBAT_PATH.
+     *
+     * The properties file must have the same structure as a standard
+     * mama.properties file.
+     *
+     * If null is passed as the path the API will look for the properties file
+     * on
+     * the \$WOMBAT_PATH.
+     *
+     * If null is passed as the filename the API will look for the default
+     * filename of mama.properties.
+     *
+     * MAMA employs a reference count to track multiple
+     * calls to Mama::open() and Mama::close(). The count is incremented every time
+     * Mama::open() is called and decremented when Mama::close() is called. The
+     * resources are not actually released until the count reaches zero. 
      *
      * @param[in] path Fully qualified path to the directory containing the
      * properties
@@ -297,16 +349,25 @@ public:
     static const char * getProperty (const char* name);
 
     /**
-     * Close MAMA and free all associated resource.
-     *
-     * MAMA employs a reference count to track multiple
-     * calls to Mama::open() and Mama::close(). The count is incremented every time
-     * Mama::open() is called and decremented when Mama::close() is called. The
-     * resources are not actually released until the count reaches zero. 
+     * Close MAMA and free all associated resources if no more references exist
+     * (e.g.if open has been called 3 times then it will require 3 calls to 
+     * close in order for all resources to be freed).
      *
      * This function is thread safe.
      */
     static void close ();
+
+    /**
+     * Close MAMA and free all associated resources if no more references exist
+     * (e.g.if open has been called 3 times then it will require 3 calls to 
+     * close in order for all resources to be freed).
+     *
+     * This function is thread safe.
+     *
+     * @return The reference count for the MAMA library after closing once.  If
+     * this is zero then MAMA and all resources will have been freed.
+     */
+    static unsigned int closeCount ();
 
     /**
      * Start processing messages on the internal queue. This starts Mama's

--- a/mama/c_cpp/src/cpp/mamacpp.cpp
+++ b/mama/c_cpp/src/cpp/mamacpp.cpp
@@ -57,22 +57,36 @@ namespace Wombat
         return (bridge);
     }
 
-
-    void Mama::open()
+    void Mama::open ()
     {
-        // Open MAMA
-        mamaTry (mama_open ());
+        openCount (NULL, NULL);
+    }
 
-        MamaReservedFields::initReservedFields();
+    unsigned int Mama::openCount ()
+    {
+        return openCount (NULL, NULL);
     }
 
     void Mama::open (const char* path,
                      const char* filename)
     {
-        // Open MAMA
-        mamaTry (mama_openWithProperties (path, filename));
+        openCount (path, filename);
+    }
 
-        MamaReservedFields::initReservedFields();
+    unsigned int Mama::openCount (const char* path,
+                                  const char* filename)
+    {
+        unsigned int refCount = 0;
+
+        // Open MAMA
+        mamaTry (mama_openWithPropertiesCount (path, filename, &refCount));
+        
+        if (1 == refCount)
+        {
+            MamaReservedFields::initReservedFields ();
+        }
+
+        return refCount;
     }
 
     #ifdef WITH_ENTITLEMENTS 
@@ -154,8 +168,22 @@ namespace Wombat
 
     void Mama::close ()
     {
+        closeCount ();
+    }
+
+    unsigned int Mama::closeCount ()
+    {
+        unsigned int refCount = 0;
+
         // Close mama
-        mamaTry (mama_close ());
+        mamaTry (mama_closeCount (&refCount));
+
+        if (0 == refCount)
+        {
+            MamaReservedFields::uninitReservedFields();
+        }
+
+        return refCount;
     }
 
     void Mama::start (mamaBridge bridgeImpl)

--- a/mama/c_cpp/src/gunittest/cpp/MamaDateTimeTest.cpp
+++ b/mama/c_cpp/src/gunittest/cpp/MamaDateTimeTest.cpp
@@ -112,6 +112,7 @@ TEST_F(MamaDateTimeTest, CompareDates)
 
 	// Set the date from this string
 	//ASSERT_EQ(mamaDateTime_setFromString(m_cDateTime, completeDateTime), MAMA_STATUS_OK);
+    delete m_DateTime;
     m_DateTime = new MamaDateTime(completeDateTime);    
 
 	// Get the number of seconds

--- a/mama/c_cpp/src/gunittest/cpp/MamaMsgTest.cpp
+++ b/mama/c_cpp/src/gunittest/cpp/MamaMsgTest.cpp
@@ -28,17 +28,14 @@ using namespace Wombat;
 
 void MamaMsgTestCPP::SetUp(void)
 {
-    
     m_bridge = Mama::loadBridge(getMiddleware());
 
     Mama::open();
-
 }
 
 void MamaMsgTestCPP::TearDown(void)
 {
     Mama::close();
-    MamaReservedFields::uninitReservedFields();
 }
 
 TEST_F (MamaMsgTestCPP, CreateTest)

--- a/mama/c_cpp/src/gunittest/cpp/MamaOpenCloseTest.cpp
+++ b/mama/c_cpp/src/gunittest/cpp/MamaOpenCloseTest.cpp
@@ -104,7 +104,6 @@ TEST_F(MamaOpenCloseTest, OpenCloseReopenSameBridge)
     {
         Mama::open();    
     }
-
     catch(MamaStatus status)
     {
         return;
@@ -165,4 +164,7 @@ TEST_F(MamaOpenCloseTest, StartStopDifferentThreads)
 
     // Close mama
     Mama::close();
+
+    // Cleanup
+    delete startBackgroundCB;
 }

--- a/mama/c_cpp/src/gunittest/cpp/MamaTimerTest.cpp
+++ b/mama/c_cpp/src/gunittest/cpp/MamaTimerTest.cpp
@@ -220,5 +220,9 @@ TEST_F(MamaTimerTestCPP, TwoTimer)
     
     mtarray[0].destroy();
     mtarray[1].destroy();
+
+    // Cleanup
+    delete timerCb;
+    delete stopperCb;
 }
 


### PR DESCRIPTION
replacing [bz-70](http://bugs.openmama.org/show_bug.cgi?id=70).

- Fixed two types of leaks for reserved fields:

  (1) MamaCPP: Fields weren't being destroyed on the final (or any)
      Mama::close().

  (2) MamaCPP: Field initialisation was called on every Mama::open(),
      causing lost pointers on every successive call.

- Simplified the init/destroy of reserved fields within MamaC and
  MamaCpp via the use of macros - This was mainly due to the addition of
  additional protection to ensure calls to init/destroy were always
  idempotent so it doesn't matter how many times you call either (esp.
  because the init/destroy functions are exposed to users).

- Exposed the reference counting versions of MamaC/MamaCPP open/close,
  which was primarily used to implement the balanced calls to reserved
  fields init/destroy.  We actually use these for some other one-time
  setup and destroy at Vulcan, so might be useful for others.  Docs
  were also updated to be consistent across versions (needs checked).

- Added calls to cleanup reserved fields if MamaC open() fails.

Additional changes:

- Fixed some memory leaks with MamaCPP unit tests.

Signed-off-by: Lee Skillen <lskillen@vulcanft.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/79)
<!-- Reviewable:end -->
