### PR TITLE
Fixed function prototype for unserialize payload bridge function

### DIFF
--- a/mama/c_cpp/src/c/payload/avismsg/avispayload.c
+++ b/mama/c_cpp/src/c/payload/avismsg/avispayload.c
@@ -235,9 +235,9 @@ avismsgPayload_getByteSize       (const msgPayload    msg,
 }
 
 mama_status
-avismsgPayload_unSerialize (const msgPayload    msg,
-                           const void*        buffer,
-                           mama_size_t        bufferLength)
+avismsgPayload_unSerialize (const msgPayload   msg,
+                            const void*        buffer,
+                            mama_size_t        bufferLength)
 {
     avisPayloadImpl* impl = (avisPayloadImpl*) msg;
     char tempName[64];

--- a/mama/c_cpp/src/c/payload/qpidmsg/payload.c
+++ b/mama/c_cpp/src/c/payload/qpidmsg/payload.c
@@ -913,7 +913,7 @@ qpidmsgPayload_serialize (const msgPayload  msg,
 
 mama_status
 qpidmsgPayload_unSerialize (const msgPayload    msg,
-                            const void**        buffer,
+                            const void*         buffer,
                             mama_size_t         bufferLength)
 {
     qpidmsgPayloadImpl*  impl       = (qpidmsgPayloadImpl*) msg;

--- a/mama/c_cpp/src/c/payload/qpidmsg/qpidpayloadfunctions.h
+++ b/mama/c_cpp/src/c/payload/qpidmsg/qpidpayloadfunctions.h
@@ -290,7 +290,7 @@ qpidmsgPayload_serialize        (const msgPayload    msg,
 MAMAExpBridgeDLL
 mama_status
 qpidmsgPayload_unSerialize      (const msgPayload    msg,
-                                 const void**        buffer,
+                                 const void*         buffer,
                                  mama_size_t         bufferLength);
 
 /**

--- a/mama/c_cpp/src/c/payloadbridge.h
+++ b/mama/c_cpp/src/c/payloadbridge.h
@@ -476,7 +476,7 @@ typedef mama_status
 
 typedef mama_status
 (*msgPayload_unSerialize)      (const msgPayload    msg,
-                                const void**        buffer,
+                                const void*         buffer,
                                 mama_size_t         bufferLength);
 
 typedef mama_status


### PR DESCRIPTION
The bridges have lived with this in the past and typically already
cast to a void* anyway, so this should have no impact.

Signed-off-by: Frank Quinn <fquinn.ni@gmail.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/123)
<!-- Reviewable:end -->
