### PR TITLE
UNITTESTS: correction missing function definition removed when mergin…

### DIFF
--- a/mama/c_cpp/src/gunittest/c/MainUnitTestC.cpp
+++ b/mama/c_cpp/src/gunittest/c/MainUnitTestC.cpp
@@ -41,7 +41,7 @@ static string version     ("APPNAMESTR:  Version " VERSIONSTR
 
 static const char*       gMiddleware  = "wmw";
 static const char*       gPayload     = "wmsg";
-static const char        gPayloadId   = 'w';
+static char              gPayloadId   = 'W';
 static const char*       gTransport   = "tport";
 
 
@@ -80,6 +80,11 @@ static void parseCommandLine (int argc, char** argv)
         else if (strcmp ("-p", argv[i]) == 0)
         {
             gPayload = argv[i+1];
+            i += 2;
+        }
+        else if (strcmp ("-i", argv[i]) == 0)
+        {
+            gPayloadId = argv[i+1][0];
             i += 2;
         }
         else if (strcmp ("-tport", argv[i]) == 0)


### PR DESCRIPTION
Merge for previous pull request was incorrect. 
Adding missing function definition back in and fixing default payload ID value for C unit tests.

Signed-off-by: Matt Mulhern <matt@openmama.org>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/104)
<!-- Reviewable:end -->
