### PR TITLE
Fixed issue with Payload ID not working with messages

### DIFF
--- a/mama/c_cpp/src/c/mama.c
+++ b/mama/c_cpp/src/c/mama.c
@@ -2244,6 +2244,9 @@ mama_loadPayloadBridgeInternal  (mamaPayloadBridge* impl,
                             payloadName,
                             (void*)payloadLib);
 
+    // Update the payload bridge to back reference to this library
+    (*impl)->payloadLib = payloadLib;
+
     /* wtable_insert may return 1 for success, 0 for inserting a duplicate key,
      * -1 for failure of allocation. Unfortunately it also returns 0 for no table,
      * which means we have an abiguity. However, we shouldn't be able to reach

--- a/mama/c_cpp/src/c/msg.c
+++ b/mama/c_cpp/src/c/msg.c
@@ -73,8 +73,6 @@ typedef struct mamaMsgImpl_
     /* Set of get/set/update methods to use for a non wmsg payload */
     mamaPayloadBridgeImpl*  mPayloadBridge;
 
-    mamaPayloadLib          mPayloadLib;
-
     mamaMsg*                mLastVectorMsg;
     mama_size_t             mLastVectorMsgLen;
 
@@ -347,10 +345,8 @@ mamaMsgImpl_getPayloadId (mamaMsg msg, char* id)
 
     if (!impl || !id) return MAMA_STATUS_NULL_ARG;
 
-    mamaPayloadLib lib = impl->mPayloadLib;
+    *id = impl->mPayloadBridge->payloadLib->id;
 
-    *id = lib.id;
-    
     return MAMA_STATUS_OK;
 }
 
@@ -3228,12 +3224,9 @@ mamaMsg_setNewBuffer (mamaMsg msg, void* buffer,
 
     if (impl->mPayloadBridge)
     {
-        impl->mPayloadLib.id = (char) ((const char*)buffer) [0];
-
-        return
-        impl->mPayloadBridge->msgPayloadUnSerialize (impl->mPayload,
-                                                     buffer,
-                                                     size);
+        return impl->mPayloadBridge->msgPayloadUnSerialize (impl->mPayload,
+                                                            buffer,
+                                                            size);
     }
 
     return MAMA_STATUS_NULL_ARG;

--- a/mama/c_cpp/src/c/payloadbridge.h
+++ b/mama/c_cpp/src/c/payloadbridge.h
@@ -1497,6 +1497,9 @@ typedef struct mamaPayloadBridgeImpl_
 
     void*                               closure;
 
+    // Back reference to parent library itself
+    mamaPayloadLib*                     payloadLib;
+
 } mamaPayloadBridgeImpl;
 
 

--- a/mama/c_cpp/src/gunittest/c/mamainternaltest.cpp
+++ b/mama/c_cpp/src/gunittest/c/mamainternaltest.cpp
@@ -28,6 +28,7 @@
 #include <mama/status.h>
 
 #include <mamainternal.h>
+#include <msgimpl.h>
 
 #include "MainUnitTestC.h"
 
@@ -288,6 +289,26 @@ TEST_F (MamaInternalTestC, getPayloadChar)
 
     ASSERT_EQ (MAMA_STATUS_OK, mama_close ());
 }
+
+TEST_F (MamaInternalTestC, getPayloadCharFromMessage)
+{
+    char payloadChar = '\0';
+    mamaMsg msg = NULL;
+
+    ASSERT_EQ (MAMA_STATUS_OK, mama_loadPayloadBridge (&mPayload, getPayload ()));
+    ASSERT_EQ (MAMA_STATUS_OK, mama_loadBridge (&mBridge, getMiddleware ()));
+    ASSERT_EQ (MAMA_STATUS_OK, mama_open ());
+    ASSERT_EQ (MAMA_STATUS_OK, mamaMsg_createForPayload(&msg, getPayloadId ()));
+
+    EXPECT_EQ (MAMA_STATUS_OK, mamaMsgImpl_getPayloadId (msg, &payloadChar));
+
+    EXPECT_EQ (getPayloadId (), payloadChar);
+
+    mamaMsg_destroy(msg);
+
+    ASSERT_EQ (MAMA_STATUS_OK, mama_close ());
+}
+
 
 TEST_F (MamaInternalTestC, getPayloadCharNullPayloadName)
 {


### PR DESCRIPTION
The payload bridge now contains a back-reference to the mamaPayloadLib.
The mamaPayloadLib contains meta data about the payload such as which
payload ID was decided on for representing the payload on the wire.

Without this change, any calls from bridges to mamaMsgImpl_getPayloadId
will return NULL unless the message in question has been created from
a byte buffer.

Fix addresses issue #116.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/117)
<!-- Reviewable:end -->
