### PR TITLE
Bug Fix #126 - Initial seqnum in mamaDQPublisherManager

### DIFF
--- a/mama/c_cpp/src/c/dqpublisher.c
+++ b/mama/c_cpp/src/c/dqpublisher.c
@@ -92,6 +92,7 @@ mama_status mamaDQPublisher_send (mamaDQPublisher pub, mamaMsg msg)
 
         mamaMsg_updateU32(modifableMsg, MamaFieldSeqNum.mName, MamaFieldSeqNum.mFid,
                 impl->mSeqNum);
+        impl->mSeqNum++;
 
         switch (mamaMsgType_typeForMsg (modifableMsg))
         {
@@ -101,19 +102,6 @@ mama_status mamaDQPublisher_send (mamaDQPublisher pub, mamaMsg msg)
             case MAMA_MSG_TYPE_NOT_PERMISSIONED :
             case MAMA_MSG_TYPE_NOT_FOUND : 
                 break;
-            case MAMA_MSG_TYPE_INITIAL      :
-            case MAMA_MSG_TYPE_BOOK_INITIAL :
-            case MAMA_MSG_TYPE_RECAP        :
-            case MAMA_MSG_TYPE_BOOK_RECAP   :
-                if(MAMA_STATUS_OK !=
-                        mamaMsg_updateU8(modifableMsg,MamaFieldMsgStatus.mName,
-                            MamaFieldMsgStatus.mFid, impl->mStatus))
-                {
-                    mamaMsg_updateI16(modifableMsg,MamaFieldMsgStatus.mName,
-                            MamaFieldMsgStatus.mFid, impl->mStatus);
-                }
-                break;
-
             default:
                 if(MAMA_STATUS_OK !=
                         mamaMsg_updateU8(modifableMsg,MamaFieldMsgStatus.mName,
@@ -122,7 +110,6 @@ mama_status mamaDQPublisher_send (mamaDQPublisher pub, mamaMsg msg)
                    mamaMsg_updateI16(modifableMsg,MamaFieldMsgStatus.mName,
                            MamaFieldMsgStatus.mFid, impl->mStatus);
                 }
-                impl->mSeqNum++;
                 break;
         }
     }
@@ -134,7 +121,7 @@ mama_status mamaDQPublisher_send (mamaDQPublisher pub, mamaMsg msg)
     }
 
     if (impl->mSendTime)
-        {
+    {
         mamaMsg_getTempCopy (msg, &modifableMsg);
         updateSendTime(impl, modifableMsg);
     }

--- a/mama/c_cpp/src/c/dqpublisher.c
+++ b/mama/c_cpp/src/c/dqpublisher.c
@@ -82,13 +82,17 @@ mama_status mamaDQPublisher_create (mamaDQPublisher pub, mamaTransport transport
 
 
 mama_status mamaDQPublisher_send (mamaDQPublisher pub, mamaMsg msg)
-{     
+{
     mamaDQPublisherImpl* impl = (mamaDQPublisherImpl*) (pub);
     mamaMsg modifableMsg = NULL;
 
     if (impl->mSeqNum != 0)
     {
         mamaMsg_getTempCopy (msg, &modifableMsg);
+
+        mamaMsg_updateU32(modifableMsg, MamaFieldSeqNum.mName, MamaFieldSeqNum.mFid,
+                impl->mSeqNum);
+
         switch (mamaMsgType_typeForMsg (modifableMsg))
         {
             case MAMA_MSG_TYPE_REFRESH :
@@ -121,10 +125,8 @@ mama_status mamaDQPublisher_send (mamaDQPublisher pub, mamaMsg msg)
                 impl->mSeqNum++;
                 break;
         }
-        mamaMsg_updateU32(modifableMsg, MamaFieldSeqNum.mName, MamaFieldSeqNum.mFid,
-                impl->mSeqNum);
     }
-    
+
     if (impl->mSenderId != 0)
     {
         mamaMsg_getTempCopy (msg, &modifableMsg);
@@ -141,7 +143,7 @@ mama_status mamaDQPublisher_send (mamaDQPublisher pub, mamaMsg msg)
         return (mamaPublisher_send (impl->mPublisher, modifableMsg));
     else
         return (mamaPublisher_send (impl->mPublisher, msg));
-} 
+}
 
 mama_status mamaDQPublisher_sendReply (mamaDQPublisher pub,
                                        mamaMsg request,


### PR DESCRIPTION
The mamaDQPublisher now sets the seqnum of a message before incrementing its local buffer.
This ensures the first seqnum used by the publisher(s) is equal to that configured by the client.
ref `mamaDQPublisherManager_setSeqNum()`

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/127)
<!-- Reviewable:end -->
