### PR TITLE
MamdaSubscription incorrectly mapping MamaStatus to MamdaErrorCode

### DIFF
--- a/mama/jni/src/com/wombat/mama/MamaStatus.java
+++ b/mama/jni/src/com/wombat/mama/MamaStatus.java
@@ -83,6 +83,8 @@ public class MamaStatus
     public static final short MAMA_STATUS_NO_BRIDGE_IMPL              = 26;
     /** Invalid queue */
     public static final short MAMA_STATUS_INVALID_QUEUE               = 27;
+    /** Message Type DELETE  */
+    public static final short MAMA_STATUS_DELETE                      = 29;
     /** Not permissioned for the subject */
     public static final short MAMA_STATUS_NOT_PERMISSIONED            = 4001;
     /** Subscription is in an invalid state. */
@@ -91,7 +93,12 @@ public class MamaStatus
     public static final short MAMA_STATUS_QUEUE_OPEN_OBJECTS          = 5002;
     /** The function isn't supported for this type of subscription. */
     public static final short MAMA_STATUS_SUBSCRIPTION_INVALID_TYPE   = 5003;
-
+    /** A symbol has no subscribers. */
+    public static final short MAMA_STATUS_NO_SUBSCRIBERS              = 5006;
+    /** The symbol has expired. */
+    public static final short MAMA_STATUS_EXPIRED                     = 5007;
+    /** The application's bandwidth limit has been exceeded. */
+    public static final short MAMA_STATUS_BANDWIDTH_EXCEEDED          = 5008;
     /**
      * Return a text description of the message's status.
      *

--- a/mamda/java/com/wombat/mamda/MamdaErrorCode.java
+++ b/mamda/java/com/wombat/mamda/MamdaErrorCode.java
@@ -22,6 +22,7 @@
 package com.wombat.mamda;
 
 import com.wombat.mama.MamaMsgStatus;
+import com.wombat.mama.MamaStatus;
 
 /**
  * MamdaErrorCode defines MAMDA error codes.
@@ -108,7 +109,7 @@ public class MamdaErrorCode
         }
     }
 
-    public static short codeForMamaMsgStatus (short wombatStatus)
+    @Deprecated public static short codeForMamaMsgStatus (short wombatStatus)
     {
         switch (wombatStatus)
         {
@@ -129,6 +130,27 @@ public class MamdaErrorCode
         case MamaMsgStatus.STATUS_BANDWIDTH_EXCEEDED:   return MAMDA_ERROR_BANDWIDTH_EXCEEDED;
         case MamaMsgStatus.STATUS_EXCEPTION:            return MAMDA_ERROR_EXCEPTION;
         case MamaMsgStatus.STATUS_DELETE:               return MAMDA_ERROR_DELETE;
+        }
+
+        return -1;
+    }
+
+    public static short codeForMamaStatus (short wombatStatus)
+    {
+        switch (wombatStatus)
+        {
+
+        case MamaStatus.MAMA_STATUS_OK:                 return MAMDA_NO_ERROR;
+        case MamaStatus.MAMA_STATUS_NO_SUBSCRIBERS:     return MAMDA_ERROR_NO_SUBSCRIBERS;
+        case MamaStatus.MAMA_STATUS_BAD_SYMBOL:         return MAMDA_ERROR_BAD_SYMBOL;
+        case MamaStatus.MAMA_STATUS_EXPIRED:            return MAMDA_ERROR_EXPIRED;
+        case MamaStatus.MAMA_STATUS_TIMEOUT:            return MAMDA_ERROR_TIMEOUT;
+        case MamaStatus.MAMA_STATUS_PLATFORM:           return MAMDA_ERROR_PLATFORM_STATUS;
+        case MamaStatus.MAMA_STATUS_NOT_ENTITLED:       return MAMDA_ERROR_NOT_ENTITLED;
+        case MamaStatus.MAMA_STATUS_NOT_FOUND:          return MAMDA_ERROR_NOT_FOUND;
+        case MamaStatus.MAMA_STATUS_NOT_PERMISSIONED:   return MAMDA_ERROR_NOT_PERMISSIONED;
+        case MamaStatus.MAMA_STATUS_BANDWIDTH_EXCEEDED: return MAMDA_ERROR_BANDWIDTH_EXCEEDED;
+        case MamaStatus.MAMA_STATUS_DELETE:             return MAMDA_ERROR_DELETE;
         }
 
         return -1;

--- a/mamda/java/com/wombat/mamda/MamdaSubscription.java
+++ b/mamda/java/com/wombat/mamda/MamdaSubscription.java
@@ -566,7 +566,7 @@ public class MamdaSubscription
                  */
                 MamdaErrorListener listener =
                     (MamdaErrorListener)listeners.elementAt(i);
-                short errorCode = MamdaErrorCode.codeForMamaMsgStatus (wombatStatus);
+                short errorCode = MamdaErrorCode.codeForMamaStatus (wombatStatus);
                 listener.onError (
                     mSubscription,
                     MamdaErrorSeverity.severityForErrorCode (errorCode),


### PR DESCRIPTION
## Areas Affected
*Place an 'x' within the braces to check the box*
- [ ] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [x] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [x] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
MamdaSubscription was found to be incorrectly mapping a MamaStatus to a MamdaErrorCode.
This patch adds a new helper function `MamdaErrorCode.codeForMamaStatus` to fix this error.

Also added a few relevant MamaStatus'es which were missing from JNI.

## Testing
1) publish a message with status NOT_PERMISSIONED:
```./mamapublisherc -tport pub -msgstatus 12 -msgtype 21 -s CTA.SPY -l _MD.CTA -i 3```
2) subscribe to it:
```
java MamdaListen -tport sub -S CTA -s SPY -v -v -v -v
```

you'll get the following **without the fix**:
```
Error (SPY)Severity: 2 errorCode: -1 errorStr: UNKNOWN
```


With the fid, this will properly map to a NOT_PERMISSIONED error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/167)
<!-- Reviewable:end -->
