### PR TITLE
Fixed issue with MSVC2015 User Defined Literals

### DIFF
--- a/mama/c_cpp/src/c/playback/playbackcapture.c
+++ b/mama/c_cpp/src/c/playback/playbackcapture.c
@@ -253,7 +253,7 @@ mama_status mamaCapture_saveMamaMsg (mamaPlaybackCapture* mamaCapture,
         strcat (captureBuffer, temp);
         strcat (captureBuffer, delim);
         memset (bufferLength, '\0', LENGTH);
-        sprintf (bufferLength, "%"PRI_MAMA_SIZE_T"", bufferSize);
+        sprintf (bufferLength, "%" PRI_MAMA_SIZE_T "", bufferSize);
         strcat (captureBuffer, bufferLength);
         fwrite (captureBuffer, 1, strlen(captureBuffer), myPlaybackFile);
         fputc  ((char)29,myPlaybackFile);

--- a/mama/c_cpp/src/examples/c/mamalistencachedc.c
+++ b/mama/c_cpp/src/examples/c/mamalistencachedc.c
@@ -1924,7 +1924,7 @@ highWaterMarkCallback (mamaQueue     queue,
     }
 
     printf ("%s high water mark exceeded. Num events "
-            "on queue: %"PRI_MAMA_SIZE_T"\n",
+            "on queue: %" PRI_MAMA_SIZE_T "\n",
             queueName == NULL ? "" : queueName, size);
 }
 
@@ -1950,7 +1950,7 @@ lowWaterMarkCallback  (mamaQueue     queue,
     }
 
     printf ("%s low water mark exceeded. Num events "
-            "on queue: %"PRI_MAMA_SIZE_T"\n",
+            "on queue: %" PRI_MAMA_SIZE_T "\n",
             queueName == NULL ? "" : queueName, size);
 }
 
@@ -2473,7 +2473,7 @@ mama_status printAllCacheFields(mamaFieldCache fieldCache)
     mama_size_t size = 0;
 
     mamaFieldCache_getSize(fieldCache, &size);
-    printf("Cache size: %"PRI_MAMA_SIZE_T"\n", size);
+    printf("Cache size: %" PRI_MAMA_SIZE_T "\n", size);
     
     ret = mamaFieldCacheIterator_create(&cacheIterator, fieldCache);
     while (mamaFieldCacheIterator_hasNext(cacheIterator))

--- a/mama/c_cpp/src/examples/cpp/mamalistencachedcpp.cpp
+++ b/mama/c_cpp/src/examples/cpp/mamalistencachedcpp.cpp
@@ -418,7 +418,7 @@ public:
                                           size_t size, 
                                           void* closure)
     {
-        printf ("%s queue high water mark exceeded. Size %"PRI_MAMA_SIZE_T"\n",
+        printf ("%s queue high water mark exceeded. Size %" PRI_MAMA_SIZE_T "\n",
                 queue->getQueueName(), size);
     }
 
@@ -426,7 +426,7 @@ public:
                                  size_t size, 
                                  void *closure)
     {
-        printf ("%s queue low water mark exceeded. Size %"PRI_MAMA_SIZE_T"\n",
+        printf ("%s queue low water mark exceeded. Size %" PRI_MAMA_SIZE_T "\n",
                 queue->getQueueName(), size);
     }
 private:


### PR DESCRIPTION
More details on the issue can be found on stack overflow:

http://stackoverflow.com/questions/31738796/using-macro-with-string-fails-on-vc-2015

I also updated the C code to be consistent even if it's not actually
required to prevent a compilation error in C code.

Signed-off-by: Frank Quinn <fquinn.ni@gmail.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/101)
<!-- Reviewable:end -->
