### PR TITLE
Feature mamamsg vector price datetime

### DIFF
--- a/mama/c_cpp/src/c/mama/msg.h
+++ b/mama/c_cpp/src/c/mama/msg.h
@@ -1411,7 +1411,7 @@ mamaMsg_updateVectorPrice (
     mamaMsg               msg,
     const char*           fname,
     mama_fid_t            fid,
-    const mamaPrice*      priceList[],
+    const mamaPrice       priceList[],
     mama_size_t           numElements);
 
 /**
@@ -1993,7 +1993,7 @@ mamaMsg_getVectorDateTime (
     const mamaMsg         msg,
     const char*           name,
     mama_fid_t            fid,
-    const mamaDateTime*   result,
+    const mamaDateTime**  result,
     mama_size_t*          resultLen);
 
 /**
@@ -2012,7 +2012,7 @@ mamaMsg_getVectorPrice (
     const mamaMsg         msg,
     const char*           name,
     mama_fid_t            fid,
-    const mamaPrice*      result,
+    const mamaPrice**     result,
     mama_size_t*          resultLen);
 
 /**

--- a/mama/c_cpp/src/c/msg.c
+++ b/mama/c_cpp/src/c/msg.c
@@ -2282,7 +2282,7 @@ mamaMsg_updateVectorPrice (
     const mamaMsg         msg,
     const char*           name,
     mama_fid_t            fid,
-    const mamaPrice*      value[],
+    const mamaPrice       value[],
     mama_size_t           numElements)
 {
     mamaMsgImpl*    impl    = (mamaMsgImpl*)msg;
@@ -3051,7 +3051,7 @@ mamaMsg_getVectorDateTime (
     const mamaMsg         msg,
     const char*           name,
     mama_fid_t            fid,
-    const mamaDateTime*   result,
+    const mamaDateTime**  result,
     mama_size_t*          resultLen)
 {
     mamaMsgImpl*    impl     = (mamaMsgImpl*)msg;
@@ -3075,7 +3075,7 @@ mamaMsg_getVectorPrice (
     const mamaMsg         msg,
     const char*           name,
     mama_fid_t            fid,
-    const mamaPrice*      result,
+    const mamaPrice**     result,
     mama_size_t*          resultLen)
 {
     mamaMsgImpl*    impl     = (mamaMsgImpl*)msg;

--- a/mama/c_cpp/src/c/msg.c
+++ b/mama/c_cpp/src/c/msg.c
@@ -2258,6 +2258,46 @@ mamaMsg_updatePrice(
 }
 
 mama_status
+mamaMsg_updateVectorTime (
+    const mamaMsg         msg,
+    const char*           name,
+    mama_fid_t            fid,
+    const mamaDateTime    value[],
+    mama_size_t           numElements)
+{
+    mamaMsgImpl*    impl    = (mamaMsgImpl*)msg;
+
+    if (!impl || !impl->mPayloadBridge) return MAMA_STATUS_NULL_ARG;
+    CHECK_MODIFY (impl->mMessageOwner);
+
+    return impl->mPayloadBridge->msgPayloadUpdateVectorTime (impl->mPayload,
+                                                             name,
+                                                             fid,
+                                                             value,
+                                                             numElements);
+}
+
+mama_status
+mamaMsg_updateVectorPrice (
+    const mamaMsg         msg,
+    const char*           name,
+    mama_fid_t            fid,
+    const mamaPrice*      value[],
+    mama_size_t           numElements)
+{
+    mamaMsgImpl*    impl    = (mamaMsgImpl*)msg;
+
+    if (!impl || !impl->mPayloadBridge) return MAMA_STATUS_NULL_ARG;
+    CHECK_MODIFY (impl->mMessageOwner);
+
+    return impl->mPayloadBridge->msgPayloadUpdateVectorPrice (impl->mPayload,
+                                                              name,
+                                                              fid,
+                                                              value,
+                                                              numElements);
+}
+
+mama_status
 mamaMsg_updateVectorMsg (
     mamaMsg               msg,
     const char*           name,

--- a/mama/c_cpp/src/c/payload/qpidmsg/payload.c
+++ b/mama/c_cpp/src/c/payload/qpidmsg/payload.c
@@ -2752,7 +2752,6 @@ qpidmsgPayload_updateVectorTime (msgPayload          msg,
     /* Store value */
     pn_data_put_array (impl->mBody, 0, PN_LIST);
     pn_data_enter     (impl->mBody);
