### PR TITLE
SCONS: Added 'debug' arg to SCons

### DIFF
--- a/mama/c_cpp/src/c/payload/qpidmsg/SConscript
+++ b/mama/c_cpp/src/c/payload/qpidmsg/SConscript
@@ -16,6 +16,9 @@ libPath = []
 libPath.append('$qpid_home/lib')
 libPath.append('$qpid_home/lib64')
 
+for i, x in enumerate(env['CCFLAGS']):
+    if '-O0' == x:
+        env['CCFLAGS'][i] = '-O2'
 env['CCFLAGS'] = [x for x in env['CCFLAGS'] if x != '-pedantic-errors']
 
 env.Append(LIBS=['mama', 'qpid-proton', 'm'], LIBPATH=libPath,

--- a/site_scons/community/command_line.py
+++ b/site_scons/community/command_line.py
@@ -24,6 +24,7 @@ def get_command_line_opts( host, products, VERSIONS ):
        BoolVariable('with_unittest','Build with gunit tests',False),
        BoolVariable('with_testtools','Build with test tools',False),
        BoolVariable('with_examples','Build with test tools',True),
+       BoolVariable('debug', 'Build without compiler optimisation.',False),
        BoolVariable('entitled','Whether the build is entitled or unentitled',False),
        PathVariable('gtest_home','Path to Google Test home',None, PathVariable.PathIsDir),
        PathVariable('junit_home','Path to Junit home',None, PathVariable.PathIsDir),

--- a/site_scons/community/linux.py
+++ b/site_scons/community/linux.py
@@ -105,7 +105,10 @@ class Linux:
     # Configures all the necessary environment variables for Linux
     def configure(self, env ):
         env.Append( CPPDEFINES = ['HAVE_CONFIG_H','_GNU_SOURCE'] )
-        env.Append( CCFLAGS = ['-g','-O2','-pedantic-errors'] )
+        if env['debug']:
+            env.Append( CCFLAGS = ['-g','-O0','-pedantic-errors'] )
+        else:
+            env.Append( CCFLAGS = ['-g','-O2','-pedantic-errors'] )
         env.Append( CFLAGS = ['-std=gnu99','-Wmissing-prototypes','-Wstrict-prototypes'] )
         env.Append( CXXFLAGS = ['-Wall','-Wno-long-long'] )
 


### PR DESCRIPTION
Added a 'debug' arg to SCons (defaults to False) to build without compiler optimisation.

This option is explicitly being ignored in qpidmsg for now due to compatibility problems with how proton is distributed.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/113)
<!-- Reviewable:end -->
