### PR TITLE
MAMA: Add method to get transport from publisher impl

### DIFF
--- a/mama/c_cpp/src/c/publisher.c
+++ b/mama/c_cpp/src/c/publisher.c
@@ -46,9 +46,9 @@ typedef struct mamaPublisherImpl_
     /*The bridge implementation for the publisher*/
     publisherBridge     mMamaPublisherBridgeImpl;
     /*Outstanding actions for the throttled publishing*/
-    wList           	mPendingActions;
+    wList               mPendingActions;
     /*Used for throttling of sends.*/
-    mamaTransport   	mTport;
+    mamaTransport       mTport;
 
     void *mTransportHandle;
 } mamaPublisherImpl;
@@ -611,3 +611,13 @@ mamaPublisher_getTransport (mamaPublisher   publisher,
 
     return MAMA_STATUS_OK;
 }
+
+mamaTransport
+mamaPublisherImpl_getTransportImpl (mamaPublisher publisher)
+{
+    mamaPublisherImpl* impl = (mamaPublisherImpl*)publisher;
+
+    if (!impl) return NULL;
+    return impl->mTport;
+}
+

--- a/mama/c_cpp/src/c/publisherimpl.h
+++ b/mama/c_cpp/src/c/publisherimpl.h
@@ -28,6 +28,7 @@
 extern "C" {
 #endif
 
+MAMAExpDLL
 extern mama_status
 mamaPublisher_createByIndex (mamaPublisher*    result,
                              mamaTransport     tport,
@@ -36,13 +37,20 @@ mamaPublisher_createByIndex (mamaPublisher*    result,
                              const char*       source,
                              const char*       root);
 
+MAMAExpDLL
 extern mama_status
 mamaPublisher_sendFromInboxByIndex (mamaPublisher publisher,
                                     int           tportIndex,
                                     mamaInbox     inbox,
                                     mamaMsg       msg);
 
-mama_status mamaPublisherImpl_clearTransport (mamaPublisher publisher);
+MAMAExpDLL
+extern mama_status
+mamaPublisherImpl_clearTransport (mamaPublisher publisher);
+
+MAMAExpDLL
+extern mamaTransport
+mamaPublisherImpl_getTransportImpl (mamaPublisher publisher);
 
 #if defined(__cplusplus)
 }

--- a/mama/c_cpp/src/gunittest/c/MainUnitTestC.cpp
+++ b/mama/c_cpp/src/gunittest/c/MainUnitTestC.cpp
@@ -39,18 +39,24 @@ static string version     ("APPNAMESTR:  Version " VERSIONSTR
                            "  Date " DATESTR "  Build " BUILDSTR);
 
 
-static const char*       gMiddleware         = "wmw";
-static const char*       gPayload         = "wmsg";
+static const char*       gMiddleware  = "wmw";
+static const char*       gPayload     = "wmsg";
+static const char*       gTransport   = "tport";
 
 
 const char* getMiddleware (void)
 {
-	return gMiddleware;
+    return gMiddleware;
 }
 
 const char* getPayload (void)
 {
-	return gPayload;
+    return gPayload;
+}
+
+const char* getTransport (void)
+{
+    return gTransport;
 }
 
 static void parseCommandLine (int argc, char** argv)
@@ -60,16 +66,21 @@ static void parseCommandLine (int argc, char** argv)
 
     for (i = 1; i < argc;)
     {
-		if (strcmp ("-m", argv[i]) == 0)
-		{
-			gMiddleware = argv[i+1];
-			i += 2;
-		}
-		else if (strcmp ("-p", argv[i]) == 0)
-		{
-			gPayload = argv[i+1];
-			i += 2;
-		}
+        if (strcmp ("-m", argv[i]) == 0)
+        {
+            gMiddleware = argv[i+1];
+            i += 2;
+        }
+        else if (strcmp ("-p", argv[i]) == 0)
+        {
+            gPayload = argv[i+1];
+            i += 2;
+        }
+        else if (strcmp ("-tport", argv[i]) == 0)
+        {
+            gTransport = argv[i+1];
+            i += 2;
+        }
         else
         {
            //unknown arg

--- a/mama/c_cpp/src/gunittest/c/MainUnitTestC.h
+++ b/mama/c_cpp/src/gunittest/c/MainUnitTestC.h
@@ -22,7 +22,7 @@
 #ifndef MAINUNITTESTC_H_
 #define MAINUNITTESTC_H_
 
-#define NOT_NULL	( (void*)1 )
+#define NOT_NULL ( (void*)1 )
 
 
 #define ALLOW_NON_IMPLEMENTED(status)                                          \
@@ -67,4 +67,6 @@
 const char* getMiddleware (void);
 
 const char* getPayload (void);
+
+const char* getTransport (void);
 #endif /* MAINUNITTESTC_H_ */

--- a/mama/c_cpp/src/gunittest/c/publishertest.cpp
+++ b/mama/c_cpp/src/gunittest/c/publishertest.cpp
@@ -27,13 +27,14 @@
 #include "mama/timer.h"
 #include "mama/queue.h"
 #include "mama/io.h"
+#include <publisherimpl.h>
 #include <cstring>
 #include <cstdio>
 #include <cstdlib>
 
 
 class MamaPublisherTestC : public ::testing::Test
-{	
+{
 protected:
     MamaPublisherTestC();          
     virtual ~MamaPublisherTestC(); 
@@ -55,7 +56,7 @@ MamaPublisherTestC::~MamaPublisherTestC()
 }
 
 void MamaPublisherTestC::SetUp(void)
-{	
+{
     m_this = this;
 
     mama_loadBridge (&mBridge, getMiddleware());
@@ -88,10 +89,40 @@ TEST_F (MamaPublisherTestC, CreateDestroy)
                mamaTransport_allocate (&tport));
 
     ASSERT_EQ (MAMA_STATUS_OK,
-               mamaTransport_create (tport, "test_tport", mBridge));
+               mamaTransport_create (tport, getTransport(), mBridge));
 
     ASSERT_EQ (MAMA_STATUS_OK,
                mamaPublisher_create (&publisher, tport, source, NULL, NULL));
+
+    ASSERT_EQ (MAMA_STATUS_OK,
+               mamaPublisher_destroy (publisher));
+
+    ASSERT_EQ (MAMA_STATUS_OK,
+               mamaTransport_destroy (tport));
+}
+
+/*  Description: Create a mamaPublisher and get its transport
+ *
+ *  Expected Result: MAMA_STATUS_OK
+ */
+TEST_F (MamaPublisherTestC, GetTransport)
+{
+    mamaPublisher    publisher = NULL;
+    mamaTransport    tport     = NULL;
+    const char*      symbol    = "SYM";
+    const char*      root      = "ROOT";
+    const char*      source    = "SRC";
+   
+    ASSERT_EQ (MAMA_STATUS_OK,
+               mamaTransport_allocate (&tport));
+
+    ASSERT_EQ (MAMA_STATUS_OK,
+               mamaTransport_create (tport, getTransport(), mBridge));
+
+    ASSERT_EQ (MAMA_STATUS_OK,
+               mamaPublisher_create (&publisher, tport, source, NULL, NULL));
+
+    ASSERT_EQ(tport, mamaPublisherImpl_getTransportImpl (publisher));
 
     ASSERT_EQ (MAMA_STATUS_OK,
                mamaPublisher_destroy (publisher));
@@ -126,7 +157,7 @@ TEST_F (MamaPublisherTestC, DISABLED_Send)
                mamaTransport_allocate (&tport));
 
     ASSERT_EQ (MAMA_STATUS_OK,
-               mamaTransport_create (tport, "test_tport", mBridge));
+               mamaTransport_create (tport, getTransport(), mBridge));
 
     ASSERT_EQ (MAMA_STATUS_OK,
                mamaPublisher_create (&publisher, tport, source, NULL, NULL));


### PR DESCRIPTION
For publisher plugins add a method to get the transport from the publisher impl. This allows plugins to get the transport when getting called with the publisher in PublisherFieldCheckMamaPlugin_publisherPreSendHook(). Also add unit test as MamaPublisherTestC.GetTransport.

Signed-off-by: Reed Alpert <reed.alpert@gmail.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/91)
<!-- Reviewable:end -->
