### PR TITLE
PLAT-563: Core within mamaBridgeImpl_getInternalEventQueue() when CM …

### DIFF
--- a/mama/c_cpp/src/c/mama.c
+++ b/mama/c_cpp/src/c/mama.c
@@ -2537,6 +2537,9 @@ mama_loadBridgeWithPathInternal (mamaBridge* impl,
         goto error_handling_impl_allocated;
     }
 
+    /* Create the bridge lock */
+    (*impl)->mLock = wlock_create();
+
     /* Populate bridge meta data based on bridge's init properties */
     mamaBridgeImpl_populateBridgeMetaData (*impl);
 


### PR DESCRIPTION

## Summary
Create the bridge lock.

## Areas Affected
*Place an 'x' within the braces to check the box*
- [x] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
The bridge create lock was omitted when we done new bridge implementation

## Testing
If you enable the cm responder and run the example app mamalistenc for example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/170)
<!-- Reviewable:end -->
