### PR TITLE
GH #157: Adding template mama plugin to examples.

### DIFF
--- a/mama/c_cpp/src/examples/c/SConscript
+++ b/mama/c_cpp/src/examples/c/SConscript
@@ -31,3 +31,5 @@ for b in bins:
 
 Alias('install',env.Install('$bindir',binary))
 Alias('install',env.Install('$prefix/examples/mama/c',examples))
+
+env.SConscript('plugin/SConscript','env')

--- a/mama/c_cpp/src/examples/c/plugin/Makefile.sample
+++ b/mama/c_cpp/src/examples/c/plugin/Makefile.sample
@@ -1,0 +1,34 @@
+#==============================================================================
+# To build MAMA examples set the following:
+#   API_HOME: Path to API installation
+#=============================================================================
+# Example:
+#    make -f Makefile.sample API_HOME=/home/wombat/apis
+#=============================================================================
+API_HOME=../../../../
+
+# Standard defines:
+CC = gcc
+CFLAGS = -fPIC -Wall -O2 -g -I$(API_HOME)/include
+LDFLAGS = -shared
+RM = rm -f
+TARGET_LIB = libmamaplugintemplate.so
+
+SRCS = mamaPluginTemplate.c
+OBJS = $(SRCS:.c=.o)
+
+.PHONY: all
+all: ${TARGET_LIB}
+
+$(TARGET_LIB): $(OBJS)
+	$(CC) ${LDFLAGS} -o $@ $^
+
+$(SRCS:.c=.d):%.d:%.c
+	$(CC) $(CFLAGS) -MM $< >$@
+
+include $(SRCS:.c=.d)
+
+.PHONY: clean
+clean:
+	-${RM} ${TARGET_LIB} ${OBJS} $(SRCS:.c=.d)
+

--- a/mama/c_cpp/src/examples/c/plugin/SConscript
+++ b/mama/c_cpp/src/examples/c/plugin/SConscript
@@ -1,0 +1,27 @@
+import os
+Import('env')
+env = env.Clone()
+
+lib_target  = "mamaplugintemplate"
+
+lib_sources = ["mamaPluginTemplate.c"]
+lib_install_files = ["mamaPluginTemplate.h", "Makefile.sample"]
+lib_install_files.extend(lib_sources)
+
+includePath = []
+includePath.append('.')
+includePath.append('../../../../c')
+# includePath.append('#common/c_cpp/src/c')
+# includePath.append('$prefix/include')
+
+libPath = []
+libPath.append('$prefix/lib')
+
+env.Append( LIBPATH = libPath )
+env.Append( CPPPATH = [ includePath ] )
+env.Append( LIBS = [ 'mama' ] )	
+
+pluginso = env.SharedLibrary(target = lib_target, source = lib_sources)
+
+Alias('install',env.Install('$libdir', pluginso))
+Alias('install',env.Install('$prefix/examples/mama/c/plugin', lib_install_files))

--- a/mama/c_cpp/src/examples/c/plugin/mamaPluginTemplate.c
+++ b/mama/c_cpp/src/examples/c/plugin/mamaPluginTemplate.c
@@ -1,0 +1,47 @@
+/*
+ * mamaPluginTemplate.c
+ *
+ *  Created on: 23 Mar 2015
+ */
+
+#include <stdio.h>
+#include "mama/mama.h"
+#include "mama/status.h"
+#include "mama/types.h"
+#include "mamaPluginTemplate.h"
+
+
+mama_status templateMamaPlugin_initHook (mamaPluginInfo* pluginInfo)
+{
+    mama_status status = MAMA_STATUS_OK;
+    mama_log(MAMA_LOG_LEVEL_FINEST,"templateMamaPlugin_initHook fired!");
+
+    return status;
+}
+
+mama_status
+templateMamaPlugin_transportPostCreateHook (mamaPluginInfo pluginInfo, mamaTransport transport)
+{
+    mama_status status = MAMA_STATUS_OK;
+    mama_log(MAMA_LOG_LEVEL_FINEST,"templateMamaPlugin_transportPostCreateHook fired");
+
+    return status;
+}
+
+mama_status
+templateMamaPlugin_publisherPreSendHook (mamaPluginInfo pluginInfo, mamaPublisher publisher, mamaMsg message)
+{
+    mama_status status = MAMA_STATUS_OK;
+    mama_log(MAMA_LOG_LEVEL_FINEST,"templateMamaPlugin_publisherPreSendHook fired!");
+
+    return status;
+}
+
+mama_status
+templateMamaPlugin_shutdownHook (mamaPluginInfo pluginInfo)
+{
+    mama_status status = MAMA_STATUS_OK;
+    mama_log(MAMA_LOG_LEVEL_FINEST,"templateMamaPlugin_shutdownHook fired!");
+
+    return status;
+}

--- a/mama/c_cpp/src/examples/c/plugin/mamaPluginTemplate.h
+++ b/mama/c_cpp/src/examples/c/plugin/mamaPluginTemplate.h
@@ -1,0 +1,38 @@
+/*
+ * mamaPluginTemplate.h
+ *
+ *  Created on: 23 Mar 2015
+ */
+
+#ifndef MAMAPLUGINHOOK_H_
+#define MAMAPLUGINHOOK_H_
+
+#include "mama/mama.h"
+#include "mama/status.h"
+#include "mama/types.h"
+
+#if defined( WIN32 )
+#   define PLUGINExpDLL __declspec( dllexport )
+#else
+#   define PLUGINExpDLL
+#endif
+
+
+PLUGINExpDLL
+mama_status
+templateMamaPlugin_initHook (mamaPluginInfo* pluginInfo);
+
+PLUGINExpDLL
+mama_status
+templateMamaPlugin_transportPostCreateHook (mamaPluginInfo pluginInfo, mamaTransport transport);
+
+PLUGINExpDLL
+mama_status
+templateMamaPlugin_publisherPreSendHook (mamaPluginInfo pluginInfo, mamaPublisher publisher, mamaMsg message);
+
+PLUGINExpDLL
+mama_status
+templateMamaPlugin_shutdownHook (mamaPluginInfo pluginInfo);
+
+#endif /* MAMAPLUGINHOOK_H_ */
+


### PR DESCRIPTION
# Adding plugin template to MAMA examples
## Summary
As described in #157, a template plugin would be useful to have in the MAMA examples.
## Areas Affected
- [x] MAMAC
- [x] Examples

## Testing

Run any of the mama example apps with `mama.plugin.name_1=template` in your mama.properties:
```
2016-03-29 17:41:34: (5bb36740) : mama_loadPlugin(): Sucessfully registered plugin functions for [template]                                                    │# Source which you are going to consume from
2016-03-29 17:41:34: (5bb36740) : templateMamaPlugin_initHook fired!
```
Signed-off-by: Matt Mulhern <matt@openmama.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/159)
<!-- Reviewable:end -->