-
     for (i=0; i != size; i++)
     {
         mamaDateTime_getWithHints (value[i],

--- a/mama/c_cpp/src/c/payload/qpidmsg/qpidcommon.h
+++ b/mama/c_cpp/src/c/payload/qpidmsg/qpidcommon.h
@@ -150,6 +150,20 @@ typedef struct qpidmsgFieldPayloadImpl_
     /* Biggest number of elements in vector */
     mama_size_t     mDataMaxVectorCount;
 
+    /* Data buffer used for vectors of date times */
+    mamaDateTime*   mDataVectorDateTime;
+    /* Number of elements in vector */
+    mama_size_t     mDataVectorDateTimeCount;
+    /* Biggest number of elements in vector */
+    mama_size_t     mDataMaxVectorDateTimeCount;
+
+    /* Data buffer used for vectors of prices */
+    mamaPrice*      mDataVectorPrice;
+    /* Number of elements in vector */
+    mama_size_t     mDataVectorPriceCount;
+    /* Biggest number of elements in vector */
+    mama_size_t     mDataMaxVectorPriceCount;
+
     /* Name of the field */
     pn_bytes_t      mName;
 

--- a/mama/c_cpp/src/c/payload/qpidmsg/qpidpayloadfunctions.h
+++ b/mama/c_cpp/src/c/payload/qpidmsg/qpidpayloadfunctions.h
@@ -970,7 +970,7 @@ mama_status
 qpidmsgPayload_updateVectorPrice (msgPayload          msg,
                                   const char*         fname,
                                   mama_fid_t          fid,
-                                  const mamaPrice*    priceList[],
+                                  const mamaPrice     priceList[],
                                   mama_size_t         size);
 
 /**
@@ -1256,11 +1256,11 @@ qpidmsgPayload_getVectorString  (const msgPayload    msg,
  */
 MAMAExpBridgeDLL
 mama_status
-qpidmsgPayload_getVectorDateTime (const msgPayload    msg,
-                                  const char*         name,
-                                  mama_fid_t          fid,
-                                  const mamaDateTime* result,
-                                  mama_size_t*        size);
+qpidmsgPayload_getVectorDateTime (const msgPayload     msg,
+                                  const char*          name,
+                                  mama_fid_t           fid,
+                                  const mamaDateTime** result,
+                                  mama_size_t*         size);
 
 /**
  * Note: getVectorPrice() is not currently supported by MAMA, so implementation
@@ -1276,7 +1276,7 @@ mama_status
 qpidmsgPayload_getVectorPrice   (const msgPayload    msg,
                                  const char*         name,
                                  mama_fid_t          fid,
-                                 const mamaPrice*    result,
+                                 const mamaPrice**   result,
                                  mama_size_t*        size);
 
 /**
@@ -1713,7 +1713,7 @@ qpidmsgFieldPayload_getVectorString (const msgFieldPayload   field,
 MAMAExpBridgeDLL
 mama_status
 qpidmsgFieldPayload_getVectorDateTime (const msgFieldPayload   field,
-                                       const mamaDateTime*     result,
+                                       const mamaDateTime**    result,
                                        mama_size_t*            size);
 
 /**
@@ -1732,7 +1732,7 @@ qpidmsgFieldPayload_getVectorDateTime (const msgFieldPayload   field,
 MAMAExpBridgeDLL
 mama_status
 qpidmsgFieldPayload_getVectorPrice (const msgFieldPayload   field,
-                                    const mamaPrice*        result,
+                                    const mamaPrice**       result,
                                     mama_size_t*            size);
 
 /**

--- a/mama/c_cpp/src/c/payloadbridge.h
+++ b/mama/c_cpp/src/c/payloadbridge.h
@@ -491,7 +491,7 @@ typedef mama_status
 (*msgPayload_updateVectorPrice)(msgPayload          msg,
                                 const char*         fname,
                                 mama_fid_t          fid,
-                                const mamaPrice*    priceList[],
+                                const mamaPrice     priceList[],
                                 mama_size_t         size);
 typedef mama_status
 (*msgPayload_updateVectorTime) (msgPayload          msg,
@@ -667,13 +667,13 @@ typedef mama_status
 (*msgPayload_getVectorDateTime)(const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
-                                const mamaDateTime* result,
+                                const mamaDateTime** result,
                                 mama_size_t*        size);
 typedef mama_status
 (*msgPayload_getVectorPrice)   (const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
-                                const mamaPrice*    result,
+                                const mamaPrice**   result,
                                 mama_size_t*        size);
 typedef mama_status
 (*msgPayload_getVectorMsg)     (const msgPayload    msg,

--- a/mama/c_cpp/src/c/registerfunctions.c
+++ b/mama/c_cpp/src/c/registerfunctions.c
@@ -252,7 +252,7 @@ mamaInternal_registerPayloadFunctions (LIB_HANDLE         bridgeLib,
     REGISTER_OPTIONAL_BRIDGE_FUNCTION (Payload_updateVectorF32, msgPayloadUpdateVectorF32, msgPayload_updateVectorF32);
     REGISTER_OPTIONAL_BRIDGE_FUNCTION (Payload_updateVectorF64, msgPayloadUpdateVectorF64, msgPayload_updateVectorF64);
     REGISTER_OPTIONAL_BRIDGE_FUNCTION (Payload_updateVectorPrice, msgPayloadUpdateVectorPrice, msgPayload_updateVectorPrice);
-    REGISTER_OPTIONAL_BRIDGE_FUNCTION (Payload_updateVectorPrice, msgPayloadUpdateVectorTime, msgPayload_updateVectorTime);
+    REGISTER_OPTIONAL_BRIDGE_FUNCTION (Payload_updateVectorTime, msgPayloadUpdateVectorTime, msgPayload_updateVectorTime);
 
     /* Get methods */
     REGISTER_BRIDGE_FUNCTION (Payload_getBool, msgPayloadGetBool, msgPayload_getBool);

--- a/mama/c_cpp/src/gunittest/c/mamamsg/msgvectortests.cpp
+++ b/mama/c_cpp/src/gunittest/c/mamamsg/msgvectortests.cpp
@@ -31,10 +31,6 @@ using std::endl;
 #define  VECTOR_SIZE                ( 10U )
 #define  VECTOR_UPDATE_SIZE         ( 20U )
 
-#define MAMA_DATE_TIME_GET_VECTOR_CAST (const mamaDateTime*)
-#define MAMA_PRICE_GET_VECTOR_CAST     (const mamaPrice*)
-#define MAMA_PRICE_UPDATE_VECTOR_CAST  (const mamaPrice**)
-
 class MsgVectorTestsC : public ::testing::Test
 {
 protected:
@@ -3563,7 +3559,7 @@ TEST_F(MsgVectorDateTimeTestsC, AddVectorDateTime)
     mStatus = mamaMsg_getVectorDateTime (mMsg,
                                          NULL,
                                          1,
-                                         MAMA_DATE_TIME_GET_VECTOR_CAST(&mOut),
+                                         &mOut,
                                          &mOutSize);
     ASSERT_EQ( mStatus, MAMA_STATUS_OK );
     EXPECT_EQ( mOutSize, VECTOR_SIZE );
@@ -3619,7 +3615,7 @@ TEST_F(MsgVectorDateTimeTestsC, UpdateVectorDateTime)
         mStatus = mamaMsg_getVectorDateTime (mMsg,
                                              NULL,
                                              1,
-                                             MAMA_DATE_TIME_GET_VECTOR_CAST(&mOut),
+                                             &mOut,
                                              &mOutSize);
         EXPECT_EQ( mStatus, MAMA_STATUS_OK );
         EXPECT_EQ( mOutSize, VECTOR_SIZE );
@@ -3636,7 +3632,7 @@ TEST_F(MsgVectorDateTimeTestsC, UpdateVectorDateTime)
     mStatus = mamaMsg_getVectorDateTime (mMsg,
                                          NULL,
                                          1,
-                                         MAMA_DATE_TIME_GET_VECTOR_CAST(&mOut),
+                                         &mOut,
                                          &mOutSize);
 
     EXPECT_EQ( mStatus, MAMA_STATUS_OK );
@@ -3691,7 +3687,7 @@ TEST_F(MsgVectorDateTimeTestsC, GetVectorDateTime)
         mStatus = mamaMsg_getVectorDateTime (mMsg,
                                              NULL,
                                              1,
-                                             MAMA_DATE_TIME_GET_VECTOR_CAST(&mOut),
+                                             &mOut,
                                              &mOutSize);
         ASSERT_EQ( mStatus, MAMA_STATUS_OK );
         EXPECT_EQ( mOutSize, VECTOR_SIZE );
@@ -3751,7 +3747,7 @@ TEST_F(MsgVectorDateTimeTestsC, GetVectorDateTimeNullAdd)
     mStatus = mamaMsg_getVectorDateTime (mMsg,
                                          NULL,
                                          1,
-                                         MAMA_DATE_TIME_GET_VECTOR_CAST(&mOut),
+                                         &mOut,
                                          NULL);
     EXPECT_EQ(mStatus, MAMA_STATUS_NULL_ARG);
 }
@@ -3769,7 +3765,7 @@ TEST_F(MsgVectorDateTimeTestsC, GetVectorDateTimeNullMsg)
     mStatus = mamaMsg_getVectorDateTime (NULL,
                                          NULL,
                                          1,
-                                         MAMA_DATE_TIME_GET_VECTOR_CAST(&mOut),
+                                         &mOut,
                                          &mOutSize);
     EXPECT_EQ(mStatus, MAMA_STATUS_NULL_ARG);
 }
@@ -3848,7 +3844,7 @@ TEST_F(MsgVectorPriceTestsC, AddVectorPrice)
     mStatus = mamaMsg_getVectorPrice (mMsg,
                                       NULL,
                                       1,
-                                      MAMA_PRICE_GET_VECTOR_CAST(&mOut),
+                                      &mOut,
                                       &mOutSize);
     ASSERT_EQ( mStatus, MAMA_STATUS_OK );
     EXPECT_EQ( mOutSize, VECTOR_SIZE );
@@ -3904,7 +3900,7 @@ TEST_F(MsgVectorPriceTestsC, UpdateVectorPrice)
         mStatus = mamaMsg_getVectorPrice (mMsg,
                                           NULL,
                                           1,
-                                          MAMA_PRICE_GET_VECTOR_CAST(&mOut),
+                                          &mOut,
                                           &mOutSize);
         ASSERT_EQ( mStatus, MAMA_STATUS_OK );
         EXPECT_EQ( mOutSize, VECTOR_SIZE );
@@ -3913,14 +3909,14 @@ TEST_F(MsgVectorPriceTestsC, UpdateVectorPrice)
     mStatus = mamaMsg_updateVectorPrice (mMsg,
                                          NULL,
                                          1,
-                                         MAMA_PRICE_UPDATE_VECTOR_CAST(mUpdate),
+                                         mUpdate,
                                          VECTOR_UPDATE_SIZE);
     EXPECT_EQ(mStatus, MAMA_STATUS_OK);
 
     mStatus = mamaMsg_getVectorPrice (mMsg,
                                       NULL,
                                       1,
-                                      (const mamaPrice*) &mOut,
+                                      &mOut,
                                       &mOutSize);
     EXPECT_EQ( mStatus, MAMA_STATUS_OK );
     EXPECT_EQ( mOutSize, VECTOR_UPDATE_SIZE );
@@ -3951,7 +3947,7 @@ TEST_F(MsgVectorPriceTestsC, UpdateVectorPriceNullMsg)
     mStatus = mamaMsg_updateVectorPrice (NULL,
                                          NULL,
                                          1,
-                                         MAMA_PRICE_UPDATE_VECTOR_CAST(mUpdate),
+                                         mUpdate,
                                          VECTOR_UPDATE_SIZE);
     CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     EXPECT_EQ(mStatus, MAMA_STATUS_NULL_ARG);
@@ -3974,7 +3970,7 @@ TEST_F(MsgVectorPriceTestsC, GetVectorPrice)
         mStatus = mamaMsg_getVectorPrice (mMsg,
                                           NULL,
                                           1,
-                                          MAMA_PRICE_GET_VECTOR_CAST(&mOut),
+                                          &mOut,
                                           &mOutSize);
         ASSERT_EQ( mStatus, MAMA_STATUS_OK );
         EXPECT_EQ( mOutSize, VECTOR_SIZE );
@@ -3992,14 +3988,14 @@ TEST_F(MsgVectorPriceTestsC, GetVectorPrice)
     mStatus = mamaMsg_updateVectorPrice (mMsg,
                                          NULL,
                                          1,
-                                         MAMA_PRICE_UPDATE_VECTOR_CAST(mUpdate),
+                                         mUpdate,
                                          VECTOR_UPDATE_SIZE);
     EXPECT_EQ(mStatus, MAMA_STATUS_OK);
 
     mStatus = mamaMsg_getVectorPrice (mMsg,
                                       NULL,
                                       1,
-                                      MAMA_PRICE_GET_VECTOR_CAST(&mOut),
+                                      &mOut,
                                       &mOutSize);
 
     EXPECT_EQ( mStatus, MAMA_STATUS_OK );
@@ -4032,7 +4028,7 @@ TEST_F(MsgVectorPriceTestsC, GetVectorPriceNullAdd)
     mStatus = mamaMsg_getVectorPrice (mMsg,
                                       NULL,
                                       1,
-                                      MAMA_PRICE_GET_VECTOR_CAST(&mOut),
+                                      &mOut,
                                       NULL);
     EXPECT_EQ(mStatus, MAMA_STATUS_NULL_ARG);
 }
