### PR TITLE
COMMON: Fixed race condition in timer creation / dequeueing

### DIFF
--- a/common/c_cpp/src/c/timers.c
+++ b/common/c_cpp/src/c/timers.c
@@ -291,11 +291,18 @@ int createTimer (timerElement* timer, timerHeap heap, timerFireCb cb, struct tim
         ele->mCb = cb;
         ele->mClosure = closure;
 
+        // Populate returned timer element before scheduling it
+        *timer = ele;
+
         wthread_mutex_lock (&heapImpl->mLock);
         ret = _addTimer (heapImpl, ele);
         wthread_mutex_unlock (&heapImpl->mLock);
-        if (ret < 0) return ret;
-        *timer = ele;
+        if (ret < 0)
+        {
+            // Something went wrong - blank the return element and return error
+            *timer = NULL;
+            return ret;
+        }
     }
     return 0;
 }


### PR DESCRIPTION
There was a race condition as per issue 109 where it was possible to
dequeue a timer element before its timer heap pointer had been
populated in createTimer (the one in timers.c).

This fix populates this pointer before queueing and on failure will
reset its value to NULL before returning as well as returning an
error code.

Signed-off-by: Frank Quinn <fquinn.ni@gmail.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/118)
<!-- Reviewable:end -->
