### PR TITLE
PLAT-318: No BOOK RECAP during FT takeover when dqstrategy=ignoredups…

### DIFF
--- a/mama/c_cpp/src/c/dqstrategy.c
+++ b/mama/c_cpp/src/c/dqstrategy.c
@@ -291,10 +291,10 @@ dqStrategy_checkSeqNum (dqStrategy      strategy,
 
         /* For late joins or middlewares that support a publish cache, it is possible that you will get old updates
            in this case take no action */
-        if (DQ_SCHEME_INGORE_DUPS==mamaTransportImpl_getDqStrategyScheme(tport))
+        if (DQ_SCHEME_INGORE_DUPS == mamaTransportImpl_getDqStrategyScheme(tport))
         {
-            if ((seqNum <= ctxSeqNum) && ((ctxDqState != DQ_STATE_WAITING_FOR_RECAP) ||
-                                          (ctxDqState != DQ_STATE_WAITING_FOR_RECAP_AFTER_FT)))
+            if ((seqNum <= ctxSeqNum) && ((ctx->mDQState != DQ_STATE_WAITING_FOR_RECAP) &&
+                                          (ctx->mDQState != DQ_STATE_WAITING_FOR_RECAP_AFTER_FT)))
             {
                 ctx->mDoNotForward = 1;
                 return MAMA_STATUS_OK;
@@ -385,13 +385,37 @@ dqStrategy_checkSeqNum (dqStrategy      strategy,
     case MAMA_MSG_TYPE_BOOK_RECAP   :
     /* For late joins or middlewares that support a publish cache, it is possible that you will get old updates
        in this case take no action */
-        if (DQ_SCHEME_INGORE_DUPS==mamaTransportImpl_getDqStrategyScheme(tport))
+        if (DQ_SCHEME_INGORE_DUPS == mamaTransportImpl_getDqStrategyScheme(tport))
         {
-            if ((seqNum <= ctxSeqNum) && ((ctxDqState != DQ_STATE_WAITING_FOR_RECAP) ||
-                                          (ctxDqState != DQ_STATE_WAITING_FOR_RECAP_AFTER_FT)))
+            if (MAMA_MSG_TYPE_RECAP == msgType)
             {
-                ctx->mDoNotForward = 1;
-                return MAMA_STATUS_OK;
+                /* Feed-handlers maintain sequence number for a Record FT Recap. */
+                if ((seqNum <= ctxSeqNum) && ((ctx->mDQState != DQ_STATE_WAITING_FOR_RECAP) &&
+                                              (ctx->mDQState != DQ_STATE_WAITING_FOR_RECAP_AFTER_FT)))
+                {
+                    ctx->mDoNotForward = 1;
+                    return MAMA_STATUS_OK;
+                }
+            }
+            else if (MAMA_MSG_TYPE_BOOK_RECAP == msgType)
+            {
+                if (0 == seqNum && ctxSeqNum > 0)
+                {
+                    /* Special case of an FT Order Book Recap where a SeqNum of 0 is used. */
+                    if (ctx->mDQState != DQ_STATE_WAITING_FOR_RECAP_AFTER_FT)
+                    {
+                        ctx->mDoNotForward = 1;
+                        return MAMA_STATUS_OK;
+                    }
+                }
+                /* Solicited Recap from Feed-Handler or
+                 * solicited / unsolicited Recap from mid-tier. */
+                else if ((seqNum <= ctxSeqNum) && ((ctx->mDQState != DQ_STATE_WAITING_FOR_RECAP) &&
+                                                   (ctx->mDQState != DQ_STATE_WAITING_FOR_RECAP_AFTER_FT)))
+                {
+                    ctx->mDoNotForward = 1;
+                    return MAMA_STATUS_OK;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
No book recaps seen after FT takeover

## Areas Affected
- [x] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
Book recaps were being ignored with dqstrategy=ignoredups and ftstrategy=waitforrecap
set at the same time

Signed-off-by: Gary Molloy <g.molloy@srtechlabs.com>

## Testing
To test this simply put the following into your mama.properties: 

 mama.transport.<tport>.dqstrategy=ignoredups 
 mama.transport.<tport>.ftstrategy=waitforrecap 

Run 2 publishers in a fault tolerant pair, subscribe to a book symbol and after a short time kill the primary publisher. 

BEFORE: 
```
 .CTA.bSPY.AMX Type: BOOK_UPDATE Status OK 
   MdMsgType | 1 | U8 | 17 
   MdSeqNum | 10 | U32 | 375 
   MamaSenderId | 20 | U64 | 72058139498782336 
 Transport callback: DISCONNECT 
 Quality changed to MAYBE_STALE for bSPY.AMX, cause 12, platformInfo: 
 Transport callback: PUBLISHER_DISCONNECT 
 ... 
 2016-04-25 16:30:49: dqStrategy_checkSeqNum(): bSPY.AMX : seq# 1 
 2016-04-25 16:30:49: Subscription for bSPY.AMX not forwarded as message seqnum is before seqnum expecting 
 2016-04-25 16:30:49: dqStrategy_checkSeqNum(): bSPY.AMX : seq# 2 
 ... 
 2016-04-25 16:31:10: Subscription for bSPY.AMX not forwarded as message seqnum is before seqnum expecting 
 2016-04-25 16:31:10: dqStrategy_checkSeqNum(): bSPY.AMX : seq# 375 
 2016-04-25 16:31:10: Subscription for bSPY.AMX not forwarded as message seqnum is before seqnum expecting 
 2016-04-25 16:31:10: dqStrategy_checkSeqNum(): bSPY.AMX : seq# 376 
 Transport callback: QUALITY 
 Quality changed to OK for bSPY.AMX, cause 0, platformInfo: 
 .CTA.bSPY.AMX Type: BOOK_UPDATE Status OK 
   MdMsgType | 1 | U8 | 17 
   MdSeqNum | 10 | U32 | 376 
   MamaSenderId | 20 | U64 | 72058139498782351 
```
No book recap and the next update is the next seqnum following on from when the ft takeover occurred... 

AFTER: 
```
 .CTA.bSPY.AMX Type: BOOK_UPDATE Status OK 
   MdMsgType | 1 | U8 | 17 
   MdSeqNum | 10 | U32 | 218 
   MamaSenderId | 20 | U64 | 72058139498782463 
 Transport callback: DISCONNECT 
 Quality changed to MAYBE_STALE for bSPY.AMX, cause 12, platformInfo: 
 Transport callback: PUBLISHER_DISCONNECT 
 ... 
 Quality changed to OK for bSPY.AMX, cause 0, platformInfo: 
 .CTA.bSPY.AMX Type: BOOK_RECAP Status OK 
   MdMsgType | 1 | U8 | 19 
   MdSeqNum | 10 | U32 | 3 
   MamaSenderId | 20 | U64 | 72058139498782472 
```
 You can see that we now get the book recap. 
 In my test the book recap came in seqnum #3, but it could also have been 0, 1 etc....

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/176)
<!-- Reviewable:end -->
