### PR TITLE
[PLAT-481] - Guard incrementObjectCount() with a check to make sure it is not a snapshot subscription

### DIFF
--- a/mama/c_cpp/src/c/subscription.c
+++ b/mama/c_cpp/src/c/subscription.c
@@ -980,7 +980,11 @@ mamaSubscription_initialize (mamaSubscription subscription)
         configureForMultipleTopics (subscription);
     }
 
-    self->mLockHandle = mamaQueue_incrementObjectCount(self->mQueue, subscription);
+    if (self->mSubscMsgType != MAMA_SUBSC_DDICT_SNAPSHOT &&
+        self->mSubscMsgType != MAMA_SUBSC_SNAPSHOT)
+    {
+        self->mLockHandle = mamaQueue_incrementObjectCount(self->mQueue, subscription);
+    }
 
     if (gGenerateQueueStats)
     {


### PR DESCRIPTION
# [PLAT-481] Snapshot subscription does not shutdown cleanly
## Summary
Don't call incrementObjectCount() when we use snapshot subscription because it will cause an endless loop on the destroy side.

## Areas Affected
*Place an 'x' within the braces to check the box*
- [x] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
The fix here is guard incrementObjectCount() in mamaSubscriptionImpl_completeMarketDataInitialisation() with a check to make sure it is not a snapshot subscription.

## Testing
Configure mamalistenc to listen to the feed using a snapshot subscription and kill the client.

Signed-off-by: Marti Queralt <m.queralt@daxplat01v.srl.srtechlabs.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/179)
<!-- Reviewable:end -->
