### PR TITLE
[PLAT-540] - Correcting possible junk return value in mamaSubscription_processMsg

### DIFF
--- a/mama/c_cpp/src/c/subscription.c
+++ b/mama/c_cpp/src/c/subscription.c
@@ -2268,8 +2268,8 @@ mamaSubscription_processMsg (mamaSubscription subscription, mamaMsg msg)
         mamaSubscription_forwardMsg (self, msg);
 
         /*Do not access subscription here as it mey have been deleted/destroyed*/
-        return MAMA_STATUS_OK;
     }
+    return MAMA_STATUS_OK;
 }
 
 mama_status


### PR DESCRIPTION
# [PLAT-540] - mamaSubscription_processMsg() failing across all platforms
## Summary
The following failure can be seen across all languages: 'mamaSubscription_processMsg() failed. [6342112]'

## Areas Affected
*Place an 'x' within the braces to check the box*
- [x] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
I only affected the logging. Basically the workaround here is correcting the possible case where we are returning junk value inside mamaSubscription_processMsg().

## Testing
It can be easily replicated using FH/PUB + SUB (i.e, mamalistencpp).

Signed-off-by: Marti Queralt <m.queralt@daxplat01v.srl.srtechlabs.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/180)
<!-- Reviewable:end -->
