### PR TITLE
Avis dynamic loading

### DIFF
--- a/mama/c_cpp/src/c/bridge/avis/avis.vcxproj
+++ b/mama/c_cpp/src/c/bridge/avis/avis.vcxproj
@@ -64,18 +64,18 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.40219.1</_ProjectFileVersion>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(Platform)\$(Configuration)\</OutDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)$(Configuration)\</OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(Platform)\$(Configuration)\</IntDir>
     <IgnoreImportLibrary Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</IgnoreImportLibrary>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</LinkIncremental>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)$(Platform)\$(Configuration)</OutDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)$(Configuration)\</OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(Platform)\$(Configuration)\</IntDir>
     <IgnoreImportLibrary Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</IgnoreImportLibrary>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</LinkIncremental>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)$(Configuration)\</OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(Configuration)\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)$(Platform)\$(Configuration)</OutDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)$(Configuration)\</OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(Platform)\$(Configuration)\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</LinkIncremental>
     <IgnoreImportLibrary Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</IgnoreImportLibrary>

--- a/mama/c_cpp/src/c/bridge/avis/avisbridgefunctions.h
+++ b/mama/c_cpp/src/c/bridge/avis/avisbridgefunctions.h
@@ -43,24 +43,31 @@ MAMAExpDLL
 extern mama_status
 avisBridge_init (mamaBridge bridgeImpl);
 
+MAMAExpDLL
 extern const char*
 avisBridge_getVersion (void);
 
+MAMAExpDLL
 mama_status
 avisBridge_getDefaultPayloadId (char***name, char** id);
 
+MAMAExpDLL
 extern mama_status
 avisBridge_open (mamaBridge bridgeImpl);
 
+MAMAExpDLL
 extern mama_status
 avisBridge_close (mamaBridge bridgeImpl);
 
+MAMAExpDLL
 extern mama_status
 avisBridge_start (mamaQueue defaultEventQueue);
 
+MAMAExpDLL
 extern mama_status
 avisBridge_stop (mamaQueue defaultEventQueue);
 
+MAMAExpDLL
 extern const char*
 avisBridge_getName (void);
 
@@ -68,94 +75,117 @@ avisBridge_getName (void);
 /*=========================================================================
   =                    Functions for the mamaQueue                        =
   =========================================================================*/
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaQueue_create (queueBridge *queue, mamaQueue parent);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaQueue_create_usingNative (queueBridge *queue, mamaQueue parent, void* nativeQueue);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaQueue_destroy (queueBridge queue);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaQueue_getEventCount (queueBridge queue, size_t* count);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaQueue_dispatch (queueBridge queue);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaQueue_timedDispatch (queueBridge queue, uint64_t timeout);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaQueue_dispatchEvent (queueBridge queue);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaQueue_enqueueEvent (queueBridge        queue,
                                    mamaQueueEnqueueCB callback,
                                    void*              closure);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaQueue_stopDispatch (queueBridge queue);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaQueue_setEnqueueCallback (queueBridge        queue,
                                          mamaQueueEnqueueCB callback,
                                          void*              closure);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaQueue_removeEnqueueCallback (queueBridge queue);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaQueue_getNativeHandle (queueBridge queue,
                                     void**      result);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaQueue_setLowWatermark (queueBridge queue,
                                     size_t      lowWatermark);
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaQueue_setHighWatermark (queueBridge queue,
                                      size_t      highWatermark);
 /*=========================================================================
   =                    Functions for the mamaTransport                    =
   =========================================================================*/
