### PR TITLE
PLAT-537: segfault  in oea entitlement bridge

### DIFF
--- a/mama/c_cpp/src/c/entitlement/oea/oea.c
+++ b/mama/c_cpp/src/c/entitlement/oea/oea.c
@@ -107,15 +107,6 @@ oeaEntitlementBridge_init(entitlementBridge* bridge)
         return status;
     }
 
-    oeaClient* oClient = malloc(sizeof(oeaEntitlementBridge));
-    if (NULL == oClient)
-    {
-        mama_log(MAMA_LOG_LEVEL_SEVERE,
-                 "Could not allocate memory for oea entitlements bridge.");
-        status = MAMA_STATUS_NOMEM;
-        goto initFreeBridge;
-    }
-
     if (NULL == (entitlementServers = oeaEntitlmentBridge_parseServersProperty()))
     {
         goto initFreeClientAndBridge;
@@ -168,7 +159,7 @@ oeaEntitlementBridge_init(entitlementBridge* bridge)
                  "oeaEntitlementBridge_init: Error creating oea client[%s].",
                  mamaStatus_stringForStatus((mama_status) entitlementStatus));
         status = (mama_status) entitlementStatus;  /* oea status codes match MAMA so cast is safe. */
-        goto initFreeClientAndBridge;
+        goto initFreeBridge;
 
     }
 
@@ -214,7 +205,7 @@ oeaEntitlementBridge_init(entitlementBridge* bridge)
     return MAMA_STATUS_OK;
 
 initFreeClientAndBridge:
-    free(oClient);
+    oeaClient_destroy(oClient);
 initFreeBridge:
     free(oeaBridge);
     return status;


### PR DESCRIPTION
## Summary
Core seen when using a misconfigures altuserid with OEA entitlements.
Root cause is seen to be memory management in oeaEntitlementBridge.
## Areas Affected
- [x] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Testing
Checked with both basic and market data subscriptions using OEA entitlements.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/178)
<!-- Reviewable:end -->