@@ -4050,7 +4046,7 @@ TEST_F(MsgVectorPriceTestsC, GetVectorPriceNullMsg)
     mStatus = mamaMsg_getVectorPrice (NULL,
                                       NULL,
                                       1,
-                                      MAMA_PRICE_GET_VECTOR_CAST(&mOut),
+                                      &mOut,
                                       &mOutSize);
     EXPECT_EQ(mStatus, MAMA_STATUS_NULL_ARG);
 }

--- a/mama/c_cpp/src/gunittest/c/mamamsg/msgvectortests.cpp
+++ b/mama/c_cpp/src/gunittest/c/mamamsg/msgvectortests.cpp
@@ -31,6 +31,10 @@ using std::endl;
 #define  VECTOR_SIZE                ( 10U )
 #define  VECTOR_UPDATE_SIZE         ( 20U )
 
+#define MAMA_DATE_TIME_GET_VECTOR_CAST (const mamaDateTime*)
+#define MAMA_PRICE_GET_VECTOR_CAST     (const mamaPrice*)
+#define MAMA_PRICE_UPDATE_VECTOR_CAST  (const mamaPrice**)
+
 class MsgVectorTestsC : public ::testing::Test
 {
 protected:
@@ -3546,20 +3550,20 @@ protected:
 // AddVectorDateTime test fixtures
 // *******************************
 
-TEST_F(MsgVectorDateTimeTestsC, DISABLED_AddVectorDateTime)
-// Disabled as mamaMsg_addVectorDateTime is not implemented.
+TEST_F(MsgVectorDateTimeTestsC, AddVectorDateTime)
 {
     mStatus = mamaMsg_addVectorDateTime (mMsg,
                                          NULL,
                                          1,
                                          mIn,
                                          VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     ASSERT_EQ(mStatus, MAMA_STATUS_OK);
 
     mStatus = mamaMsg_getVectorDateTime (mMsg,
                                          NULL,
                                          1,
-                                         (mama_u64_t* const*) &mOut,
+                                         MAMA_DATE_TIME_GET_VECTOR_CAST(&mOut),
                                          &mOutSize);
     ASSERT_EQ( mStatus, MAMA_STATUS_OK );
     EXPECT_EQ( mOutSize, VECTOR_SIZE );
@@ -3575,14 +3579,14 @@ TEST_F(MsgVectorDateTimeTestsC, DISABLED_AddVectorDateTime)
     }
 }
 
-TEST_F(MsgVectorDateTimeTestsC, DISABLED_AddVectorDateTimeNullAdd)
-// Disabled as mamaMsg_addVectorDateTime is not implemented.
+TEST_F(MsgVectorDateTimeTestsC, AddVectorDateTimeNullAdd)
 {
     mStatus = mamaMsg_addVectorDateTime (mMsg,
                                          NULL,
                                          1,
                                          NULL,
                                          VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     EXPECT_EQ(mStatus, MAMA_STATUS_NULL_ARG);
 }
 
@@ -3593,20 +3597,21 @@ TEST_F(MsgVectorDateTimeTestsC, AddVectorDateTimeNullMsg)
                                          1,
                                          mIn,
                                          VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     EXPECT_EQ(mStatus, MAMA_STATUS_NULL_ARG);
 }
 
 // UpdateVectorDateTime test fixtures
 // **********************************
 
-TEST_F(MsgVectorDateTimeTestsC, DISABLED_UpdateVectorDateTime)
-// Disabled as mamaMsg_updateVectorTime is not implemented.
+TEST_F(MsgVectorDateTimeTestsC, UpdateVectorDateTime)
 {
     mStatus = mamaMsg_addVectorDateTime (mMsg,
                                          NULL,
                                          1,
                                          mIn,
                                          VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     EXPECT_EQ(mStatus, MAMA_STATUS_OK);
 
     if (MAMA_STATUS_OK == mStatus)
@@ -3614,14 +3619,13 @@ TEST_F(MsgVectorDateTimeTestsC, DISABLED_UpdateVectorDateTime)
         mStatus = mamaMsg_getVectorDateTime (mMsg,
                                              NULL,
                                              1,
-                                             (mama_u64_t* const*) &mOut,
+                                             MAMA_DATE_TIME_GET_VECTOR_CAST(&mOut),
                                              &mOutSize);
         EXPECT_EQ( mStatus, MAMA_STATUS_OK );
         EXPECT_EQ( mOutSize, VECTOR_SIZE );
     }
 
 
-    /*
     mStatus = mamaMsg_updateVectorTime (mMsg,
                                         NULL,
                                         1,
@@ -3632,7 +3636,7 @@ TEST_F(MsgVectorDateTimeTestsC, DISABLED_UpdateVectorDateTime)
     mStatus = mamaMsg_getVectorDateTime (mMsg,
                                          NULL,
                                          1,
-                                         (mama_u64_t* const*) &mOut,
+                                         MAMA_DATE_TIME_GET_VECTOR_CAST(&mOut),
                                          &mOutSize);
 
     EXPECT_EQ( mStatus, MAMA_STATUS_OK );
@@ -3646,45 +3650,40 @@ TEST_F(MsgVectorDateTimeTestsC, DISABLED_UpdateVectorDateTime)
             EXPECT_EQ(1, eq);
         }
     }
-    */
 }
 
-TEST_F(MsgVectorDateTimeTestsC, DISABLED_UpdateVectorDateTimeNullAdd)
-// Disabled as mamaMsg_updateVectorTime is not implemented.
+TEST_F(MsgVectorDateTimeTestsC, UpdateVectorDateTimeNullAdd)
 {
-    /*
     mStatus = mamaMsg_updateVectorTime (mMsg,
                                         NULL,
                                         1,
                                         NULL,
                                         VECTOR_UPDATE_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     EXPECT_EQ(mStatus, MAMA_STATUS_NULL_ARG);
-    */
 }
 
-TEST_F(MsgVectorDateTimeTestsC, DISABLED_UpdateVectorDateTimeNullMsg)
-// Disabled as mamaMsg_updateVectorTime is not implemented.
+TEST_F(MsgVectorDateTimeTestsC, UpdateVectorDateTimeNullMsg)
 {
-    /*
     mStatus = mamaMsg_updateVectorTime (NULL,
                                         NULL,
                                         1,
                                         mUpdate,
                                         VECTOR_UPDATE_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     EXPECT_EQ(mStatus, MAMA_STATUS_NULL_ARG);
-    */
 }
 
 // GetVectorDateTime test fixtures
 // *******************************
-TEST_F(MsgVectorDateTimeTestsC, DISABLED_GetVectorDateTime)
-// Disabled as mamaMsg_addVectorTime is not implemented.
+TEST_F(MsgVectorDateTimeTestsC, GetVectorDateTime)
 {
     mStatus = mamaMsg_addVectorDateTime (mMsg,
                                          NULL,
                                          1,
                                          mIn,
                                          VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     ASSERT_EQ(mStatus, MAMA_STATUS_OK);
 
     if (MAMA_STATUS_OK == mStatus)
@@ -3692,7 +3691,7 @@ TEST_F(MsgVectorDateTimeTestsC, DISABLED_GetVectorDateTime)
         mStatus = mamaMsg_getVectorDateTime (mMsg,
                                              NULL,
                                              1,
-                                             (mama_u64_t* const*) &mOut,
+                                             MAMA_DATE_TIME_GET_VECTOR_CAST(&mOut),
                                              &mOutSize);
         ASSERT_EQ( mStatus, MAMA_STATUS_OK );
         EXPECT_EQ( mOutSize, VECTOR_SIZE );
@@ -3732,14 +3731,14 @@ TEST_F(MsgVectorDateTimeTestsC, DISABLED_GetVectorDateTime)
     */
 }
 
-TEST_F(MsgVectorDateTimeTestsC, DISABLED_GetVectorDateTimeNullAdd)
-// Disabled as mamaMsg_addVectorDateTime is not implemented.
+TEST_F(MsgVectorDateTimeTestsC, GetVectorDateTimeNullAdd)
 {
     mStatus = mamaMsg_addVectorDateTime (mMsg,
                                          NULL,
                                          1,
                                          mIn,
                                          VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     ASSERT_EQ(mStatus, MAMA_STATUS_OK);
 
     mStatus = mamaMsg_getVectorDateTime (mMsg,
@@ -3752,25 +3751,25 @@ TEST_F(MsgVectorDateTimeTestsC, DISABLED_GetVectorDateTimeNullAdd)
     mStatus = mamaMsg_getVectorDateTime (mMsg,
                                          NULL,
                                          1,
-                                         (mama_u64_t* const*) &mOut,
+                                         MAMA_DATE_TIME_GET_VECTOR_CAST(&mOut),
                                          NULL);
     EXPECT_EQ(mStatus, MAMA_STATUS_NULL_ARG);
 }
 
-TEST_F(MsgVectorDateTimeTestsC, DISABLED_GetVectorDateTimeNullMsg)
-// Disabled as mamaMsg_addVectorDateTime is not implemented.
+TEST_F(MsgVectorDateTimeTestsC, GetVectorDateTimeNullMsg)
 {
     mStatus = mamaMsg_addVectorDateTime (mMsg,
                                          NULL,
                                          1,
                                          mIn,
                                          VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     ASSERT_EQ(mStatus, MAMA_STATUS_OK);
 
     mStatus = mamaMsg_getVectorDateTime (NULL,
                                          NULL,
                                          1,
-                                         (mama_u64_t* const*) &mOut,
+                                         MAMA_DATE_TIME_GET_VECTOR_CAST(&mOut),
                                          &mOutSize);
     EXPECT_EQ(mStatus, MAMA_STATUS_NULL_ARG);
 }
@@ -3836,20 +3835,20 @@ protected:
 // AddVectorPrice test fixtures
 // ****************************
 
-TEST_F(MsgVectorPriceTestsC, DISABLED_AddVectorPrice)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(MsgVectorPriceTestsC, AddVectorPrice)
 {
     mStatus = mamaMsg_addVectorPrice (mMsg,
                                       NULL,
                                       1,
                                       mIn,
                                       VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     ASSERT_EQ(mStatus, MAMA_STATUS_OK);
 
     mStatus = mamaMsg_getVectorPrice (mMsg,
                                       NULL,
                                       1,
-                                      (const mamaPrice*) &mOut,
+                                      MAMA_PRICE_GET_VECTOR_CAST(&mOut),
                                       &mOutSize);
     ASSERT_EQ( mStatus, MAMA_STATUS_OK );
     EXPECT_EQ( mOutSize, VECTOR_SIZE );
@@ -3865,14 +3864,14 @@ TEST_F(MsgVectorPriceTestsC, DISABLED_AddVectorPrice)
     }
 }
 
-TEST_F(MsgVectorPriceTestsC, DISABLED_AddVectorPriceNullAdd)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(MsgVectorPriceTestsC, AddVectorPriceNullAdd)
 {
     mStatus = mamaMsg_addVectorPrice (mMsg,
                                       NULL,
                                       1,
                                       NULL,
                                       VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     EXPECT_EQ(mStatus, MAMA_STATUS_NULL_ARG);
 }
 
@@ -3883,20 +3882,21 @@ TEST_F(MsgVectorPriceTestsC, AddVectorPriceNullMsg)
                                       1,
                                       mIn,
                                       VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     EXPECT_EQ(mStatus, MAMA_STATUS_NULL_ARG);
 }
 
 // UpdateVectorPrice test fixtures
 // *******************************
 
-TEST_F(MsgVectorPriceTestsC, DISABLED_UpdateVectorPrice)
-// Disabled as  mamaMsg_updateVectorPrice is not implemented.
+TEST_F(MsgVectorPriceTestsC, UpdateVectorPrice)
 {
     mStatus = mamaMsg_addVectorPrice (mMsg,
                                       NULL,
                                       1,
                                       mIn,
                                       VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     ASSERT_EQ(mStatus, MAMA_STATUS_OK);
 
     if (MAMA_STATUS_OK == mStatus)
@@ -3904,17 +3904,16 @@ TEST_F(MsgVectorPriceTestsC, DISABLED_UpdateVectorPrice)
         mStatus = mamaMsg_getVectorPrice (mMsg,
                                           NULL,
                                           1,
-                                          (const mamaPrice*) &mOut,
+                                          MAMA_PRICE_GET_VECTOR_CAST(&mOut),
                                           &mOutSize);
         ASSERT_EQ( mStatus, MAMA_STATUS_OK );
         EXPECT_EQ( mOutSize, VECTOR_SIZE );
     }
 
-    /*
     mStatus = mamaMsg_updateVectorPrice (mMsg,
                                          NULL,
                                          1,
-                                         (void* const**) &mUpdate,
+                                         MAMA_PRICE_UPDATE_VECTOR_CAST(mUpdate),
                                          VECTOR_UPDATE_SIZE);
     EXPECT_EQ(mStatus, MAMA_STATUS_OK);
 
@@ -3934,45 +3933,40 @@ TEST_F(MsgVectorPriceTestsC, DISABLED_UpdateVectorPrice)
             EXPECT_EQ(1, eq);
         }
     }
-    */
 }
 
-TEST_F(MsgVectorPriceTestsC, DISABLED_UpdateVectorPriceNullAdd)
-// Disabeld as mamaMsg_updateVectorPrice is not implemented.
+TEST_F(MsgVectorPriceTestsC, UpdateVectorPriceNullAdd)
 {
-    /*
     mStatus = mamaMsg_updateVectorPrice (mMsg,
                                          NULL,
                                          1,
                                          NULL,
                                          VECTOR_UPDATE_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     EXPECT_EQ(mStatus, MAMA_STATUS_NULL_ARG);
-    */
 }
 
-TEST_F(MsgVectorPriceTestsC, DISABLED_UpdateVectorPriceNullMsg)
-// Disabled as mamaMsg_updateVectorPrice is not implemented.
+TEST_F(MsgVectorPriceTestsC, UpdateVectorPriceNullMsg)
 {
-    /*
     mStatus = mamaMsg_updateVectorPrice (NULL,
                                          NULL,
                                          1,
-                                         (void* const**) mUpdate,
+                                         MAMA_PRICE_UPDATE_VECTOR_CAST(mUpdate),
                                          VECTOR_UPDATE_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     EXPECT_EQ(mStatus, MAMA_STATUS_NULL_ARG);
-    */
 }
 
 // GetVectorPrice test fixtures
 // *******************************
-TEST_F(MsgVectorPriceTestsC, DISABLED_GetVectorPrice)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(MsgVectorPriceTestsC, GetVectorPrice)
 {
     mStatus = mamaMsg_addVectorPrice (mMsg,
                                       NULL,
                                       1,
                                       mIn,
                                       VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     ASSERT_EQ(mStatus, MAMA_STATUS_OK);
 
     if (MAMA_STATUS_OK == mStatus)
@@ -3980,7 +3974,7 @@ TEST_F(MsgVectorPriceTestsC, DISABLED_GetVectorPrice)
         mStatus = mamaMsg_getVectorPrice (mMsg,
                                           NULL,
                                           1,
-                                          (const mamaPrice*) &mOut,
+                                          MAMA_PRICE_GET_VECTOR_CAST(&mOut),
                                           &mOutSize);
         ASSERT_EQ( mStatus, MAMA_STATUS_OK );
         EXPECT_EQ( mOutSize, VECTOR_SIZE );
@@ -3995,18 +3989,17 @@ TEST_F(MsgVectorPriceTestsC, DISABLED_GetVectorPrice)
         }
     }
 
-    /*
     mStatus = mamaMsg_updateVectorPrice (mMsg,
                                          NULL,
                                          1,
-                                         (void* const**) mUpdate,
+                                         MAMA_PRICE_UPDATE_VECTOR_CAST(mUpdate),
                                          VECTOR_UPDATE_SIZE);
     EXPECT_EQ(mStatus, MAMA_STATUS_OK);
 
     mStatus = mamaMsg_getVectorPrice (mMsg,
                                       NULL,
                                       1,
-                                      (const mamaPrice*) &mOut,
+                                      MAMA_PRICE_GET_VECTOR_CAST(&mOut),
                                       &mOutSize);
 
     EXPECT_EQ( mStatus, MAMA_STATUS_OK );
@@ -4015,19 +4008,18 @@ TEST_F(MsgVectorPriceTestsC, DISABLED_GetVectorPrice)
     {
         int eq = mamaPrice_equal( mUpdate[ii],
                                   mOut[ii] );
-        EXPECT_EQ(0, eq);
+        EXPECT_EQ(1, eq);
     }
-    */
 }
 
-TEST_F(MsgVectorPriceTestsC, DISABLED_GetVectorPriceNullAdd)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(MsgVectorPriceTestsC, GetVectorPriceNullAdd)
 {
     mStatus = mamaMsg_addVectorPrice (mMsg,
                                       NULL,
                                       1,
                                       mIn,
                                       VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     ASSERT_EQ(mStatus, MAMA_STATUS_OK);
 
     mStatus = mamaMsg_getVectorPrice (mMsg,
@@ -4040,25 +4032,25 @@ TEST_F(MsgVectorPriceTestsC, DISABLED_GetVectorPriceNullAdd)
     mStatus = mamaMsg_getVectorPrice (mMsg,
                                       NULL,
                                       1,
-                                      (const mamaPrice*) &mOut,
+                                      MAMA_PRICE_GET_VECTOR_CAST(&mOut),
                                       NULL);
     EXPECT_EQ(mStatus, MAMA_STATUS_NULL_ARG);
 }
 
-TEST_F(MsgVectorPriceTestsC, DISABLED_GetVectorPriceNullMsg)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(MsgVectorPriceTestsC, GetVectorPriceNullMsg)
 {
     mStatus = mamaMsg_addVectorPrice (mMsg,
                                       NULL,
                                       1,
                                       mIn,
                                       VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     EXPECT_EQ(mStatus, MAMA_STATUS_OK);
 
     mStatus = mamaMsg_getVectorPrice (NULL,
                                       NULL,
                                       1,
-                                      (const mamaPrice*) &mOut,
+                                      MAMA_PRICE_GET_VECTOR_CAST(&mOut),
                                       &mOutSize);
     EXPECT_EQ(mStatus, MAMA_STATUS_NULL_ARG);
 }

--- a/mama/c_cpp/src/gunittest/c/payload/fieldvectortests.cpp
+++ b/mama/c_cpp/src/gunittest/c/payload/fieldvectortests.cpp
@@ -27,6 +27,8 @@
 #include "MainUnitTestC.h"
 
 #define VECTOR_SIZE 2
+#define MAMA_DATE_TIME_GET_VECTOR_CAST (const mamaDateTime*)
+#define MAMA_PRICE_GET_VECTOR_CAST     (const mamaPrice*)
 
 using namespace ::testing;
 
@@ -960,20 +962,30 @@ protected:
 
 TEST_F(FieldVectorDateTimeTests, GetVectorDateTime)
 {
-    m_status = m_payloadBridge->msgFieldPayloadGetVectorDateTime(m_field, m_out, &m_size);
-    ASSERT_EQ (MAMA_STATUS_NOT_IMPLEMENTED, m_status);
+    size_t i = 0;
+    m_status = m_payloadBridge->msgPayloadGetField(m_msg, NULL, 1, &m_field);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
+    ASSERT_EQ(m_status, MAMA_STATUS_OK);
+    m_status = m_payloadBridge->msgFieldPayloadGetVectorDateTime(m_field, MAMA_DATE_TIME_GET_VECTOR_CAST(&m_out), &m_size);
+    for (i = 0; i < VECTOR_SIZE; i++)
+    {
+        ASSERT_EQ (1, mamaDateTime_equal (m_out[i], m_in[i]));
+    }
+    ASSERT_EQ(m_status, MAMA_STATUS_OK);
 }
 
 TEST_F(FieldVectorDateTimeTests, GetVectorDateTimeNullOut)
 {
     m_status = m_payloadBridge->msgFieldPayloadGetVectorDateTime(m_field, NULL, &m_size);
-    ASSERT_EQ (MAMA_STATUS_NOT_IMPLEMENTED, m_status);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
+    ASSERT_EQ (m_status, MAMA_STATUS_NULL_ARG);
 }
 
 TEST_F(FieldVectorDateTimeTests, GetVectorDateTimeNullSize)
 {
-    m_status = m_payloadBridge->msgFieldPayloadGetVectorDateTime(m_field, m_out, NULL);
-    ASSERT_EQ (MAMA_STATUS_NOT_IMPLEMENTED, m_status);
+    m_status = m_payloadBridge->msgFieldPayloadGetVectorDateTime(m_field, MAMA_DATE_TIME_GET_VECTOR_CAST(&m_out), NULL);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
+    ASSERT_EQ (m_status, MAMA_STATUS_NULL_ARG);
 }
 
 /**
@@ -1038,20 +1050,30 @@ protected:
 
 TEST_F(FieldVectorPriceTests, GetVectorPrice)
 {
-    m_status = m_payloadBridge->msgFieldPayloadGetVectorPrice(m_field, m_out, &m_size);
-    ASSERT_EQ (MAMA_STATUS_NOT_IMPLEMENTED, m_status);
+    size_t i = 0;
+    m_status = m_payloadBridge->msgPayloadGetField(m_msg, NULL, 1, &m_field);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
+    ASSERT_EQ(m_status, MAMA_STATUS_OK);
+    m_status = m_payloadBridge->msgFieldPayloadGetVectorPrice(m_field, MAMA_PRICE_GET_VECTOR_CAST(&m_out), &m_size);
+    ASSERT_EQ(m_status, MAMA_STATUS_OK);
+    for (i = 0; i < VECTOR_SIZE; i++)
+    {
+        ASSERT_EQ (1, mamaPrice_equal (m_out[i], m_in[i]));
+    }
 }
 
 TEST_F(FieldVectorPriceTests, GetVectorPriceNullOut)
 {
     m_status = m_payloadBridge->msgFieldPayloadGetVectorPrice(m_field, NULL, &m_size);
-    ASSERT_EQ (MAMA_STATUS_NOT_IMPLEMENTED, m_status);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
+    ASSERT_EQ (m_status, MAMA_STATUS_NULL_ARG);
 }
 
 TEST_F(FieldVectorPriceTests, GetVectorPriceNullSize)
 {
-    m_status = m_payloadBridge->msgFieldPayloadGetVectorPrice(m_field, m_out, NULL);
-    ASSERT_EQ (MAMA_STATUS_NOT_IMPLEMENTED, m_status);
+    m_status = m_payloadBridge->msgFieldPayloadGetVectorPrice(m_field, MAMA_PRICE_GET_VECTOR_CAST(&m_out), NULL);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
+    ASSERT_EQ (m_status, MAMA_STATUS_NULL_ARG);
 }
 
 /**

--- a/mama/c_cpp/src/gunittest/c/payload/payloadvectortests.cpp
+++ b/mama/c_cpp/src/gunittest/c/payload/payloadvectortests.cpp
@@ -3831,15 +3831,15 @@ protected:
 // AddVectorDateTime test fixtures
 // *******************************
 
-TEST_F(PayloadVectorDateTimeTests, DISABLED_AddVectorDateTime)
-// Disabled as mamaMsg_addVectorDateTime is not implemented.
+TEST_F(PayloadVectorDateTimeTests, AddVectorDateTime)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorDateTime(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
-    m_status = m_payloadBridge->msgPayloadGetVectorDateTime(m_msg, NULL, 1, (mama_u64_t* const*) &m_out, &m_outSize);
-    ASSERT_EQ (MAMA_STATUS_OK , m_status);
-    EXPECT_EQ (VECTOR_SIZE , m_outSize);
+    m_status = m_payloadBridge->msgPayloadGetVectorDateTime(m_msg, NULL, 1, &m_out, &m_outSize);
+    ASSERT_EQ( m_status, MAMA_STATUS_OK );
+    EXPECT_EQ( m_outSize, VECTOR_SIZE );
 
     for( unsigned int ii(0) ; ii < VECTOR_SIZE ; ++ii )
     {
@@ -3852,44 +3852,44 @@ TEST_F(PayloadVectorDateTimeTests, DISABLED_AddVectorDateTime)
     }
 }
 
-TEST_F(PayloadVectorDateTimeTests, DISABLED_AddVectorDateTimeNullDateTime)
-// Disabled as mamaMsg_addVectorDateTime is not implemented.
+TEST_F(PayloadVectorDateTimeTests, AddVectorDateTimeNullDateTime)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorDateTime(m_msg, NULL, 1, NULL, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_NULL_ARG , m_status);
 }
 
-TEST_F(PayloadVectorDateTimeTests, DISABLED_AddVectorDateTimeNullMsg)
-// Disabled as mamaMsg_addVectorDateTime is not implemented.
+TEST_F(PayloadVectorDateTimeTests, AddVectorDateTimeNullMsg)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorDateTime(NULL, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_NULL_ARG, m_status);
 }
 
-TEST_F(PayloadVectorDateTimeTests, DISABLED_AddVectorDateTimeAfterInit)
-// Disabled as mamaMsg_addVectorDateTime is not implemented.
+TEST_F(PayloadVectorDateTimeTests, AddVectorDateTimeAfterInit)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorDateTime(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
     m_status = m_payloadBridge->msgPayloadAddVectorDateTime(m_msg, NULL, 2, m_in, VECTOR_SIZE);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 }
 
-TEST_F(PayloadVectorDateTimeTests, DISABLED_AddVectorDateTimeInvalidName)
-// Disabled as mamaMsg_addVectorDateTime is not implemented.
+TEST_F(PayloadVectorDateTimeTests, AddVectorDateTimeInvalidName)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorDateTime(m_msg, "Bob", 0, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
     m_status = m_payloadBridge->msgPayloadAddVectorDateTime(m_msg, NULL, 0, m_in, VECTOR_SIZE);
     EXPECT_EQ (MAMA_STATUS_NULL_ARG, m_status);
 }
 
-TEST_F(PayloadVectorDateTimeTests, DISABLED_AddVectorDateTimeInvalidFid)
-// Disabled as mamaMsg_addVectorDateTime is not implemented.
+TEST_F(PayloadVectorDateTimeTests, AddVectorDateTimeInvalidFid)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorDateTime(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
     m_status = m_payloadBridge->msgPayloadAddVectorDateTime(m_msg, NULL, 0, m_in, VECTOR_SIZE);
@@ -3899,9 +3899,10 @@ TEST_F(PayloadVectorDateTimeTests, DISABLED_AddVectorDateTimeInvalidFid)
 // UpdateVectorDateTime test fixtures
 // **********************************
 // Disabled as mamaMsg_addVectorDateTime is not implemented.
-TEST_F(PayloadVectorDateTimeTests, DISABLED_UpdateVectorDateTime)
+TEST_F(PayloadVectorDateTimeTests, UpdateVectorDateTime)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorDateTime(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
     //m_status = m_payloadBridge->msgPayloadGetVectorDateTime(m_msg, NULL, 1, (mama_u64_t* const*) &m_out, &m_outSize);
@@ -3948,10 +3949,10 @@ TEST_F(PayloadVectorDateTimeTests, DISABLED_UpdateVectorDateTime)
     */
 }
 
-TEST_F(PayloadVectorDateTimeTests, DISABLED_UpdateVectorDateTimeNullUpdate)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(PayloadVectorDateTimeTests, UpdateVectorDateTimeNullUpdate)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorDateTime(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
     //m_status = m_payloadBridge->msgPayloadGetVectorDateTime(m_msg, NULL, 1, (mama_u64_t* const*) &m_out, &m_outSize);
@@ -3978,10 +3979,10 @@ TEST_F(PayloadVectorDateTimeTests, DISABLED_UpdateVectorDateTimeNullUpdate)
     EXPECT_EQ (MAMA_STATUS_NULL_ARG, m_status);
 }
 
-TEST_F(PayloadVectorDateTimeTests, DISABLED_UpdateVectorDateTimeNullMessage)
-// Disabled as mamaMsg_addVectorDateTime is not implemented.
+TEST_F(PayloadVectorDateTimeTests, UpdateVectorDateTimeNullMessage)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorDateTime(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
     //m_status = m_payloadBridge->msgPayloadGetVectorDateTime(m_msg, NULL, 1, (mama_u64_t* const*) &m_out, &m_outSize);
@@ -4011,14 +4012,14 @@ TEST_F(PayloadVectorDateTimeTests, DISABLED_UpdateVectorDateTimeNullMessage)
 
 // GetVectorDateTime test fixtures
 // *******************************
-TEST_F(PayloadVectorDateTimeTests, DISABLED_GetVectorDateTime)
-// Disabled as mamaMsg_addVectorDateTime is not implemented.
+TEST_F(PayloadVectorDateTimeTests, GetVectorDateTime)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorDateTime(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
     // TODO Check prototype for GetVectorDateTime
-    m_status = m_payloadBridge->msgPayloadGetVectorDateTime(m_msg, NULL, 1, (mama_u64_t* const*) &m_out, &m_outSize);
+    m_status = m_payloadBridge->msgPayloadGetVectorDateTime(m_msg, NULL, 1, &m_out, &m_outSize);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
     EXPECT_EQ ((mama_size_t)VECTOR_SIZE, m_outSize);
 
@@ -4041,7 +4042,7 @@ TEST_F(PayloadVectorDateTimeTests, DISABLED_GetVectorDateTime)
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
     // TODO Check prototype for GetVectorDateTime
-    m_status = m_payloadBridge->msgPayloadGetVectorDateTime(m_msg, NULL, 1, (mama_u64_t* const*) &m_out, &m_outSize);
+    m_status = m_payloadBridge->msgPayloadGetVectorDateTime(m_msg, NULL, 1, &m_out, &m_outSize);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
     EXPECT_EQ ((mama_size_t)VECTOR_UPDATE_SIZE, m_outSize);
 
@@ -4061,25 +4062,23 @@ TEST_F(PayloadVectorDateTimeTests, DISABLED_GetVectorDateTime)
     }
 }
 
-TEST_F(PayloadVectorDateTimeTests, DISABLED_GetVectorDateTimeNullResult)
-// Disabled as mamaMsg_addVectorDateTime is not implemented.
+TEST_F(PayloadVectorDateTimeTests, GetVectorDateTimeNullResult)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorDateTime(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
-    // TODO Check prototype for GetVectorDateTime
     m_status = m_payloadBridge->msgPayloadGetVectorDateTime(m_msg, NULL, 1, NULL, &m_outSize);
     EXPECT_EQ (MAMA_STATUS_NULL_ARG, m_status);
 }
 
-TEST_F(PayloadVectorDateTimeTests, DISABLED_GetVectorDateTimeNullSize)
-// Disabled as mamaMsg_addVectorDateTime is not implemented.
+TEST_F(PayloadVectorDateTimeTests, GetVectorDateTimeNullSize)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorDateTime(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
-    // TODO Check prototype for GetVectorDateTime
-    m_status = m_payloadBridge->msgPayloadGetVectorDateTime(m_msg, NULL, 1, m_out, NULL);
+    m_status = m_payloadBridge->msgPayloadGetVectorDateTime(m_msg, NULL, 1, &m_out, NULL);
     EXPECT_EQ (MAMA_STATUS_NULL_ARG, m_status);
 }
 
@@ -4145,14 +4144,14 @@ protected:
 // AddVectorPrice test fixtures
 // ****************************
 
-TEST_F(PayloadVectorPriceTests, DISABLED_AddVectorPrice)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(PayloadVectorPriceTests, AddVectorPrice)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorPrice(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
     // TODO Check prototype for GetVectorPrice
-    m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 1, (void* const*) &m_out, &m_outSize);
+    m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 1, &m_out, &m_outSize);
     EXPECT_EQ (MAMA_STATUS_OK , m_status);
 
     EXPECT_EQ (VECTOR_SIZE , m_outSize);
@@ -4172,44 +4171,44 @@ TEST_F(PayloadVectorPriceTests, DISABLED_AddVectorPrice)
     }
 }
 
-TEST_F(PayloadVectorPriceTests, DISABLED_AddVectorPriceNullPrice)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(PayloadVectorPriceTests, AddVectorPriceNullPrice)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorPrice(m_msg, NULL, 1, NULL, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_NULL_ARG , m_status);
 }
 
-TEST_F(PayloadVectorPriceTests, DISABLED_AddVectorPriceNullMsg)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(PayloadVectorPriceTests, AddVectorPriceNullMsg)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorPrice(NULL, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_NULL_ARG, m_status);
 }
 
-TEST_F(PayloadVectorPriceTests, DISABLED_AddVectorPriceAfterInit)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(PayloadVectorPriceTests, AddVectorPriceAfterInit)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorPrice(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
     m_status = m_payloadBridge->msgPayloadAddVectorPrice(m_msg, NULL, 2, m_in, VECTOR_SIZE);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 }
 
-TEST_F(PayloadVectorPriceTests, DISABLED_AddVectorPriceInvalidName)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(PayloadVectorPriceTests, AddVectorPriceInvalidName)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorPrice(m_msg, "Bob", 0, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
     m_status = m_payloadBridge->msgPayloadAddVectorPrice(m_msg, NULL, 0, m_in, VECTOR_SIZE);
     EXPECT_EQ (MAMA_STATUS_NULL_ARG, m_status);
 }
 
-TEST_F(PayloadVectorPriceTests, DISABLED_AddVectorPriceInvalidFid)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(PayloadVectorPriceTests, AddVectorPriceInvalidFid)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorPrice(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
     m_status = m_payloadBridge->msgPayloadAddVectorPrice(m_msg, NULL, 0, m_in, VECTOR_SIZE);
@@ -4219,13 +4218,13 @@ TEST_F(PayloadVectorPriceTests, DISABLED_AddVectorPriceInvalidFid)
 // UpdateVectorPrice test fixtures
 // *******************************
 // wmsgPayload_updateVectorPrice not implemented
-TEST_F(PayloadVectorPriceTests, DISABLED_UpdateVectorPrice)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(PayloadVectorPriceTests, UpdateVectorPrice)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorPrice(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
-    m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 1, (void* const*) &m_out, &m_outSize);
+    m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 1, &m_out, &m_outSize);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
     EXPECT_EQ (VECTOR_SIZE, m_outSize);
 
@@ -4244,11 +4243,10 @@ TEST_F(PayloadVectorPriceTests, DISABLED_UpdateVectorPrice)
     }
 
     // TODO Interface inconsistent
