### PR TITLE
[PLAT-383] - Additional NULL check before string.h function calls added.

### DIFF
--- a/mama/c_cpp/src/c/subscription.c
+++ b/mama/c_cpp/src/c/subscription.c
@@ -1738,6 +1738,10 @@ mamaSubscription_setSymbol (
 {
     if (!subscription) return MAMA_STATUS_NULL_ARG;
     checkFree (&self->mUserSymbol);
+    if (!symbol)
+    {
+        symbol = "";
+    }
     self->mUserSymbol = strdup(symbol);
     return MAMA_STATUS_OK;
 }
@@ -2487,6 +2491,11 @@ isEntitledToSymbol (const char *source, const char*symbol, mamaSubscription subs
 
 char* copyString (const char*  str)
 {
+    if (!str)
+    {
+        str = "";
+    }
+
     /* Windows does not like strdup */
     size_t len = strlen (str) + 1;
     char* result = (char*)calloc (len, sizeof (char));


### PR DESCRIPTION
# [PLAT-383] mamaSubscription_create core dumps when a NULL symbol is used
## Summary
mamaSubscription_create core dumps when a NULL symbol is used. Additional NULL check before string.h function calls is needed.

## Areas Affected
- [x] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
 Check for NULL pointers in all calls to string.h functions in the subscription functions.

## Testing
Use of a NULL symbol in a symbol list subscription

Signed-off-by: Marti Queralt <m.queralt@daxplat01v.srl.srtechlabs.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/177)
<!-- Reviewable:end -->
