### PR TITLE
MAMAMSG: Marked freeString as deprecated

### DIFF
--- a/mama/c_cpp/src/c/listenermsgcallback.c
+++ b/mama/c_cpp/src/c/listenermsgcallback.c
@@ -164,7 +164,6 @@ static void processPointToPointMessage (msgCallback*    callback,
         {
             const char *msgString = mamaMsg_toString( msg );
             mama_log (MAMA_LOG_LEVEL_FINE, "Received Initial: (%s) %s", userSymbol, msgString);
-            mamaMsg_freeString( msg, msgString );
         }
         if (!mamaSubscription_getAcceptMultipleInitials (self->mSubscription))
         {

--- a/mama/c_cpp/src/c/mama/msg.h
+++ b/mama/c_cpp/src/c/mama/msg.h
@@ -2049,8 +2049,8 @@ mamaMsg_getNumFields(
     mama_size_t*   numFields);
 
 /**
- * Return a const char * representation the message. Must call
- * mamaMsg_freeString() to free memory allocated for string.
+ * Return a const char * representation the message. Memory is owned by the
+ * underlying bridge.
  *
  * @param msg The message.
  * @return A string representation of the message.
@@ -2061,16 +2061,21 @@ mamaMsg_toString(
     const mamaMsg msg);
 
 /**
- * Free the memory allocated by mamaMsg_toString.
+ * Free the memory allocated by mamaMsg_toString [deprecated].
  *
  * @param msg The message.
  * @param msgString The string allocated by mamaMsg_toString
  */
+
+MAMAIgnoreDeprecatedOpen
+MAMAExpDeprecatedDLL(
+        "mamaMsg_freeString has been deprecated - memory now managed by bridge")
 MAMAExpDLL
 extern void
 mamaMsg_freeString(
     const mamaMsg  msg,
     const char*    msgString );
+MAMAIgnoreDeprecatedClose
 
 /**
  * Get the entitle code for this message. The result defaults to 0 (no

--- a/mama/c_cpp/src/c/msg.c
+++ b/mama/c_cpp/src/c/msg.c
@@ -2655,11 +2655,13 @@ mamaMsg_toString (const mamaMsg msg)
     return NULL;
 }
 
+MAMAIgnoreDeprecatedOpen
 void
 mamaMsg_freeString (const mamaMsg msg,  const char* msgString)
 {
 
 }
+MAMAIgnoreDeprecatedClose
 
 mama_status
 mamaMsg_iterateFields (const mamaMsg            msg,

--- a/mama/c_cpp/src/c/publisher.c
+++ b/mama/c_cpp/src/c/publisher.c
@@ -576,7 +576,6 @@ mamaPublisher_sendFromInboxWithThrottle (mamaPublisher               publisher,
     {
         const char* msgString = mamaMsg_toString (msg);
         mama_log (MAMA_LOG_LEVEL_FINER, "INBOX REQUEST (throttled): %s", msgString);
-        mamaMsg_freeString (msg, msgString);
     }
 
     c2->mPublisher            = publisher;

--- a/mama/c_cpp/src/c/subscription.c
+++ b/mama/c_cpp/src/c/subscription.c
@@ -2056,7 +2056,6 @@ mamaSubscription_processTportMsg( mamaSubscription subscription,
                 userSymbolFormatted, 
                 text, 
                 subscription);
-        mamaMsg_freeString (msg, text);
     }
 
 #ifdef WITH_ENTITLEMENTS
@@ -2110,7 +2109,6 @@ mamaSubscription_processWildCardMsg( mamaSubscription subscription,
                 userSymbolFormatted, 
                 text, 
                 subscription);
-        mamaMsg_freeString (msg, text);
     }
 
 #ifdef WITH_ENTITLEMENTS
@@ -2163,7 +2161,6 @@ mamaSubscription_processMsg (mamaSubscription subscription, mamaMsg msg)
                 userSymbolFormatted, 
                 text, 
                 subscription);
-        mamaMsg_freeString (msg, text);
     }
 
     if (callback != NULL) /* TYPE is a MARKETDATA type */

--- a/mama/c_cpp/src/cpp/MamaMsg.cpp
+++ b/mama/c_cpp/src/cpp/MamaMsg.cpp
@@ -2039,10 +2039,6 @@ void MamaMsg::method (const MamaFieldDescriptor* field, fType value)   \
 
     const char* MamaMsg::toString () const
     {
-        if (mString != NULL )
-        {
-            mamaMsg_freeString (mMsg, mString);
-        }
         mString = mamaMsg_toString (mMsg);
 
         return mString;
@@ -2373,12 +2369,6 @@ void MamaMsg::method (const MamaFieldDescriptor* field, fType value)   \
         {
             mamaTry (mamaMsg_destroy (mMsg));
             mDestroy = false;
-        }
-
-        if (mString)
-        {
-            mamaMsg_freeString (mMsg, mString);
-            mString = NULL;
         }
 
         if (mVectorMsg)

--- a/mama/dotnet/src/cs/MamaMsg.cs
+++ b/mama/dotnet/src/cs/MamaMsg.cs
@@ -4993,7 +4993,6 @@ namespace Wombat
             string strRet =  Marshal.PtrToStringAnsi(NativeMethods.mamaMsg_toString(nativeHandle));
             string val;
             val = string.Copy(strRet);
-			int code = NativeMethods.mamaMsg_freeString(nativeHandle, strRet);
             return val;
         }
 
@@ -5728,8 +5727,6 @@ namespace Wombat
 				ref int numFields);
             [DllImport(Mama.DllName, CallingConvention = CallingConvention.Cdecl)]
 			public static extern IntPtr mamaMsg_toString(IntPtr mamaMsg);
-            [DllImport(Mama.DllName, CallingConvention = CallingConvention.Cdecl)]
-			public static extern int mamaMsg_freeString(IntPtr mamaMsg,string msgString );
             [DllImport(Mama.DllName, CallingConvention = CallingConvention.Cdecl)]
 			public static extern int mamaMsg_getEntitleCode(IntPtr mamaMsg,
 				ref int code);


### PR DESCRIPTION
Added deprecation warning for mamaMsg_freeString (it's a noop anyway).
It will *actually* be deprecated at a later point.

Signed-off-by: Frank Quinn <fquinn.ni@gmail.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/124)
<!-- Reviewable:end -->
