### PR TITLE
PLAT-493: Keeping track of CPP wrappers to default queue

### DIFF
--- a/mama/c_cpp/src/cpp/MamaQueue.cpp
+++ b/mama/c_cpp/src/cpp/MamaQueue.cpp
@@ -525,10 +525,7 @@ namespace Wombat
 
     void MamaQueue::setCValue (mamaQueue cQueue)
     {
-        if (!mQueue) 
-        {
-            mQueue = cQueue;
-        }
+        mQueue = cQueue;
     }
 
     void MamaQueue::setClosure (void* closure)

--- a/mama/c_cpp/src/cpp/mama/mamacpp.h
+++ b/mama/c_cpp/src/cpp/mama/mamacpp.h
@@ -511,7 +511,7 @@ private:
     /**
      * vector of MamaQueue pointers to be tidied up at Mama::close()
      */
-    static std::vector<MamaQueue*> defaultQueueWrappers;
+    static std::vector<MamaQueue*> mDefaultQueueWrappers;
 
 };
 

--- a/mama/c_cpp/src/cpp/mama/mamacpp.h
+++ b/mama/c_cpp/src/cpp/mama/mamacpp.h
@@ -507,6 +507,12 @@ private:
      * Utility class. No instances.
      */
     Mama (void) {}
+
+    /**
+     * vector of MamaQueue pointers to be tidied up at Mama::close()
+     */
+    static std::vector<MamaQueue*> defaultQueueWrappers;
+
 };
 
 } /* namespace Wombat */

--- a/mama/c_cpp/src/cpp/mamacpp.cpp
+++ b/mama/c_cpp/src/cpp/mamacpp.cpp
@@ -37,7 +37,7 @@ namespace Wombat
     /******************************************************************************
      * Mama Implementation
      */
-    std::vector<MamaQueue*> Mama::defaultQueueWrappers;
+    std::vector<MamaQueue*> Mama::mDefaultQueueWrappers;
 
     const char* Mama::getVersion (mamaBridge bridgeImpl)
     {
@@ -154,7 +154,7 @@ namespace Wombat
     void Mama::close ()
     {
         // Close mama
-        for (std::vector<MamaQueue*>::iterator iter = Mama::defaultQueueWrappers.begin(); iter != Mama::defaultQueueWrappers.end(); ++iter)
+        for (std::vector<MamaQueue*>::iterator iter = Mama::mDefaultQueueWrappers.begin(); iter != Mama::mDefaultQueueWrappers.end(); ++iter)
         {
             MamaQueue* defaultQueue = *iter;
 
@@ -164,7 +164,7 @@ namespace Wombat
 
         }
 
-        Mama::defaultQueueWrappers.clear();
+        Mama::mDefaultQueueWrappers.clear();
 
         mamaTry (mama_close ());
     }
@@ -297,7 +297,7 @@ namespace Wombat
             {
                 defaultQueue = new MamaQueue(defaultQueueC);
                 mamaQueue_setClosure(defaultQueueC, (void*) defaultQueue);
-                Mama::defaultQueueWrappers.push_back(defaultQueue);
+                Mama::mDefaultQueueWrappers.push_back(defaultQueue);
             }
             return defaultQueue;
         }

--- a/mama/c_cpp/src/cpp/mamacpp.cpp
+++ b/mama/c_cpp/src/cpp/mamacpp.cpp
@@ -37,6 +37,7 @@ namespace Wombat
     /******************************************************************************
      * Mama Implementation
      */
+    std::vector<MamaQueue*> Mama::defaultQueueWrappers;
 
     const char* Mama::getVersion (mamaBridge bridgeImpl)
     {
@@ -153,6 +154,18 @@ namespace Wombat
     void Mama::close ()
     {
         // Close mama
+        for (std::vector<MamaQueue*>::iterator iter = Mama::defaultQueueWrappers.begin(); iter != Mama::defaultQueueWrappers.end(); ++iter)
+        {
+            MamaQueue* defaultQueue = *iter;
+
+            defaultQueue->setCValue(NULL);  // middleware  bridge's respobsibility to clean up the c-queue
+
+            delete(defaultQueue);           //delete CPP wrapper
+
+        }
+
+        Mama::defaultQueueWrappers.clear();
+
         mamaTry (mama_close ());
     }
 
@@ -284,6 +297,7 @@ namespace Wombat
             {
                 defaultQueue = new MamaQueue(defaultQueueC);
                 mamaQueue_setClosure(defaultQueueC, (void*) defaultQueue);
+                Mama::defaultQueueWrappers.push_back(defaultQueue);
             }
             return defaultQueue;
         }


### PR DESCRIPTION
## Areas Affected
*Place an 'x' within the braces to check the box*
- [ ] MAMAC
- [x] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
Currently, it is the responsibility of the middleware bridge to clean up it's default queue. In CPP, `Mama::getDefaultEventQueue` returns a CPP wrapper to this c-level queue. 

The wrapper is not tidied up and manually deleting could lead to a double free (mamaQueue::destroy tells the mw bridge to clean up the queue, which may be done again on bridge_close).

This patch keeps a track of any CPP wrappers made to default queues and cleans them up in Mama::close. This way the developer does not have to keep track of the default Queue wrapper created.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/174)
<!-- Reviewable:end -->