-    m_status = m_payloadBridge->msgPayloadUpdateVectorPrice(m_msg, NULL, 1, (void* const**) m_update, VECTOR_UPDATE_SIZE);
+    m_status = m_payloadBridge->msgPayloadUpdateVectorPrice(m_msg, NULL, 1, m_update, VECTOR_UPDATE_SIZE);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
-    /*
-    m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 1, (void* const*) &m_out, &m_outSize);
+    m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 1, &m_out, &m_outSize);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
     EXPECT_EQ (VECTOR_UPDATE_SIZE, m_outSize);
 
@@ -4265,17 +4263,16 @@ TEST_F(PayloadVectorPriceTests, DISABLED_UpdateVectorPrice)
     {
         FAIL();
     }
-    */
 }
 
-TEST_F(PayloadVectorPriceTests, DISABLED_UpdateVectorPriceNullUpdate)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(PayloadVectorPriceTests, UpdateVectorPriceNullUpdate)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorPrice(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
     // TODO Check prototype for GetVectorPrice
-    m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 1, (void* const*) &m_out, &m_outSize);
+    m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 1, &m_out, &m_outSize);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
     EXPECT_EQ ((mama_size_t)VECTOR_SIZE, m_outSize);
 
@@ -4297,14 +4294,14 @@ TEST_F(PayloadVectorPriceTests, DISABLED_UpdateVectorPriceNullUpdate)
     EXPECT_EQ (MAMA_STATUS_NULL_ARG, m_status);
 }
 
