### PR TITLE
JUNIT: Removing duplicate line causing build error.

### DIFF
--- a/mama/jni/src/junittests/MamaPublisherTest.java
+++ b/mama/jni/src/junittests/MamaPublisherTest.java
@@ -28,7 +28,6 @@ import com.wombat.mama.*;
  *
  * This class will test MamaPublisher 
  */
-public class MamaPublisherTest extends TestCase implements MamaStartBackgroundCallback, MamaThrottleCallback
 public class MamaPublisherTest extends TestCase implements MamaStartBackgroundCallback, MamaThrottleCallback,
                                                            MamaPublisherCallback,
                                                            MamaTransportListener


### PR DESCRIPTION
Duplicate line seems to have been introduced when merging in publisher events.

Signed-off-by: Matt Mulhern <m.mulhern@srtechlabs.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/140)
<!-- Reviewable:end -->