+MAMAExpDLL
 extern int
 avisBridgeMamaTransport_isValid (transportBridge transport);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaTransport_destroy (transportBridge transport);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaTransport_create (transportBridge* result,
                                  const char*      name,
                                  mamaTransport    parent);
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaTransport_forceClientDisconnect (transportBridge* transports,
                                               int              numTransports,
                                               const char*      ipAddress,
                                               uint16_t         port);
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaTransport_findConnection (transportBridge* transports,
                                        int              numTransports,
                                        mamaConnection*  result,
                                        const char*      ipAddress,
                                        uint16_t         port);
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaTransport_getAllConnections (transportBridge* transports,
                                           int              numTransports,
                                           mamaConnection** result,
                                           uint32_t*        len);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaTransport_getAllConnectionsForTopic (transportBridge* transports,
                                                     int              numTransports,
                                                     const char*      topic,
                                                     mamaConnection** result,
                                                     uint32_t*        len);
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaTransport_freeAllConnections (transportBridge* transports,
                                            int              numTransports,
                                            mamaConnection*  connections,
                                            uint32_t         len);
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaTransport_getAllServerConnections (
                                         transportBridge*       transports,
@@ -163,6 +193,7 @@ avisBridgeMamaTransport_getAllServerConnections (
                                         mamaServerConnection** result,
                                         uint32_t*              len);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaTransport_freeAllServerConnections (
                                         transportBridge*        transports,
@@ -170,30 +201,36 @@ avisBridgeMamaTransport_freeAllServerConnections (
                                         mamaServerConnection*   connections,
                                         uint32_t                len);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaTransport_getNumLoadBalanceAttributes (
                                     const char* name,
                                     int*        numLoadBalanceAttributes);
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaTransport_getLoadBalanceSharedObjectName (
                                     const char*  name,
                                     const char** loadBalanceSharedObjectName);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaTransport_getLoadBalanceScheme (const char*    name,
                                              tportLbScheme* scheme);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaTransport_sendMsgToConnection (
                                     transportBridge transport,
                                     mamaConnection  connection,
                                     mamaMsg         msg,
                                     const char*     topic);
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaTransport_isConnectionIntercepted (
                                     mamaConnection connection,
                                     uint8_t* result);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaTransport_installConnectConflateMgr (
                                     transportBridge       transport,
@@ -202,28 +239,34 @@ avisBridgeMamaTransport_installConnectConflateMgr (
                                     conflateProcessCb     processCb,
                                     conflateGetMsgCb      msgCb);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaTransport_uninstallConnectConflateMgr (
                                     transportBridge       transport,
                                     mamaConflationManager mgr,
                                     mamaConnection        connection);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaTransport_startConnectionConflation (
                                     transportBridge        transport,
                                     mamaConflationManager  mgr,
                                     mamaConnection         connection);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaTransport_requestConflation (transportBridge* transports,
                                             int              numTransports);
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaTransport_requestEndConflation (transportBridge* transports,
                                                int              numTransports);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaTransport_getNativeTransport (transportBridge transport,
                                              void**          result);
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaTransport_getNativeTransportNamingCtx (transportBridge transport,
                                                       void**          result);
@@ -231,6 +274,7 @@ avisBridgeMamaTransport_getNativeTransportNamingCtx (transportBridge transport,
 /*=========================================================================
   =                    Functions for the mamaSubscription                 =
   =========================================================================*/
+MAMAExpDLL
 extern mama_status avisBridgeMamaSubscription_create
                                (subscriptionBridge* subsc_,
                                 const char*         source,
@@ -241,6 +285,7 @@ extern mama_status avisBridgeMamaSubscription_create
                                 mamaSubscription    subscription,
                                 void*               closure );
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaSubscription_createWildCard (
                                 subscriptionBridge* subsc_,
@@ -252,37 +297,47 @@ avisBridgeMamaSubscription_createWildCard (
                                 mamaSubscription    subscription,
                                 void*               closure );
 
+MAMAExpDLL
 extern mama_status avisBridgeMamaSubscription_mute
                                 (subscriptionBridge subscriber);
 
+MAMAExpDLL
 extern  mama_status avisBridgeMamaSubscription_destroy
                                 (subscriptionBridge subscriber);
 
+MAMAExpDLL
 extern int avisBridgeMamaSubscription_isValid
                                 (subscriptionBridge bridge);
 
+MAMAExpDLL
 extern mama_status avisBridgeMamaSubscription_getSubject
                                 (subscriptionBridge subscriber,
                                  const char**       subject);
 
+MAMAExpDLL
 extern int avisBridgeMamaSubscription_hasWildcards
                                 (subscriptionBridge subscriber);
 
+MAMAExpDLL
 extern mama_status avisBridgeMamaSubscription_getPlatformError
                                 (subscriptionBridge subsc, void** error);
 
+MAMAExpDLL
 extern mama_status avisBridgeMamaSubscription_setTopicClosure
                                 (subscriptionBridge subsc, void* closure);
 
+MAMAExpDLL
 extern mama_status avisBridgeMamaSubscription_muteCurrentTopic
                                 (subscriptionBridge subsc);
 
+MAMAExpDLL
 extern int avisBridgeMamaSubscription_isTportDisconnected
                                 (subscriptionBridge subsc);
 
 /*=========================================================================
   =                    Functions for the mamaTimer                        =
   =========================================================================*/
+MAMAExpDLL
 extern mama_status avisBridgeMamaTimer_create (timerBridge* timer,
                                               void*        nativeQueueHandle,
                                               mamaTimerCb  action,
@@ -291,19 +346,24 @@ extern mama_status avisBridgeMamaTimer_create (timerBridge* timer,
                                               mamaTimer    parent,
                                               void*        closure);
 
+MAMAExpDLL
 extern mama_status avisBridgeMamaTimer_destroy (timerBridge timer);
 
+MAMAExpDLL
 extern mama_status avisBridgeMamaTimer_reset (timerBridge timer);
 
+MAMAExpDLL
 extern mama_status avisBridgeMamaTimer_setInterval (timerBridge timer,
                                                    mama_f64_t  interval);
 
+MAMAExpDLL
 extern mama_status avisBridgeMamaTimer_getInterval (timerBridge timer,
                                                    mama_f64_t* interval);
 
 /*=========================================================================
   =                    Functions for the mamaIo                           =
   =========================================================================*/
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaIo_create (ioBridge*       result,
                         void*           nativeQueueHandle,
@@ -313,9 +373,11 @@ avisBridgeMamaIo_create (ioBridge*       result,
                         mamaIo          parent,
                         void*           closure);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaIo_destroy (ioBridge io);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaIo_getDescriptor (ioBridge io, uint32_t* result);
 
@@ -323,6 +385,7 @@ avisBridgeMamaIo_getDescriptor (ioBridge io, uint32_t* result);
 /*=========================================================================
   =                    Functions for the mamaPublisher                    =
   =========================================================================*/
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaPublisher_createByIndex (
                                publisherBridge*  result,
@@ -333,26 +396,32 @@ avisBridgeMamaPublisher_createByIndex (
                                const char*       root,
                                mamaPublisher     parent);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaPublisher_destroy (publisherBridge publisher);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaPublisher_send (publisherBridge publisher, mamaMsg msg);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaPublisher_sendReplyToInbox (publisherBridge publisher,
                                          mamaMsg         request,
                                          mamaMsg         reply);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaPublisher_sendFromInbox (publisherBridge publisher,
                                       mamaInbox       inbox,
                                       mamaMsg         msg);
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaPublisher_sendFromInboxByIndex (publisherBridge publisher,
                                              int           tportIndex,
                                              mamaInbox     inbox,
                                              mamaMsg       msg);
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaPublisher_sendReplyToInboxHandle (publisherBridge publisher,
                                                void *          wmwReply,
@@ -361,6 +430,7 @@ avisBridgeMamaPublisher_sendReplyToInboxHandle (publisherBridge publisher,
 /*=========================================================================
   =                    Functions for the mamaInbox                        =
   =========================================================================*/
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaInbox_create (
             inboxBridge*           bridge,
@@ -372,6 +442,7 @@ avisBridgeMamaInbox_create (
             void*                  closure,
             mamaInbox              parent);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaInbox_createByIndex (
             inboxBridge*           bridge,
@@ -384,53 +455,68 @@ avisBridgeMamaInbox_createByIndex (
             void*                  closure,
             mamaInbox              parent);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaInbox_destroy (inboxBridge inbox);
 
 /*=========================================================================
   =                    Functions for the mamaMsg                           =
   =========================================================================*/
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaMsg_create (msgBridge* msg, mamaMsg parent);
 
+MAMAExpDLL
 extern int
 avisBridgeMamaMsg_isFromInbox (msgBridge msg);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaMsg_destroy (msgBridge msg, int destroyMsg);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaMsg_destroyMiddlewareMsg (msgBridge msg);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaMsg_detach (msgBridge msg);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaMsg_getPlatformError (msgBridge msg, void** error);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaMsg_setSendSubject (msgBridge   msg,
                                    const char* symbol,
                                    const char* subject);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaMsg_getNativeHandle (msgBridge msg, void** result);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaMsg_duplicateReplyHandle (msgBridge msg, void** result);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaMsg_copyReplyHandle (void* src, void** dest);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaMsg_destroyReplyHandle (void* result);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaMsgImpl_setReplyHandle (msgBridge msg, void* result);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaMsgImpl_setReplyHandleAndIncrement (msgBridge msg, void* result);
 
+MAMAExpDLL
 extern mama_status
 avisBridgeMamaMsgImpl_setAttributesAndSecure (msgBridge msg, void* attributes, uint8_t secure);
 

--- a/mama/c_cpp/src/c/bridge/avis/sub.c
+++ b/mama/c_cpp/src/c/bridge/avis/sub.c
@@ -195,7 +195,7 @@ avis_queue_callback (mamaQueue queue,
     /*Set the buffer and the reply handle on the bridge message structure*/
     if (MAMA_STATUS_OK!=(status=mamaMsgImpl_setMsgBuffer (tmpMsg,
                                 data,
-                                0, MAMA_PAYLOAD_AVIS)))
+                                sizeof(data), MAMA_PAYLOAD_AVIS)))
     {
         mama_log (MAMA_LOG_LEVEL_ERROR,
                   "avis_callback(): mamaMsgImpl_setMsgBuffer() failed. [%d]",

--- a/mama/c_cpp/src/c/entitlement/noop/noop.c
+++ b/mama/c_cpp/src/c/entitlement/noop/noop.c
@@ -77,7 +77,7 @@ noopEntitlementBridge_createSubscription(mamaEntitlementBridge mamaEntBridge, Su
 
     /* Allocate bridge level entitlement subscription object*/
     noopSubHandle = (noopEntitlementSubscriptionHandle*) calloc (1, sizeof(noopEntitlementSubscriptionHandle));
-    if (NULL == mamaEntSub) return MAMA_STATUS_NOMEM;
+    if (NULL == noopSubHandle) return MAMA_STATUS_NOMEM;
 
     /* Allocate mama_level entitlement subscription object and set implementation struct pointer. */
     status = mamaEntitlementBridge_createSubscription(&mamaEntSub);

--- a/mama/c_cpp/src/c/entitlement/noop/noop.h
+++ b/mama/c_cpp/src/c/entitlement/noop/noop.h
@@ -47,6 +47,7 @@ typedef struct noopEntitlementSubscriptionHandle_
  *
  * @param ctx Pointer to the SubscriptionContext to be populated.
  */
+MAMAExpDLL
 mama_status
 noopEntitlementBridge_registerSubjectContext(SubjectContext* ctx);
 
@@ -58,6 +59,7 @@ noopEntitlementBridge_registerSubjectContext(SubjectContext* ctx);
  * @param ctx The subscription SubjectContext to be populated with a pointer to
  *            the entitlement subscription object.
  */
+MAMAExpDLL
 mama_status
 noopEntitlementBridge_createSubscription(mamaEntitlementBridge entBridge, SubjectContext* ctx);
 
@@ -66,6 +68,7 @@ noopEntitlementBridge_createSubscription(mamaEntitlementBridge entBridge, Subjec
  *
  * @param handle The subscription object to free.
  */
+MAMAExpDLL
 mama_status
 noopEntitlementBridge_destroySubscription(entitlementSubscriptionHandle handle);
 
@@ -75,6 +78,7 @@ noopEntitlementBridge_destroySubscription(entitlementSubscriptionHandle handle);
  * @param handle Entitlement subscription object to update.
  * @param isSnapshot Value to update object to.
  */
+MAMAExpDLL
 mama_status
 noopEntitlementBridge_setIsSnapshot(entitlementSubscriptionHandle* handle, int isSnapshot);
 
@@ -85,6 +89,7 @@ noopEntitlementBridge_setIsSnapshot(entitlementSubscriptionHandle* handle, int i
  * @param handle The entitlement subscription objec tto check against
  * @param subject The topic to check.
  */
+MAMAExpDLL
 int
 noopEntitlementBridge_isAllowed(entitlementSubscriptionHandle handle, char* subject);
 
@@ -95,6 +100,7 @@ noopEntitlementBridge_isAllowed(entitlementSubscriptionHandle handle, char* subj
  *
  * @param bridge The bridge object to destroy.
  */
+MAMAExpDLL
 mama_status
 noopEntitlementBridge_destroy(mamaEntitlementBridge bridge);
 
@@ -106,6 +112,7 @@ noopEntitlementBridge_destroy(mamaEntitlementBridge bridge);
  * @param bridge The (preallocated by mama) bridge level object to be
  *               initilized.
  */
+MAMAExpDLL
 mama_status
 noopEntitlementBridge_init(entitlementBridge* bridge);
 

--- a/mama/c_cpp/src/c/generateMamaSourceFiles.bat
+++ b/mama/c_cpp/src/c/generateMamaSourceFiles.bat
@@ -29,6 +29,6 @@ echo "generating %BUILD_DIR%/entitlementlibraries.c"
 
 echo /* This file was automatically generated */ > %BUILD_DIR%\entitlementlibraries.c
 echo #include ^<mamainternal.h^> >> %BUILD_DIR%\entitlementlibraries.c
-echo const char* gEntitlementBridges [MAX_ENTITLEMENT_BRIDGES] = {0}; >> %BUILD_DIR%\entitlementlibraries.c
+echo const char* gEntitlementBridges [MAX_ENTITLEMENT_BRIDGES] = {"noop"}; >> %BUILD_DIR%\entitlementlibraries.c
 
 echo "complete" 

--- a/mama/c_cpp/src/c/mamainternal.h
+++ b/mama/c_cpp/src/c/mamainternal.h
@@ -227,9 +227,11 @@ mamaInternal_getEntitlementBridgeCount (void);
  mama_status
 mamaInternal_getEntitlementBridgeByName(mamaEntitlementBridge* entBridge, const char* name);
 
+MAMAExpDLL
 const char*
 mamaInternal_getMetaProperty (const char* name);
 
+MAMAExpDLL
 mama_status
 mamaInternal_setMetaProperty (const char* name, const char* value);
 

--- a/mama/c_cpp/src/c/payload/avismsg/avismsg.vcxproj
+++ b/mama/c_cpp/src/c/payload/avismsg/avismsg.vcxproj
@@ -64,18 +64,18 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.40219.1</_ProjectFileVersion>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(Platform)\$(Configuration)\</OutDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)$(Configuration)\</OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(Platform)\$(Configuration)\</IntDir>
     <IgnoreImportLibrary Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</IgnoreImportLibrary>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</LinkIncremental>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)$(Platform)\$(Configuration)</OutDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)$(Configuration)\</OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(Platform)\$(Configuration)\</IntDir>
     <IgnoreImportLibrary Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</IgnoreImportLibrary>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</LinkIncremental>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)$(Configuration)\</OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(Configuration)\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)$(Platform)\$(Configuration)</OutDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)$(Configuration)\</OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(Platform)\$(Configuration)\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</LinkIncremental>
   </PropertyGroup>

--- a/mama/c_cpp/src/c/payload/avismsg/avispayload.c
+++ b/mama/c_cpp/src/c/payload/avismsg/avispayload.c
@@ -2013,7 +2013,10 @@ avismsgPayloadIter_get          (msgPayloadIter  iter,
     /* If this is a special meta field, do not consider during iteration */
     if ((strcmp(SUBJECT_FIELD_NAME, avisField(field)->mName) == 0) ||
         (strcmp(INBOX_FIELD_NAME, avisField(field)->mName)== 0))
-            return (avismsgPayloadIter_next(iter,field,msg));
+    {
+        impl->mIndex++;
+        return (avismsgPayloadIter_next(iter,field,msg));
+    }
 
     return field;
 }

--- a/mama/c_cpp/src/c/payload/avismsg/avispayload.h
+++ b/mama/c_cpp/src/c/payload/avismsg/avispayload.h
@@ -80,18 +80,22 @@ extern mama_status
 avismsgPayload_getNumFields      (const msgPayload    msg,
                                 mama_size_t*        numFields);
 
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_getSendSubject      (const msgPayload    msg,
                                 const char **        subject);
 
+MAMAExpBridgeDLL
 extern const char*
 avismsgPayload_toString          (const msgPayload    msg);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_iterateFields     (const msgPayload    msg,
                                 const mamaMsg       parent,
                                 mamaMsgField        field,
                                 mamaMsgIteratorCb   cb,
                                 void*               closure);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_getFieldAsString  (const msgPayload    msg,
                                 const char*         name,
@@ -99,11 +103,13 @@ avismsgPayload_getFieldAsString  (const msgPayload    msg,
                                 char*               buffer,
                                 mama_size_t         len);
 
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_serialize (const msgPayload    payload,
                            const void**        buffer,
                            mama_size_t*        bufferLength);
 
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_unSerialize (const msgPayload    payload,
                            const void*        buffer,
@@ -114,260 +120,309 @@ extern mama_status
 avismsgPayload_getByteBuffer     (const msgPayload    msg,
                                 const void**        buffer,
                                 mama_size_t*        bufferLength);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_setByteBuffer     (const msgPayload    msg,
                                 mamaPayloadBridge       bridge,
                                 const void*         buffer,
                                 mama_size_t         bufferLength);
 
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_createFromByteBuffer (msgPayload*          msg,
                                    mamaPayloadBridge        bridge,
                                    const void*          buffer,
                                    mama_size_t          bufferLength);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_apply             (msgPayload          dest,
                                 const msgPayload    src);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_getNativeMsg     (const msgPayload    msg,
                                void**              nativeMsg);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_addBool           (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 mama_bool_t         value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_addChar           (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 char                value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_addI8             (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 mama_i8_t           value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_addU8             (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 mama_u8_t           value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_addI16            (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 mama_i16_t          value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_addU16            (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 mama_u16_t          value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_addI32            (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 mama_i32_t          value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_addU32            (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 mama_u32_t          value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_addI64            (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 mama_i64_t          value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_addU64            (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 mama_u64_t          value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_addF32            (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 mama_f32_t          value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_addF64            (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 mama_f64_t          value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_addString         (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const char*         value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_addOpaque         (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const void*         value,
                                 mama_size_t         size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_addDateTime       (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const mamaDateTime  value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_addPrice          (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const mamaPrice     value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_addMsg            (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 msgPayload          value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_addVectorBool     (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const mama_bool_t   value[],
                                 mama_size_t         size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_addVectorChar     (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const char          value[],
                                 mama_size_t         size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_addVectorI8       (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const mama_i8_t     value[],
                                 mama_size_t         size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_addVectorU8       (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const mama_u8_t     value[],
                                 mama_size_t         size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_addVectorI16      (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const mama_i16_t    value[],
                                 mama_size_t         size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_addVectorU16      (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const mama_u16_t    value[],
                                 mama_size_t         size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_addVectorI32      (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const mama_i32_t    value[],
                                 mama_size_t         size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_addVectorU32      (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const mama_u32_t    value[],
                                 mama_size_t         size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_addVectorI64      (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const mama_i64_t    value[],
                                 mama_size_t         size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_addVectorU64      (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const mama_u64_t    value[],
                                 mama_size_t         size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_addVectorF32      (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const mama_f32_t    value[],
                                 mama_size_t         size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_addVectorF64      (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const mama_f64_t    value[],
                                 mama_size_t         size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_addVectorString   (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const char*         value[],
                                 mama_size_t         size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_addVectorMsg      (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const mamaMsg       value[],
                                 mama_size_t         size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_addVectorDateTime (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const mamaDateTime  value[],
                                 mama_size_t         size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_addVectorPrice    (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const mamaPrice     value[],
                                 mama_size_t         size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_updateBool        (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 mama_bool_t         value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_updateChar        (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 char                value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_updateU8          (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 mama_u8_t           value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_updateI8          (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 mama_i8_t           value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_updateI16         (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 mama_i16_t          value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_updateU16         (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 mama_u16_t          value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_updateI32         (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 mama_i32_t          value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_updateU32         (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 mama_u32_t          value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_updateI64         (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 mama_i64_t          value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_updateU64         (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 mama_u64_t          value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_updateF32         (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 mama_f32_t          value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_updateF64
                                (msgPayload          msg,
@@ -381,178 +436,210 @@ avismsgPayload_updateString      (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const char*         value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_updateOpaque      (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const void*         value,
                                 mama_size_t         size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_updateDateTime    (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const mamaDateTime  value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_updatePrice       (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const mamaPrice     value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_getBool           (const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 mama_bool_t*        result);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_updateSubMsg      (msgPayload          msg,
                                 const char*         fname,
                                 mama_fid_t          fid,
                                 const msgPayload    subMsg);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_updateVectorMsg   (msgPayload          msg,
                                 const char*         fname,
                                 mama_fid_t          fid,
                                 const mamaMsg       value[],
                                 mama_size_t         size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_updateVectorString (msgPayload         msg,
                                 const char*         fname,
                                 mama_fid_t          fid,
                                 const char*         value[],
                                 mama_size_t         size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_updateVectorBool  (msgPayload          msg,
                                 const char*         fname,
                                 mama_fid_t          fid,
                                 const mama_bool_t   value[],
                                 mama_size_t         size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_updateVectorChar  (msgPayload          msg,
                                 const char*         fname,
                                 mama_fid_t          fid,
                                 const char          value[],
                                 mama_size_t         size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_updateVectorI8    (msgPayload          msg,
                                 const char*         fname,
                                 mama_fid_t          fid,
                                 const mama_i8_t     value[],
                                 mama_size_t         size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_updateVectorU8    (msgPayload          msg,
                                 const char*         fname,
                                 mama_fid_t          fid,
                                 const mama_u8_t     value[],
                                 mama_size_t         size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_updateVectorI16   (msgPayload          msg,
                                 const char*         fname,
                                 mama_fid_t          fid,
                                 const mama_i16_t    value[],
                                 mama_size_t         size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_updateVectorU16   (msgPayload          msg,
                                 const char*         fname,
                                 mama_fid_t          fid,
                                 const mama_u16_t    value[],
                                 mama_size_t         size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_updateVectorI32   (msgPayload          msg,
                                 const char*         fname,
                                 mama_fid_t          fid,
                                 const mama_i32_t    value[],
                                 mama_size_t         size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_updateVectorU32   (msgPayload          msg,
                                 const char*         fname,
                                 mama_fid_t          fid,
                                 const mama_u32_t    value[],
                                 mama_size_t         size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_updateVectorI64   (msgPayload          msg,
                                 const char*         fname,
                                 mama_fid_t          fid,
                                 const mama_i64_t    value[],
                                 mama_size_t         size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_updateVectorU64   (msgPayload          msg,
                                 const char*         fname,
                                 mama_fid_t          fid,
                                 const mama_u64_t    value[],
                                 mama_size_t         size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_updateVectorF32   (msgPayload          msg,
                                 const char*         fname,
                                 mama_fid_t          fid,
                                 const mama_f32_t    value[],
                                 mama_size_t         size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_updateVectorF64   (msgPayload          msg,
                                 const char*         fname,
                                 mama_fid_t          fid,
                                 const mama_f64_t    value[],
                                 mama_size_t         size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_updateVectorPrice (msgPayload          msg,
                                 const char*         fname,
                                 mama_fid_t          fid,
                                 const mamaPrice     value[],
                                 mama_size_t         size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_updateVectorTime  (msgPayload          msg,
                                 const char*         fname,
                                 mama_fid_t          fid,
                                 const mamaDateTime  value[],
                                 mama_size_t         size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_getChar           (const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 char*               result);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_getI8             (const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 mama_i8_t*          result);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_getU8             (const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 mama_u8_t*          result);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_getI16            (const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 mama_i16_t*         result);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_getU16            (const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 mama_u16_t*         result);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_getI32            (const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 mama_i32_t*         result);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_getU32            (const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 mama_u32_t*         result);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_getI64            (const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 mama_i64_t*         result);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_getU64            (const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 mama_u64_t*         result);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_getF32            (const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 mama_f32_t*         result);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_getF64            (const msgPayload    msg,
                                 const char*         name,
@@ -565,145 +652,172 @@ avismsgPayload_getString         (const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const char**        result);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_getOpaque         (const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const void**        result,
                                 mama_size_t*        size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_getField          (const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 msgFieldPayload*    result);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_getDateTime       (const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 mamaDateTime        result);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_getPrice          (const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 mamaPrice           result);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_getMsg            (const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 msgPayload*         result);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_getVectorBool     (const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const mama_bool_t** result,
                                 mama_size_t*        size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_getVectorChar     (const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const char**        result,
                                 mama_size_t*        size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_getVectorI8       (const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const mama_i8_t**   result,
                                 mama_size_t*        size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_getVectorU8       (const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const mama_u8_t**   result,
                                 mama_size_t*        size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_getVectorI16      (const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const mama_i16_t**  result,
                                 mama_size_t*        size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_getVectorU16      (const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const mama_u16_t**  result,
                                 mama_size_t*        size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_getVectorI32      (const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const mama_i32_t**  result,
                                 mama_size_t*        size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_getVectorU32      (const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const mama_u32_t**  result,
                                 mama_size_t*        size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_getVectorI64      (const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const mama_i64_t**  result,
                                 mama_size_t*        size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_getVectorU64      (const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const mama_u64_t**  result,
                                 mama_size_t*        size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_getVectorF32      (const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const mama_f32_t**  result,
                                 mama_size_t*        size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_getVectorF64      (const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const mama_f64_t**  result,
                                 mama_size_t*        size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_getVectorString   (const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const char***       result,
                                 mama_size_t*        size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_getVectorDateTime (const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const mamaDateTime* result,
                                 mama_size_t*        size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_getVectorPrice    (const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const mamaPrice*    result,
                                 mama_size_t*        size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayload_getVectorMsg      (const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
                                 const msgPayload**  result,
                                 mama_size_t*        size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayloadIter_create        (msgPayloadIter*     iter,
                                 msgPayload          msg);
+MAMAExpBridgeDLL
 extern msgFieldPayload
 avismsgPayloadIter_next          (msgPayloadIter      iter,
                                 msgFieldPayload     field,
                                 msgPayload          msg);
+MAMAExpBridgeDLL
 extern mama_bool_t
 avismsgPayloadIter_hasNext       (msgPayloadIter      iter,
                                 msgPayload          msg);
+MAMAExpBridgeDLL
 extern msgFieldPayload
 avismsgPayloadIter_begin         (msgPayloadIter      iter,
                                 msgFieldPayload     field,
                                 msgPayload          msg);
+MAMAExpBridgeDLL
 extern msgFieldPayload
 avismsgPayloadIter_end           (msgPayloadIter      iter,
                                 msgPayload          msg);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgPayloadIter_associate     (msgPayloadIter      iter,
                                 msgPayload          msg);
@@ -712,124 +826,157 @@ MAMAExpBridgeDLL
 extern mama_status
 avismsgPayloadIter_destroy       (msgPayloadIter      iter);
 
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_create       (msgFieldPayload*    field);
 
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_destroy      (msgFieldPayload     field);
 
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getName      (const msgFieldPayload   field,
                                 mamaDictionary          dict,
                                 mamaFieldDescriptor     desc,
                                 const char**            result);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getFid       (const msgFieldPayload   field,
                                 mamaDictionary          dict,
                                 mamaFieldDescriptor     desc,
                                 uint16_t*               result);
 
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getDescriptor(const msgFieldPayload   field,
                                 mamaDictionary          dict,
                                 mamaFieldDescriptor*    result);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getType      (const msgFieldPayload   field,
                                 mamaFieldType*          result);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_updateBool   (msgFieldPayload         field,
                                 msgPayload              msg,
                                 mama_bool_t             value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_updateChar   (msgFieldPayload         field,
                                 msgPayload              msg,
                                 char                    value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_updateU8     (msgFieldPayload         field,
                                 msgPayload              msg,
                                 mama_u8_t               value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_updateI8     (msgFieldPayload         field,
                                 msgPayload              msg,
                                 mama_i8_t               value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_updateI16    (msgFieldPayload         field,
                                 msgPayload              msg,
                                 mama_i16_t              value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_updateU16    (msgFieldPayload         field,
                                 msgPayload              msg,
                                 mama_u16_t              value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_updateI32    (msgFieldPayload         field,
                                 msgPayload              msg,
                                 mama_i32_t              value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_updateU32    (msgFieldPayload         field,
                                 msgPayload              msg,
                                 mama_u32_t              value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_updateI64    (msgFieldPayload         field,
                                 msgPayload              msg,
                                 mama_i64_t              value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_updateU64    (msgFieldPayload         field,
                                 msgPayload              msg,
                                 mama_u64_t              value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_updateF32    (msgFieldPayload         field,
                                 msgPayload              msg,
                                 mama_f32_t              value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_updateF64    (msgFieldPayload         field,
                                 msgPayload              msg,
                                 mama_f64_t              value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_updateDateTime
                                (msgFieldPayload         field,
                                 msgPayload              msg,
                                 const mamaDateTime      value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_updatePrice  (msgFieldPayload         field,
                                 msgPayload              msg,
                                 const mamaPrice         value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_updateString (msgFieldPayload         field,
                                   msgPayload              msg,
                                   const char*             value);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getBool      (const msgFieldPayload   field,
                                 mama_bool_t*            result);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getChar      (const msgFieldPayload   field,
                                 char*                   result);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getI8        (const msgFieldPayload   field,
                                 mama_i8_t*              result);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getU8        (const msgFieldPayload   field,
                                 mama_u8_t*              result);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getI16       (const msgFieldPayload   field,
                                 mama_i16_t*             result);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getU16       (const msgFieldPayload   field,
                                 mama_u16_t*             result);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getI32       (const msgFieldPayload   field,
                                 mama_i32_t*             result);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getU32       (const msgFieldPayload   field,
                                 mama_u32_t*             result);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getI64       (const msgFieldPayload   field,
                                 mama_i64_t*             result);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getU64       (const msgFieldPayload   field,
                                 mama_u64_t*             result);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getF32       (const msgFieldPayload   field,
                                 mama_f32_t*             result);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getF64       (const msgFieldPayload   field,
                                 mama_f64_t*             result);
@@ -838,93 +985,115 @@ MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getString    (const msgFieldPayload   field,
                                 const char**            result);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getOpaque    (const msgFieldPayload   field,
                                 const void**            result,
                                 mama_size_t*            size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getField     (const msgFieldPayload   field,
                                 mamaMsgField*           result);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getDateTime  (const msgFieldPayload   field,
                                 mamaDateTime            result);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getPrice     (const msgFieldPayload   field,
                                 mamaPrice               result);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getMsg       (const msgFieldPayload   field,
                                 msgPayload*             result);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getVectorBool
                                (const msgFieldPayload   field,
                                 const mama_bool_t**     result,
                                 mama_size_t*            size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getVectorChar
                                (const msgFieldPayload   field,
                                 const char**            result,
                                 mama_size_t*            size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getVectorI8
                                (const msgFieldPayload   field,
                                 const mama_i8_t**       result,
                                 mama_size_t*            size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getVectorU8  (const msgFieldPayload   field,
                                 const mama_u8_t**       result,
                                 mama_size_t*            size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getVectorI16 (const msgFieldPayload   field,
                                 const mama_i16_t**      result,
                                 mama_size_t*            size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getVectorU16 (const msgFieldPayload   field,
                                 const mama_u16_t**      result,
                                 mama_size_t*            size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getVectorI32 (const msgFieldPayload   field,
                                 const mama_i32_t**      result,
                                 mama_size_t*            size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getVectorU32 (const msgFieldPayload   field,
                                 const mama_u32_t**      result,
                                 mama_size_t*            size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getVectorI64 (const msgFieldPayload   field,
                                 const mama_i64_t**      result,
                                 mama_size_t*            size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getVectorU64 (const msgFieldPayload   field,
                                 const mama_u64_t**      result,
                                 mama_size_t*            size);
+MAMAExpBridgeDLL
  extern mama_status
 avismsgFieldPayload_getVectorF32 (const msgFieldPayload   field,
                                 const mama_f32_t**      result,
                                 mama_size_t*            size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getVectorF64 (const msgFieldPayload   field,
                                 const mama_f64_t**      result,
                                 mama_size_t*            size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getVectorString
                                (const msgFieldPayload   field,
                                 const char***           result,
                                 mama_size_t*            size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getVectorDateTime
                                (const msgFieldPayload   field,
                                 const mamaDateTime*     result,
                                 mama_size_t*            size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getVectorPrice
                                (const msgFieldPayload   field,
                                 const mamaPrice*        result,
                                 mama_size_t*            size);
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getVectorMsg (const msgFieldPayload   field,
                                 const msgPayload**      result,
                                 mama_size_t*            size);
 
+MAMAExpBridgeDLL
 extern mama_status
 avismsgFieldPayload_getAsString (
     const msgFieldPayload   field,


### PR DESCRIPTION
Fixes necessary to make avis middleware and payload bridges work with new dynamic loading mechanic, including.
- Added external loading macros to payload and middleware functions
- Fixed bug in avis iterators.
- Setting default entitlement bridge on VS builds to 'noop'.
- Correcting VS install paths.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/146)
<!-- Reviewable:end -->