-TEST_F(PayloadVectorPriceTests, DISABLED_UpdateVectorPriceNullMessage)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(PayloadVectorPriceTests, UpdateVectorPriceNullMessage)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorPrice(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
     // TODO Check prototype for GetVectorPrice
-    m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 1, (void* const*) &m_out, &m_outSize);
+    m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 1, &m_out, &m_outSize);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
     EXPECT_EQ ((mama_size_t)VECTOR_SIZE, m_outSize);
 
@@ -4323,20 +4320,20 @@ TEST_F(PayloadVectorPriceTests, DISABLED_UpdateVectorPriceNullMessage)
         FAIL();
     }
 
-    m_status = m_payloadBridge->msgPayloadUpdateVectorPrice(NULL, NULL, 1, (void* const**) m_update, VECTOR_UPDATE_SIZE);
+    m_status = m_payloadBridge->msgPayloadUpdateVectorPrice(NULL, NULL, 1, m_update, VECTOR_UPDATE_SIZE);
     EXPECT_EQ (MAMA_STATUS_NULL_ARG, m_status);
 }
 
 // GetVectorPrice test fixtures
 // ****************************
-TEST_F(PayloadVectorPriceTests, DISABLED_GetVectorPrice)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(PayloadVectorPriceTests, GetVectorPrice)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorPrice(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
     // TODO Check prototype for GetVectorPrice
-    m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 1, (void* const*) &m_out, &m_outSize);
+    m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 1, &m_out, &m_outSize);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
     EXPECT_EQ ((mama_size_t)VECTOR_SIZE, m_outSize);
 
