### PR TITLE
PLAT-100: Mamda subscription deactivation failure

### DIFF
--- a/mamda/dotnet/src/cs/MamdaSubscription.cs
+++ b/mamda/dotnet/src/cs/MamdaSubscription.cs
@@ -256,8 +256,7 @@ namespace Wombat
 		{
 			if (mSubscription != null)
 			{
-				mSubscription.deallocate();
-				mSubscription = null;
+				mSubscription.destroyEx();
 			}
 		}
 
@@ -486,6 +485,8 @@ namespace Wombat
 			public void onDestroy (
 				MamaSubscription subscription)
 			{
+				subscription.deallocate ();
+				mSubscription = null;
 			}
 		}
 

--- a/mamda/java/com/wombat/mamda/MamdaSubscription.java
+++ b/mamda/java/com/wombat/mamda/MamdaSubscription.java
@@ -266,8 +266,7 @@ public class MamdaSubscription
     {
         if( mSubscription != null )
         {
-            mSubscription.destroy();
-            mSubscription = null;
+            mSubscription.destroyEx();
         }
         mValid = false;
     }  
@@ -608,7 +607,8 @@ public class MamdaSubscription
 
         public void onDestroy (MamaSubscription subscription)            
         {
-            // Do nothing
+            subscription.deallocate ();
+            mSubscription = null;
         }
     }
 }


### PR DESCRIPTION
## Summary
Calling MamdaSubscription.deactivate() in C# was resulting in an error / unhandled exception.

## Areas Affected
- [ ] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [x] MAMDADOTNET
- [x] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
Calling MamdaSubscription.deactivate() in C# was not working properly resulting in the following issue:

Could not deallocate mamaSubscription as it has not been destroyed.
Wombat.MamaException: mamaStatus: (MAMA_STATUS_SUBSCRIPTION_INVALID_STATE)

JAVA was also updated to reflect this change (however the same issue didn't not exist in JAVA)

## Testing
For testing I simply modified the MamdaListen C# example application and added the following into the onMsg() callback:

```c#
Console.WriteLine("Mamda subscription deactivate called.");
try
{
    subscription.deactivate();
}
catch (Exception)
{
    Console.WriteLine("Could not deactivate subscription");
}
```

C# Output, subscribing to the symbol "SPY" (Before)

```
Update (SPY)
Mamda subscription deactivate called.
Could not deactivate subscription
Update (SPY)
Mamda subscription deactivate called.
Could not deactivate subscription
...
...
```

C# Output (After)

```
Update (SPY)
Mamda subscription deactivate called.
```

and then no further updates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/171)
<!-- Reviewable:end -->
