### PR TITLE
VS: Fixed issue with project files creating wrong jni lib for 64 bit

### DIFF
--- a/mama/jni/src/c/mamajni.vcproj
+++ b/mama/jni/src/c/mamajni.vcproj
@@ -225,7 +225,7 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
-				OutputFile="$(OutDir)\libmamajni.dll"
+				OutputFile="$(OutDir)\mamajni.dll"
 				LinkIncremental="2"
 				GenerateDebugInformation="true"
 				SubSystem="2"
@@ -303,7 +303,7 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
-				OutputFile="$(OutDir)\libmamajni.dll"
+				OutputFile="$(OutDir)\mamajni.dll"
 				LinkIncremental="1"
 				GenerateDebugInformation="true"
 				SubSystem="2"


### PR DESCRIPTION
Further details may be seen on https://github.com/OpenMAMA/OpenMAMA/issues/82

Signed-off-by: Frank Quinn <fquinn.ni@gmail.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/119)
<!-- Reviewable:end -->
