### PR TITLE
Bug Fix #126 - Initial seqnum in mamaDQPublisherManager

### DIFF
--- a/mama/c_cpp/src/c/dqpublisher.c
+++ b/mama/c_cpp/src/c/dqpublisher.c
@@ -97,19 +97,6 @@ mama_status mamaDQPublisher_send (mamaDQPublisher pub, mamaMsg msg)
             case MAMA_MSG_TYPE_NOT_PERMISSIONED :
             case MAMA_MSG_TYPE_NOT_FOUND : 
                 break;
-            case MAMA_MSG_TYPE_INITIAL      :
-            case MAMA_MSG_TYPE_BOOK_INITIAL :
-            case MAMA_MSG_TYPE_RECAP        :
-            case MAMA_MSG_TYPE_BOOK_RECAP   :
-                if(MAMA_STATUS_OK !=
-                        mamaMsg_updateU8(modifableMsg,MamaFieldMsgStatus.mName,
-                            MamaFieldMsgStatus.mFid, impl->mStatus))
-                {
-                    mamaMsg_updateI16(modifableMsg,MamaFieldMsgStatus.mName,
-                            MamaFieldMsgStatus.mFid, impl->mStatus);
-                }
-                break;
-
             default:
                 if(MAMA_STATUS_OK !=
                         mamaMsg_updateU8(modifableMsg,MamaFieldMsgStatus.mName,
@@ -118,11 +105,11 @@ mama_status mamaDQPublisher_send (mamaDQPublisher pub, mamaMsg msg)
                    mamaMsg_updateI16(modifableMsg,MamaFieldMsgStatus.mName,
                            MamaFieldMsgStatus.mFid, impl->mStatus);
                 }
-                impl->mSeqNum++;
                 break;
         }
         mamaMsg_updateU32(modifableMsg, MamaFieldSeqNum.mName, MamaFieldSeqNum.mFid,
                 impl->mSeqNum);
+        impl->mSeqNum++;
     }
     
     if (impl->mSenderId != 0)


### PR DESCRIPTION
My previous pull request, although favourably reviewed, was inadequate as it still meant that a publisher could send multiple messages with the same seqnum.

Prior to this new fix, the seqnum would only be incremented for a subset of message types.
In the typical case a MAMA_MSG_TYPE_INITIAL is sent followed by multiple MAMA_MSG_TYPE_UPDATEs. This would correctly follow sequential seqnums.

For other cases, such as multiple MAMA_MSG_TYPE_INITIALs, multiple messages could have the same seqnum.

In my case, no MAMA_MSG_TYPE_INITIALs are sent, only MAMA_MSG_TYPE_UPDATEs.
Currently, my seqnums will never start from 1.

This fix in this pull request ensures that:
1. The seqnum will always begin with the value passed to mamaDQPublisher_setSeqNum, default 1
2. All messages from a given publisher will have a unique seqnum (until mama_seqnum_t overflows).

Confession: In violation of the documented submission process, I haven't unit tested these changes.
I have been unable to get a working set of unit tests for the "next" branch, even before applying my changes.
I get a compilation error in:
    mama/c_cpp/src/gunittest/c/payload/payloadgeneraltests.cpp
Building on CentOS 6.6 (final) x64, gcc 4.4.7, gtest 1.5.
I've tried custom installs of gtest 1.6/1.7 but still no success.
I can see that the openmama jenkins job is successfully building so it must be my setup.

Even if I comment out the test that fails to compile, some remaining tests FAIL.
I'm using the qpid middleware and have followed the [build instructions](https://github.com/OpenMAMA/OpenMAMA/wiki/Building-on-Linux) as best I can, although there are no explicit instructions about running the tests. 
I presume the `-m qpid and -p qpidmsg` options are correct.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/129)
<!-- Reviewable:end -->
