### PR TITLE
WINDOWS: Adding missing source files to SCons.win and VS.

### DIFF
--- a/mama/c_cpp/src/c/SConscript.win
+++ b/mama/c_cpp/src/c/SConscript.win
@@ -70,6 +70,7 @@ symbolmapfile.c
 transport.c
 symbollist.c
 symbollistmember.c
+registerfunctions.c
 conflation/connection.c
 conflation/serverconnection.c
 playback/playbackcapture.c

--- a/mama/c_cpp/src/c/mamac.vcproj
+++ b/mama/c_cpp/src/c/mamac.vcproj
@@ -510,6 +510,10 @@
 				>
 			</File>
 			<File
+				RelativePath=".\plugin.c"
+				>
+			</File>
+			<File
 				RelativePath=".\price.c"
 				>
 			</File>
@@ -531,6 +535,10 @@
 			</File>
 			<File
 				RelativePath=".\refreshtransport.c"
+				>
+			</File>
+			<File
+				RelativePath=".\registerfunctions.c"
 				>
 			</File>
 			<File
@@ -868,6 +876,10 @@
 				>
 			</File>
 			<File
+				RelativePath=".\plugin.h"
+				>
+			</File>
+			<File
 				RelativePath=".\mama\price.h"
 				>
 			</File>
@@ -897,6 +909,10 @@
 			</File>
 			<File
 				RelativePath=".\refreshtransport.h"
+				>
+			</File>
+			<File
+				RelativePath=".\registerfunctions.h"
 				>
 			</File>
 			<File


### PR DESCRIPTION
New dynamic loading functionality missing in windows SCons implementation.

Tested with 
```scons libevent_home=d:\mmulhern\libevent\1.4.15 middleware=qpid qpid_home=d:\qpid\qpid-proton-0.11.1\ buildtype=dynamic```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/130)
<!-- Reviewable:end -->
