### PR TITLE
Issue #151 - Adding call to mama_shutdownPlugins() in mama_close removed

### DIFF
--- a/mama/c_cpp/src/c/mama.c
+++ b/mama/c_cpp/src/c/mama.c
@@ -1461,6 +1461,9 @@ mama_closeCount (unsigned int* count)
         /* Once the libraries have been unloaded, clear down the wtable. */
         wtable_clear (gImpl.payloads.table);
 
+        /* This will shutdown all plugins */
+        mama_shutdownPlugins();
+
         /* Reset the count of loaded payloads */
         gImpl.payloads.count = 0;
 


### PR DESCRIPTION
Issue #151 - Adding call to mama_shutdownPlugins() in mama_close removed
during dynamic loading feature branch merge.

Signed-off-by: Matt Mulhern <m.mulhern@srtechlabs.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/152)
<!-- Reviewable:end -->
