### PR TITLE
[SBZ-58154] MAMA: fix for deferred entitlements error

### DIFF
--- a/mama/c_cpp/src/c/subscription.c
+++ b/mama/c_cpp/src/c/subscription.c
@@ -481,18 +481,19 @@ mamaSubscription_setupBasic (
         else
         {
             mama_status status = mamaTransportImpl_getEntitlementBridge(transport, &mamaEntBridge);
+            if (NULL != mamaEntBridge)
+            {
+                mamaEntBridge->createSubscription(mamaEntBridge, &self->mSubjectContext);
+            }
+            else
+            {
+                mama_log(MAMA_LOG_LEVEL_ERROR,
+                         "mamaSubscription_setupBasic(): Could not find entitlement bridge!");
+                return MAMA_STATUS_NO_BRIDGE_IMPL;
+            }
         }
 
-        if (NULL != mamaEntBridge)
-        {
-            mamaEntBridge->createSubscription(mamaEntBridge, &self->mSubjectContext);
-        }
-        else
-        {
-            mama_log(MAMA_LOG_LEVEL_ERROR,
-                     "mamaSubscription_setupBasic(): Could not find entitlement bridge!");
-            return MAMA_STATUS_NO_BRIDGE_IMPL;
-        }
+
     }
 
     if (!isEntitledToSymbol (source, symbol, self, transport))


### PR DESCRIPTION
# Solace fix for deferred entitlements error
## Summary
Deferred entitlements MAMA_STATUS_NO_BRIDGE_IMPL error on mamaSubscription_setupBasic

## Areas Affected
*Place an 'x' within the braces to check the box*
- [x] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
There is an issue in openmama 2.4.0 with the deferred entitlements property.
When a bridge set the bridge property deferred entitlements to true the mama
layer returns MAMA_STATUS_NO_BRIDGE_IMPL for any call to
mamaSubscription_setupBasic.
The openmama-dev list seems to concur the issue is indeed in the openmama layer
and have asked we submit a pull request to track the issue from there end.
Solace internal reference: bug [58154](http://solace2/show_bug.cgi?id=58154)
Reference to thread on OpenMAMA-Dev mailing list:
http://lists.openmama.org/pipermail/openmama-dev/2016/001686.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/161)
<!-- Reviewable:end -->
