### PR TITLE
SCONS: add Linux target for 32-bit build

### DIFF
--- a/site_scons/community/linux.py
+++ b/site_scons/community/linux.py
@@ -109,6 +109,19 @@ class Linux:
         env.Append( CFLAGS = ['-std=gnu99','-Wmissing-prototypes','-Wstrict-prototypes'] )
         env.Append( CXXFLAGS = ['-Wall','-Wno-long-long'] )
 
+        if env['target_arch'] == 'x86':
+            env.Append(CCFLAGS  = ['-m32'])
+            env.Append(CFLAGS   = ['-m32'])
+            env.Append(LINKFLAGS = ['-m32'])
+
+        if os.environ.has_key('CC'):
+            print 'Setting User defined CC: ' + os.environ['CC']
+            env['CC'] = os.environ['CC']
+
+        if os.environ.has_key('CXX'):
+            print 'Setting User defined CXX: ' + os.environ['CXX']
+            env['CXX'] = os.environ['CXX']
+
         if os.environ.has_key('CCFLAGS'):
             print 'Setting User defined CCFLAGS: ' + os.environ['CCFLAGS']
             env.Append( CCFLAGS = Split( os.environ['CCFLAGS'] ) )


### PR DESCRIPTION
Add scons target for Linux 32-bit build. Also add FLAGS for GNU compilers. Also add CC and CXX from environment to use an alternative version of the GNU compiler.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/93)
<!-- Reviewable:end -->
