### PR TITLE
PLAT-235: MAMDA: Using higher precision prices when creating unique i…

### DIFF
--- a/mamda/c_cpp/src/cpp/orderbooks/MamdaOrderBookListener.cpp
+++ b/mamda/c_cpp/src/cpp/orderbooks/MamdaOrderBookListener.cpp
@@ -1623,9 +1623,14 @@ namespace Wombat
                 // uniqueId is for the entry manager
                 char uniqueId[64];  /* catenate the price to the symbol */
                 char* uniqueIdPtr = uniqueId;
+
+                size_t places = (size_t) level->getMamaPrice ().getPrecision ();
+                if (places < MAMA_PRICE_PREC_10 || places > MAMA_PRICE_PREC_100000000)
+                    places = (size_t) MAMA_PRICE_PREC_100000000;
+
                 wmFastCopyAndShiftStr (&uniqueIdPtr, &lenAvail, id);
                 wmFastPrintAndShiftF64 (&uniqueIdPtr, &lenAvail,
-                                        level->getPrice(), 4); 
+                                        level->getPrice(), places);
                 uniqueIdPtr[0] = (char)level->getSide();
                 uniqueIdPtr[1] = '\0';
 


### PR DESCRIPTION
## Summary
Some price levels seen to not be tidied up due to a clash in unique id in the Entry Manager.
## Areas Affected
*Place an 'x' within the braces to check the box*
- [ ] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [x] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
Unique identifiers in the Entry Manager are used to identify each price level object. This change raises the precision(where possible) of the mamaPrice used to generate these identifiers, making it less likely for then to clash.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/164)
<!-- Reviewable:end -->
