### PR TITLE
SCONS: making default entitlements bridge 'noop'.

### DIFF
--- a/site_scons/community/command_line.py
+++ b/site_scons/community/command_line.py
@@ -25,7 +25,7 @@ def get_command_line_opts( host, products, VERSIONS ):
        BoolVariable('with_testtools','Build with test tools',False),
        BoolVariable('with_examples','Build with test tools',True),
        PathVariable('oea_home','Path to oea entitlements home',None, PathVariable.PathIsDir),
-       ListVariable('entitlements', 'List of entitlements libraries to enforce e.g. \'oea\' (NOTE: 1st in list the default entitlements library to use.)', '',
+       ListVariable('entitlements', 'List of entitlements libraries to enforce e.g. \'oea\' (NOTE: 1st in list the default entitlements library to use.)', 'noop',
                      names = ['oea','noop'] ),
        PathVariable('gtest_home','Path to Google Test home',None, PathVariable.PathIsDir),
        PathVariable('junit_home','Path to Junit home',None, PathVariable.PathIsDir),


### PR DESCRIPTION
Changing default behaviour to build 'no-op' entitlements bridge implementation.

Signed-off-by: Matt Mulhern <m.mulhern@srtechlabs.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/136)
<!-- Reviewable:end -->
