### PR TITLE
MAMAC publisher create double free

### DIFF
--- a/mama/c_cpp/src/c/publisher.c
+++ b/mama/c_cpp/src/c/publisher.c
@@ -207,7 +207,7 @@ _createByIndex (mamaPublisher*              result,
             mamaPublisherCallbacks_deallocate(cb);
             list_destroy (impl->mPendingActions, NULL, NULL);
             mamaPublisherImpl_cleanup (impl);
-			return status;
+            return status;
         }
     }
     mamaPublisherCallbacks_deallocate(cb);

--- a/mama/c_cpp/src/c/publisher.c
+++ b/mama/c_cpp/src/c/publisher.c
@@ -184,7 +184,6 @@ _createByIndex (mamaPublisher*              result,
                                     (mamaPublisher)impl)))) 
     {
         mamaPublisherImpl_cleanup (impl);
-        free (impl);
         return status;
     }
 
@@ -205,11 +204,10 @@ _createByIndex (mamaPublisher*              result,
                 impl->mClosure);
         if (MAMA_STATUS_OK != status)
         {
-            mamaPublisherImpl_cleanup (impl);
             mamaPublisherCallbacks_deallocate(cb);
             list_destroy (impl->mPendingActions, NULL, NULL);
-            free (impl);
-            return status;
+            mamaPublisherImpl_cleanup (impl);
+			return status;
         }
     }
     mamaPublisherCallbacks_deallocate(cb);


### PR DESCRIPTION
# Fix mamac publisher create double free
## Summary
Mama publisher _createByIndex frees mamaPublisherImpl* tice from heap on error code paths.
## Areas Affected

- [x] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
Removes free(impl) from _createByIndex in publisher.c which causes a core when bridge function calls return error status. 

This is a patch for issue https://github.com/OpenMAMA/OpenMAMA/issues/168


Signed-off-by: Chris Morgan <Christopher.Morgan@solacesystems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/169)
<!-- Reviewable:end -->
