### PR TITLE
Adding unit test for GetTransport()

### DIFF
--- a/mama/c_cpp/src/gunittest/c/publishertest.cpp
+++ b/mama/c_cpp/src/gunittest/c/publishertest.cpp
@@ -158,7 +158,7 @@ TEST_F (MamaPublisherTestC, CreateDestroy)
  *
  *  Expected Result: MAMA_STATUS_OK
  */
-TEST_F (MamaPublisherTestC, GetTransport)
+TEST_F (MamaPublisherTestC, GetTransportImpl)
 {
     mamaPublisher    publisher = NULL;
     mamaTransport    tport     = NULL;

--- a/mama/c_cpp/src/gunittest/c/publishertest.cpp
+++ b/mama/c_cpp/src/gunittest/c/publishertest.cpp
@@ -524,3 +524,36 @@ TEST_F (MamaPublisherTestC, EventSendWithCallbacksNoCallbacks)
     mamaPublisherCallbacks_deallocate(cb);
 }
 
+/*  Description:  Get the transport from the mamaPublisher and make sure its the same transport
+ *                that was used to create the publisher.
+ *
+ *  Expected Result: MAMA_STATUS_OK
+ */
+TEST_F (MamaPublisherTestC, GetTransport)
+{
+    mamaPublisher    publisher  = NULL;
+    mamaTransport    tport      = NULL;
+    const char*      source     = "SRC";
+    mamaTransport    aTransport = NULL;
+
+    ASSERT_EQ (MAMA_STATUS_OK,
+               mamaTransport_allocate (&tport));
+
+    ASSERT_EQ (MAMA_STATUS_OK,
+               mamaTransport_create (tport, "test_tport", mBridge));
+
+    ASSERT_EQ (MAMA_STATUS_OK,
+               mamaPublisher_create (&publisher, tport, source, NULL, NULL));
+
+    ASSERT_EQ (MAMA_STATUS_OK,
+               mamaPublisher_getTransport (publisher, &aTransport));
+
+    ASSERT_EQ (tport, aTransport);
+
+    ASSERT_EQ (MAMA_STATUS_OK,
+               mamaPublisher_destroy (publisher));
+
+    ASSERT_EQ (MAMA_STATUS_OK,
+               mamaTransport_destroy (tport));
+}
+


### PR DESCRIPTION
## Summary
Adding additional MamaPublisherTestC.GetTransport(). 
## Areas Affected
*Place an 'x' within the braces to check the box*
- [x] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [x] Unit Tests
- [ ] Examples

## Details
There was a previous test with this same name which did not actually explicitly call `mamaPublisher_getTransport`, but instead used `mamaPublisherImpl_getTransportImpl()`.  We have renamed the existing one to MamaPublisherTestC.GetTransportImpl to reflect this.(). 

## Testing
Both the new and renamed unit tests run and pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/165)
<!-- Reviewable:end -->