@@ -4356,10 +4353,10 @@ TEST_F(PayloadVectorPriceTests, DISABLED_GetVectorPrice)
     }
 
     // TODO Interface Inconsistent
-    m_status = m_payloadBridge->msgPayloadUpdateVectorPrice(m_msg, NULL, 1, (void* const**) m_update, VECTOR_UPDATE_SIZE);
+    m_status = m_payloadBridge->msgPayloadUpdateVectorPrice(m_msg, NULL, 1, m_update, VECTOR_UPDATE_SIZE);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
-    m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 1, (void* const*) &m_out, &m_outSize);
+    m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 1, &m_out, &m_outSize);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
     EXPECT_EQ ((mama_size_t)VECTOR_UPDATE_SIZE, m_outSize);
 
@@ -4379,33 +4376,33 @@ TEST_F(PayloadVectorPriceTests, DISABLED_GetVectorPrice)
     }
 }
 
-TEST_F(PayloadVectorPriceTests, DISABLED_GetVectorPriceNullResult)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(PayloadVectorPriceTests, GetVectorPriceNullResult)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorPrice(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
     m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 1, NULL, &m_outSize);
     EXPECT_EQ (MAMA_STATUS_NULL_ARG, m_status);
 }
 
-TEST_F(PayloadVectorPriceTests, DISABLED_GetVectorPriceNullSize)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(PayloadVectorPriceTests, GetVectorPriceNullSize)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorPrice(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
-    m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 1, (void* const*) &m_out, NULL);
+    m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 1, &m_out, NULL);
     EXPECT_EQ (MAMA_STATUS_NULL_ARG, m_status);
 }
 
-TEST_F(PayloadVectorPriceTests, DISABLED_GetVectorPriceNotFound)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(PayloadVectorPriceTests, GetVectorPriceNotFound)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorPrice(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
-    m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 2, (void* const*) &m_out, &m_outSize);
+    m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 2, &m_out, &m_outSize);
     EXPECT_EQ (MAMA_STATUS_NOT_FOUND, m_status);
 }
 


### PR DESCRIPTION
# Feature mamamsg vector price datetime
## Summary
QPIDMSG: Added implementation for the vector price / time functions

## Areas Affected
*Place an 'x' within the braces to check the box*
- [x] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [x] Unit Tests
- [ ] Examples

## Details
This patch adds support for vector price / date time to the qpid payload
bridge. It's worth noting that the function prototypes have also been
updated to reflect the way in which these functions are actually
expected to behave. This makes the code easier to understand for third
party payload bridge developers, but has the unfortunate side effect
of producing warnings while compiling until the MAMA Msg interface
is updated to reflect the same function sets.

## Testing
All unit test pass which cover this functionality pretty well now, and I also compiled the omnm payload against this version to verify that it worked ok without introducing any problems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/163)
<!-- Reviewable:end -->
