### PR TITLE
UNITTESTS: Changes to the CHECK_NON_IMPLEMENTED macros to allow dynam…

### DIFF
--- a/mama/c_cpp/src/gunittest/c/MainUnitTestC.cpp
+++ b/mama/c_cpp/src/gunittest/c/MainUnitTestC.cpp
@@ -23,7 +23,9 @@
 #include <gtest/gtest.h>
 #include <mama/mama.h>
 #include <mama/status.h>
+#include <wombat/port.h>
 #include <string>
+#include <MainUnitTestC.h>
 
 #ifndef WOMBAT_CONFIG_NO_NAMESPACES
  using std::string;
@@ -43,6 +45,7 @@ static const char*       gMiddleware  = "wmw";
 static const char*       gPayload     = "wmsg";
 static char              gPayloadId   = 'W';
 static const char*       gTransport   = "tport";
+static gtest_strictness  gStrictness  = OPTIONAL;
 
 
 const char* getMiddleware (void)
@@ -92,6 +95,28 @@ static void parseCommandLine (int argc, char** argv)
             gTransport = argv[i+1];
             i += 2;
         }
+        else if (strcmp ("--allow-not-implemented", argv[i]) == 0
+                || strcmp ("-n", argv[i]) == 0)
+        {
+            if (strcasecmp ("ALL", argv[i+1]) == 0
+                    || strcasecmp ("MANDATORY", argv[i+1]) == 0)
+            {
+                gStrictness = MANDATORY;
+            }
+            else if (strcasecmp ("RECOMMENDED", argv[i+1]) == 0)
+            {
+                gStrictness = RECOMMENDED;
+            }
+            else if (strcasecmp ("OPTIONAL", argv[i+1]) == 0)
+            {
+                gStrictness = OPTIONAL;
+            }
+            else if (strcasecmp ("NONE", argv[i+1]) == 0)
+            {
+                gStrictness = NONE;
+            }
+            i += 2;
+        }
         else
         {
            //unknown arg
@@ -100,6 +125,9 @@ static void parseCommandLine (int argc, char** argv)
     }
 }
 
+gtest_strictness getStrictness (void) {
+    return gStrictness;
+}
 
 int main(int argc, char **argv)
 {

--- a/mama/c_cpp/src/gunittest/c/MainUnitTestC.h
+++ b/mama/c_cpp/src/gunittest/c/MainUnitTestC.h
@@ -25,44 +25,28 @@
 #define NOT_NULL ( (void*)1 )
 
 
-#define ALLOW_NON_IMPLEMENTED(status)                                          \
+#define ALLOW_NON_IMPLEMENTED(strictness, status)                              \
  do {                                                                          \
-     if (MAMA_STATUS_NOT_IMPLEMENTED == status)                                \
+     if (strictness >= getStrictness()                                         \
+             && MAMA_STATUS_NOT_IMPLEMENTED == status)                         \
      {                                                                         \
          SUCCEED();                                                            \
          return;                                                               \
      }                                                                         \
  } while (0);
 
-#ifndef GTEST_STRICTNESS
-#define GTEST_STRICTNESS 3
-#endif
+#define CHECK_NON_IMPLEMENTED_MANDATORY(status)   ALLOW_NON_IMPLEMENTED(MANDATORY,   status)
+#define CHECK_NON_IMPLEMENTED_RECOMMENDED(status) ALLOW_NON_IMPLEMENTED(RECOMMENDED, status)
+#define CHECK_NON_IMPLEMENTED_OPTIONAL(status)    ALLOW_NON_IMPLEMENTED(OPTIONAL,    status)
 
-#if GTEST_STRICTNESS < 1 || GTEST_STRICTNESS > 4
-#error "Please set an appropriate GTEST_STRICTNESS level (1,2,3 or 4)"
-#endif
+typedef enum gtest_strictness {
+    MANDATORY,
+    RECOMMENDED,
+    OPTIONAL,
+    NONE
+} gtest_strictness;
 
-/* Most lenient. Allows all methods to return non-implemented */
-#if GTEST_STRICTNESS == 1
-#define CHECK_NON_IMPLEMENTED_MANDATORY(status) ALLOW_NON_IMPLEMENTED(status)
-#define CHECK_NON_IMPLEMENTED_RECOMMENDED(status) ALLOW_NON_IMPLEMENTED(status)
-#define CHECK_NON_IMPLEMENTED_OPTIONAL(status) ALLOW_NON_IMPLEMENTED(status)
-
-#elif GTEST_STRICTNESS == 2
-#define CHECK_NON_IMPLEMENTED_MANDATORY(status)
-#define CHECK_NON_IMPLEMENTED_RECOMMENDED(status) ALLOW_NON_IMPLEMENTED(status)
-#define CHECK_NON_IMPLEMENTED_OPTIONAL(status) ALLOW_NON_IMPLEMENTED(status)
-
-#elif GTEST_STRICTNESS == 3
-#define CHECK_NON_IMPLEMENTED_MANDATORY(status)
-#define CHECK_NON_IMPLEMENTED_RECOMMENDED(status)
-#define CHECK_NON_IMPLEMENTED_OPTIONAL(status) ALLOW_NON_IMPLEMENTED(status)
-
-#elif GTEST_STRICTNESS == 4
-#define CHECK_NON_IMPLEMENTED_ALL(status)
-#define CHECK_NON_IMPLEMENTED_OPTIONAL(status)
-#define CHECK_NON_IMPLEMENTED_RECOMMENDED(status)
-#endif /* GTEST_STRICTNESS_SETTINGS */
+gtest_strictness getStrictness (void);
 
 const char* getMiddleware (void);
 

--- a/mama/c_cpp/src/gunittest/c/mamamsg/msggeneraltests.cpp
+++ b/mama/c_cpp/src/gunittest/c/mamamsg/msggeneraltests.cpp
@@ -333,7 +333,7 @@ TEST_F (MsgGeneralTestsC, msgGetNumFieldsSubMessage)
 
     status = mamaMsg_addMsg (mMsg, "name2", 103, submsg);
 
-    ALLOW_NON_IMPLEMENTED (status);
+    CHECK_NON_IMPLEMENTED_RECOMMENDED (status);
 
     EXPECT_EQ (MAMA_STATUS_OK, mamaMsg_getNumFields (mMsg, &numFields));
     EXPECT_EQ (addedFields, numFields);


### PR DESCRIPTION
…ic specification

Changing the CHECK_NON_IMPLEMENTED_* macros to allow users to specify
the level of strictness at the command line rather than during compile
time.

The command line arguments come in the following forms:
--allow-not-implemented <level>
-n <level>

Where level is one of (case insensitive):
None        - No tests should pass when they return
              MAMA_STATUS_NOT_IMPLEMENTED
Optional    - Only tests denoted as optional pass when they return
              MAMA_STATUS_NOT_IMPLEMENTED
Recommended - Only tests denoted as optional or recommended pass when
              they return MAMA_STATUS_NOT_IMPLEMENTED
All         - All tests denoted as optional, recommended or mandatory
              pass when they return MAMA_STATUS_NOT_IMPLEMENTED
Mandatory   - Same behaviour as 'All'

The default level (when no command line is passed) is 'Optional'.

At present the check only impacts those which have the macro enabled,
though eventually this should cover the majority of tests.

Signed-off-by: Damian Maguire <d.maguire@srtechlabs.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/122)
<!-- Reviewable:end -->
