### PR TITLE
COMMON: Fix ret code from Win close shared lib

### DIFF
--- a/common/c_cpp/src/c/windows/platform.c
+++ b/common/c_cpp/src/c/windows/platform.c
@@ -68,7 +68,8 @@ LIB_HANDLE openSharedLib (const char* libName, const char* path)
 
 int closeSharedLib (LIB_HANDLE handle)
 {
-    return FreeLibrary ((HMODULE) handle); 
+    BOOL ret = FreeLibrary ((HMODULE) handle); 
+    return !ret;
 }
 
 void* loadLibFunc (LIB_HANDLE handle, const char* funcName)


### PR DESCRIPTION
The Win sytem call to close a shared lib returns 1=ok and 0=error.
The mama call does the opposite, so invert the Win return code.
The only current effect is an invalid error msg when unloading plugins on Win.
No unit test as we need a 'dummy' plugin to load/unload.

Signed-off-by: Reed Alpert <reed.alpert@gmail.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/84)
<!-- Reviewable:end -->
