### PR TITLE
PLAT-125: MamdaAuctionHandler getUncrossVolume does not decode F64 un…

### DIFF
--- a/mamda/dotnet/src/cs/MamdaAuctionListener.cs
+++ b/mamda/dotnet/src/cs/MamdaAuctionListener.cs
@@ -69,7 +69,7 @@ namespace Wombat
             cache.mEventSeqNum   = 0;
 
 			cache.mUncrossPrice.clear();
-			cache.mUncrossVolume = 0;
+			cache.mUncrossVolume = 0.0;
 			cache.mUncrossPriceIndStr = null;
 
             
@@ -141,9 +141,9 @@ namespace Wombat
 			return mAuctionCache.mUncrossPrice;
 		}
 
-		public long getUncrossVolume()
+		public double getUncrossVolume()
 		{
-			return (long) mAuctionCache.mUncrossVolume;
+			return mAuctionCache.mUncrossVolume;
 		}
 
         public long getUncrossPriceInd()

--- a/mamda/dotnet/src/cs/MamdaAuctionRecap.cs
+++ b/mamda/dotnet/src/cs/MamdaAuctionRecap.cs
@@ -45,7 +45,7 @@ namespace Wombat
 		/// Get the uncross Volume.
 		/// </summary>
 		/// <returns>Indicative Volume or the volume turned over in the auction</returns>
-		long getUncrossVolume();
+		double getUncrossVolume();
 
         /// <summary>
         /// Get the field state

--- a/mamda/dotnet/src/cs/MamdaAuctionUpdate.cs
+++ b/mamda/dotnet/src/cs/MamdaAuctionUpdate.cs
@@ -45,7 +45,7 @@ namespace Wombat
 		/// Get the uncross Volume.
 		/// </summary>
 		/// <returns>Indicative Volume or the volume turned over in the auction</returns>
-		long getUncrossVolume();
+		double getUncrossVolume();
 
         /// <summary>
         /// Get the field state

--- a/mamda/java/com/wombat/mamda/MamdaAuctionListener.java
+++ b/mamda/java/com/wombat/mamda/MamdaAuctionListener.java
@@ -67,7 +67,7 @@ public class MamdaAuctionListener implements MamdaMsgListener,
     public MamaString       mSymbol                = new MamaString();
 
     public MamaPrice            mUncrossPrice      = new MamaPrice();
-    public MamaLong             mUncrossVolume     = new MamaLong();
+    public MamaDouble           mUncrossVolume     = new MamaDouble();
     public MamdaUncrossPriceInd mUncrossPriceInd   = new MamdaUncrossPriceInd();
         
     public MamdaFieldState  mSrcTimeFieldState     = new MamdaFieldState();
@@ -85,9 +85,6 @@ public class MamdaAuctionListener implements MamdaMsgListener,
     public MamdaFieldState  mUncrossVolumeFieldState   = new MamdaFieldState();
     public MamdaFieldState  mUncrossPriceIndFieldState = new MamdaFieldState();
 
-    public MamaPrice        tmpPrice        = new MamaPrice();
-    public MamaDouble       tmpDouble       = new MamaDouble();
-   
     /**
      * clearCache - clears all cached data by resetting to 
      * default values.
@@ -106,7 +103,7 @@ public class MamdaAuctionListener implements MamdaMsgListener,
         mSymbol.setValue      (null);  mSymbolFieldState.setState      (MamdaFieldState.NOT_INITIALISED);
       
         mUncrossPrice.clear     ();
-        mUncrossVolume.setValue (0);
+        mUncrossVolume.setValue (0.0);
         mUncrossPriceInd.set    (MamdaUncrossPriceInd.UNCROSS_NONE);
       
         mUncrossPriceFieldState.setState    (MamdaFieldState.NOT_INITIALISED);
@@ -232,9 +229,9 @@ public class MamdaAuctionListener implements MamdaMsgListener,
      * getUncrossVolume
      * @return mUncrossVolume
      */
-    public long getUncrossVolume()
+    public MamaDouble getUncrossVolume()
     {
-        return mUncrossVolume.getValue();
+        return mUncrossVolume;
     }
 
     /**
@@ -670,7 +667,7 @@ public class MamdaAuctionListener implements MamdaMsgListener,
         public void onUpdate (MamdaAuctionListener listener,
                               MamaMsgField         field)
         {
-            listener.mUncrossVolume.setValue (field.getI64());
+            listener.mUncrossVolume.setValue (field.getF64());
             listener.mUncrossVolumeFieldState.setState (MamdaFieldState.MODIFIED);
         }
 

--- a/mamda/java/com/wombat/mamda/MamdaAuctionRecap.java
+++ b/mamda/java/com/wombat/mamda/MamdaAuctionRecap.java
@@ -39,9 +39,9 @@ public interface MamdaAuctionRecap extends MamdaBasicRecap
     /**
      * Get the uncross vol.
      *
-     * @return Ask price.   The indicative volume, or the volume turned over in the auction 
+     * @return uncross price.   The indicative volume, or the volume turned over in the auction 
      */    
-    long  getUncrossVolume();
+    MamaDouble  getUncrossVolume();
 
     /**
      * Get the uncross price Ind.

--- a/mamda/java/com/wombat/mamda/MamdaAuctionUpdate.java
+++ b/mamda/java/com/wombat/mamda/MamdaAuctionUpdate.java
@@ -43,7 +43,7 @@ public interface MamdaAuctionUpdate extends MamdaBasicEvent
      *
      * @return Ask price.   The indicative volume, or the volume turned over in the auction 
      */    
-    long  getUncrossVolume();
+    MamaDouble  getUncrossVolume();
 
     /**
      * Get the uncross price Ind.


### PR DESCRIPTION
## Summary
MamdaAuctionHandler getUncrossVolume() was incorrectly decoding uncross volumes

## Areas Affected
- [ ] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [x] MAMDADOTNET
- [x] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
Changes to both Java and C# to fix and issue in the MamdaAuctionListener class where we were attempting to read the volume as an I64 rather than a F64.

Includes some minor tidy-ups - removal of some unused variables

Signed-off-by: Gary Molloy <g.molloy@srtechlabs.com>

## Testing

Output from the example Java auctionticker application:

(BEFORE)
```
Auction Update (FIBH6)
Uncross Price: 18215.0(1), Uncross Vol:0(0), Uncross Price Ind:F(1) 
```

(AFTER)
```
Auction Update (FIBH6)
Uncross Price: 18215.0(1), Uncross Vol:45.0(0), Uncross Price Ind:F(1) 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/173)
<!-- Reviewable:end -->
