### PR TITLE
[BZ-82][MAMA] Fix memleak in mamaMsgImpl_setPayload.

### DIFF
--- a/mama/c_cpp/src/c/msg.c
+++ b/mama/c_cpp/src/c/msg.c
@@ -448,6 +448,19 @@ mamaMsgImpl_setPayload (mamaMsg msg, msgPayload payload, short owner)
         /* Do not destroy the list. We can reuse the memory! */
     }
 
+  if (impl->mPayload && impl->mPayloadBridge && impl->mMessageOwner)
+    {
+        if (MAMA_STATUS_OK != impl->mPayloadBridge->msgPayloadDestroy (impl->mPayload))
+        {
+            mama_log (MAMA_LOG_LEVEL_ERROR, "mamaMsgImpl_setPayload(): "
+                     "Could not destroy message payload.");
+        }
+
+        /*set mMessageOwner to zero now the payload has been destroyed to prevent
+          us destroying the underlying message again in the bridge specific function*/
+        impl->mMessageOwner = 0;
+    }
+
     impl->mPayload      = payload;
     impl->mMessageOwner = owner; 
     impl->mPayloadBridge->msgPayloadSetParent (impl->mPayload, msg);


### PR DESCRIPTION
Replacing [bz-82](http://bugs.openmama.org/show_bug.cgi?id=82)

_From original comment (Damien Maguire):_
> setPayload Memory Leak Patch
> Patch fixing a memleak in mamaMsgImpl_setPayload.
> impl->payload is not checked for a owned previous payload before the assignment, leading to a memory leak, in particular was showing when using mamaMsgField_getMsg.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/80)
<!-- Reviewable:end -->
