### PR TITLE
Fix dynamic loading NULL checks and extra parentheses warnings.

### DIFF
--- a/mama/c_cpp/src/c/mama.c
+++ b/mama/c_cpp/src/c/mama.c
@@ -2117,7 +2117,7 @@ mama_loadPayloadBridgeInternal  (mamaPayloadBridge* impl,
         /* Allocte the payload structure */
         *impl = calloc (1, sizeof (mamaPayloadBridgeImpl));
 
-        if (NULL == impl)
+        if (NULL == *impl)
         {
             status = MAMA_STATUS_NOMEM;
             mama_log (MAMA_LOG_LEVEL_ERROR,
@@ -2445,7 +2445,7 @@ mama_loadBridgeWithPathInternal (mamaBridge* impl,
         /* Allocate the bridge structure */
         *impl = calloc (1, sizeof (mamaBridgeImpl));
 
-        if (NULL == impl)
+        if (NULL == *impl)
         {
             status = MAMA_STATUS_NOMEM;
             mama_log (MAMA_LOG_LEVEL_ERROR,

--- a/mama/c_cpp/src/c/mama/status.h
+++ b/mama/c_cpp/src/c/mama/status.h
@@ -209,7 +209,7 @@ mamaStatus_stringForStatus (mama_status status);
 
 #define NOMEM_STATUS_CHECK(x) \
     do { \
-        if ((x==NULL))  \
+        if (x==NULL)  \
         {    \
             mama_log (MAMA_LOG_LEVEL_SEVERE, "Could not allocate memory");   \
             return MAMA_STATUS_NOMEM;      \


### PR DESCRIPTION
Couple of changes to fix NULL checks when allocating memory in the dynamic bridge loading code - we should have been checking the deref'd pointer values. It's difficult to test these sorts of changes, as we'd have to simulate memory exhaustion. 

Tested with the standard unit tests, everything looks good (except some C++ timer issues, though they appear to be unrelated). 

Additional change for a build error, which occurs because of an extra set of parentheses on a comparison check in the NOMEM_STATUS_CHECK macro. Causes the build to fail for QPID only, but it's also the only place that macro is used as well. Simple fix though.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/108)
<!-- Reviewable:end -->
