### PR TITLE
COMMON: Added support for format strings when evaluating properties

### DIFF
--- a/common/c_cpp/src/c/property.c
+++ b/common/c_cpp/src/c/property.c
@@ -336,7 +336,7 @@ properties_GetPropertyValueUsingFormatString (wproperty_t handle,
     char        paramName[PROPERTY_NAME_MAX_LENGTH];
     const char* returnVal = NULL;
 
-    /* Create list for storing the propertys passed in */
+    /* Create list for storing the properties passed in */
     va_list     arguments;
 
     /* Populate list with arguments passed in */

--- a/common/c_cpp/src/c/property.c
+++ b/common/c_cpp/src/c/property.c
@@ -21,6 +21,7 @@
 
 #include "wombat/port.h"
 
+#include <stdarg.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -31,6 +32,7 @@
 #include "propertyinternal.h"
 #include "lookup2.h"
 #include "wombat/wtable.h"
+#include "wombat/strutils.h"
 
 #define KEY_BLOCK_SIZE 64
 
@@ -300,21 +302,7 @@ properties_Merge( wproperty_t to, wproperty_t from )
 int
 properties_GetPropertyValueAsBoolean(const char* propertyValue)
 {
-  if (
-      (strcmp(propertyValue,"1")==0) ||
-      (strcmp(propertyValue,"y")==0) ||
-      (strcmp(propertyValue,"Y")==0) ||
-      (strcmp(propertyValue,"yes")==0) ||
-      (strcmp(propertyValue,"YES")==0) ||
-      (strcmp(propertyValue,"true")==0) ||
-      (strcmp(propertyValue,"TRUE")==0) ||
-      (strcmp(propertyValue,"t")==0) ||
-      (strcmp(propertyValue,"T")==0)
-    )
-  {
-    return 1;
-  }
-  return 0;
+    return strtobool(propertyValue);
 }
 
 /**
@@ -337,6 +325,39 @@ properties_Get( wproperty_t handle, const char* name )
     if( gPropertyDebug )fprintf( stderr, "Get property: %s\n", rval );
 
     return rval;
+}
+
+const char*
+properties_GetPropertyValueUsingFormatString (wproperty_t handle,
+                                              const char* defaultVal,
+                                              const char* format,
+                                              ...)
+{
+    char        paramName[PROPERTY_NAME_MAX_LENGTH];
+    const char* returnVal = NULL;
+
+    /* Create list for storing the propertys passed in */
+    va_list     arguments;
+
+    /* Populate list with arguments passed in */
+    va_start (arguments, format);
+
+    /* Create the complete transport property string */
+    vsnprintf (paramName, PROPERTY_NAME_MAX_LENGTH, format, arguments);
+
+    /* Get the property out for analysis */
+    returnVal = properties_Get (handle, paramName);
+
+    /* Properties will return NULL if property is not specified in configs */
+    if (returnVal == NULL)
+    {
+        returnVal = defaultVal;
+    }
+
+    /* Clean up the list */
+    va_end(arguments);
+
+    return returnVal;
 }
 
 int

--- a/common/c_cpp/src/c/property.h
+++ b/common/c_cpp/src/c/property.h
@@ -28,7 +28,9 @@
 extern "C" {
 #endif
 
-#define INVALID_PROPERTIES NULL
+#define     INVALID_PROPERTIES              NULL
+#define     PROPERTY_NAME_MAX_LENGTH        1024L
+
 typedef void* wproperty_t;
 
 typedef void( *propertiesCallback) (const char* name, const char* value,
@@ -107,6 +109,13 @@ properties_FreeEx2( wproperty_t handle );
 COMMONExpDLL
 int 
 properties_GetPropertyValueAsBoolean( const char* propertyValue );
+
+COMMONExpDLL
+const char*
+properties_GetPropertyValueUsingFormatString (wproperty_t handle,
+                                              const char* defaultVal,
+                                              const char* format,
+                                              ...);
 
 /**
  * Will escape the chars with a \ found to match in chars array. Returns a 

--- a/mama/c_cpp/src/c/bridge/qpid/endpointpool.h
+++ b/mama/c_cpp/src/c/bridge/qpid/endpointpool.h
@@ -43,6 +43,8 @@ typedef void* endpoint_t;
 extern "C" {
 #endif
 
+typedef void (*endpointDestroyCb)(endpoint_t endpoint);
+
 /*=========================================================================
   =                  Public implementation functions                      =
   =========================================================================*/
@@ -73,6 +75,21 @@ endpointPool_create                     (endpointPool_t*    endpoints,
 mama_status
 endpointPool_destroy                    (endpointPool_t     endpoints);
 
+/**
+ * This function is responsible for destroying the endpoint pool implementation
+ * provided and releasing all memory associated with the pool itself as well as
+ * its underlying dependencies. Includes callback to clean up cascading
+ * dependencies.
+ *
+ * @param endpoints The endpoint pool to be destroyed.
+ * @param callback  The callback to trigger to clean up the endpoint itself (or
+ *                  NULL if not applicable).
+ *
+ * @return mama_status indicating whether the method succeeded or failed.
+ */
+mama_status
+endpointPool_destroyWithCallback        (endpointPool_t     endpoints,
+                                         endpointDestroyCb  callback);
 /**
  * This will register a supplied endpoint in the pool according to the unique
  * identifier and topic provided. The combination of topic and identifier
@@ -168,7 +185,7 @@ endpointPool_getName                    (endpointPool_t     endpoints,
  * this pool)
  *
  * @param endpoints  The endpoint pool to query.
- * @param name       The topic to match on.
+ * @param topic      The topic to match on.
  * @param content    The opaque content to look for.
  *
  * @return mama_status indicating whether the method succeeded or failed.
@@ -178,6 +195,22 @@ endpointPool_isRegistedByContent        (endpointPool_t     endpoints,
                                          const char*        topic,
                                          void*              content);
 
+/**
+ * This will find a list of endpoints in the pool according to the provided
+ * topic and identifier.
+ *
+ * @param endpoints  The endpoint pool to query.
+ * @param topic      The topic to match on.
+ * @param identifier The identifier to match on.
+ * @param endpoint   The matching endpoint to return.
+ *
+ * @return mama_status indicating whether the method succeeded or failed.
+ */
+mama_status
+endpointPool_getEndpointByIdentifiers   (endpointPool_t     endpoints,
+                                         const char*        topic,
+                                         const char*        identifier,
+                                         endpoint_t*        endpoint);
 
 #if defined(__cplusplus)
 }

--- a/mama/c_cpp/src/c/bridge/qpid/qpiddefs.h
+++ b/mama/c_cpp/src/c/bridge/qpid/qpiddefs.h
@@ -54,6 +54,7 @@ extern "C" {
 /* Default timeout for send working threads */
 #define     QPID_MESSENGER_SEND_TIMEOUT     -1
 #define     QPID_MESSENGER_TIMEOUT          1 /* milliseconds */
+#define     QPID_PUBLISHER_RETRIES          3
 
 /* Message types */
 typedef enum qpidMsgType_
@@ -149,6 +150,13 @@ struct qpidMsgNode_
   qpidSubscription*     mQpidSubscription;
   qpidTransportBridge*  mQpidTransportBridge;
 };
+
+typedef struct qpidP2pEndpoint_
+{
+    char                  mUrl[MAX_URI_LENGTH];
+    size_t                mMsgCount;
+    size_t                mErrorCount;
+} qpidP2pEndpoint;
 
 #if defined(__cplusplus)
 }

--- a/mama/c_cpp/src/c/bridge/qpid/transport.c
+++ b/mama/c_cpp/src/c/bridge/qpid/transport.c
@@ -74,7 +74,7 @@
 #define     DEFAULT_RECV_BLOCK_SIZE         10
 
 /* Non configurable runtime defaults */
-#define     PN_MESSENGER_TIMEOUT            10
+#define     PN_MESSENGER_TIMEOUT            100
 #define     PARAM_NAME_MAX_LENGTH           1024L
 #define     MIN_SUB_POOL_SIZE               1L
 #define     MAX_SUB_POOL_SIZE               30000L
@@ -242,13 +242,13 @@ static void
 qpidBridgeMamaTransportImpl_stopProtonMessenger (pn_messenger_t* messenger);
 
 /**
- * This function is a wrapper for pn_messenger_stop as it caused deadlock
- * until qpid proton 0.5.
+ * This is a callback function to clean up any created endpoints.
  *
- * @param messenger  The messenger to free.
+ * @param endpoint   The endpoint to release resources for
  */
-static void
-qpidBridgeMamaTransportImpl_freeProtonMessenger (pn_messenger_t* messenger);
+void
+destroyQpidEndpoint (endpoint_t endpoint);
+
 
 /*=========================================================================
   =               Public interface implementation functions               =
@@ -290,11 +290,11 @@ qpidBridgeMamaTransport_destroy (transportBridge transport)
     pn_message_free(impl->mMsg);
 
     /* Macro wrapped as these caused deadlock prior to v0.5 of qpid proton */
-    qpidBridgeMamaTransportImpl_freeProtonMessenger (impl->mIncoming);
-    qpidBridgeMamaTransportImpl_freeProtonMessenger (impl->mOutgoing);
+    pn_messenger_free (impl->mIncoming);
+    pn_messenger_free (impl->mOutgoing);
 
     endpointPool_destroy (impl->mSubEndpoints);
-    endpointPool_destroy (impl->mPubEndpoints);
+    endpointPool_destroyWithCallback (impl->mPubEndpoints, destroyQpidEndpoint);
 
     /* Free the strdup-ed keys still held by the wtable */
     wtable_free_all_xdata (impl->mKnownSources);
@@ -1318,7 +1318,7 @@ void* qpidBridgeMamaTransportImpl_dispatchThread (void* closure)
 
             /* Move to the first element inside */
             pn_data_next     (properties); /* Move past first NULL byte */
-            pn_data_get_map(properties);
+            pn_data_get_map  (properties);
             pn_data_enter    (properties); /* Enter into meta map */
 
             int found = 0;
@@ -1349,9 +1349,10 @@ void* qpidBridgeMamaTransportImpl_dispatchThread (void* closure)
                 break;
             case QPID_MSG_SUB_REQUEST:
             {
-                pn_data_t*  data            = pn_message_body (msgNode->mMsg);
-                const char* topic           = NULL;
-                const char* replyTo         = NULL;
+                pn_data_t*    data            = pn_message_body (msgNode->mMsg);
+                const char*   topic           = NULL;
+                const char*   replyTo         = NULL;
+                qpidP2pEndpoint* endpoint     = NULL;
 
                 /* Move to the content which will contain the topic */
                 pn_data_next (data);
@@ -1365,11 +1366,47 @@ void* qpidBridgeMamaTransportImpl_dispatchThread (void* closure)
                           topic,
                           replyTo);
 
-                endpointPool_registerWithIdentifier (impl->mPubEndpoints,
-                                                     topic,
-                                                     replyTo,
-                                                     NULL);
-                pn_data_exit (properties);
+                if (QPID_TRANSPORT_TYPE_P2P ==
+                        qpidBridgeMamaTransportImpl_getType ((transportBridge) impl))
+                {
+                    /* Try and recycle existing endpoint */
+                    endpointPool_getEndpointByIdentifiers (impl->mPubEndpoints,
+                                                           topic,
+                                                           replyTo,
+                                                           (endpoint_t*)&endpoint);
+                    /* If an endpoint for this URI does not already exist */
+                    if (NULL == endpoint)
+                    {
+                        mama_log (MAMA_LOG_LEVEL_FINER,
+                                  "qpidBridgeMamaTransportImpl_dispatchThread(): "
+                                  "Endpoint does not exist - creating one.");
+                        endpoint = (qpidP2pEndpoint*)calloc (1, sizeof(qpidP2pEndpoint));
+                    }
+                    else
+                    {
+                        mama_log (MAMA_LOG_LEVEL_FINER,
+                                  "qpidBridgeMamaTransportImpl_dispatchThread(): "
+                                  "Endpoint does exist - reconnection detected.");
+                        endpoint->mErrorCount = 0;
+                        endpoint->mMsgCount = 0;
+                    }
+                    if (NULL == endpoint)
+                    {
+                        mama_log (MAMA_LOG_LEVEL_ERROR,
+                                  "qpidBridgeMamaTransportImpl_dispatchThread(): "
+                                  "Failed to allocate endpoint for URL: %s",
+                                  replyTo);
+                    }
+                    else
+                    {
+                        strncpy (endpoint->mUrl, replyTo, sizeof(endpoint->mUrl));
+                        endpoint->mUrl[sizeof(endpoint->mUrl) - 1] = '\0';
+                        endpointPool_registerWithIdentifier (impl->mPubEndpoints,
+                                                             topic,
+                                                             replyTo,
+                                                             endpoint);
+                    }
+                }
 
                 memoryPool_returnNode (impl->mQpidMsgPool, node);
                 continue;
@@ -1522,7 +1559,10 @@ void qpidBridgeMamaTransportImpl_stopProtonMessenger (pn_messenger_t* messenger)
     pn_messenger_stop (messenger);
 }
 
-void qpidBridgeMamaTransportImpl_freeProtonMessenger (pn_messenger_t* messenger)
+void destroyQpidEndpoint (endpoint_t endpoint)
 {
-    pn_messenger_free (messenger);
+    if (NULL != endpoint)
+    {
+        free (endpoint);
+    }
 }

--- a/mama/c_cpp/src/c/mama.c
+++ b/mama/c_cpp/src/c/mama.c
@@ -2548,6 +2548,9 @@ mama_loadBridgeWithPathInternal (mamaBridge* impl,
         goto error_handling_impl_allocated;
     }
 
+    /* Create the bridge lock */
+    (*impl)->mLock = wlock_create();
+
     /* Populate bridge meta data based on bridge's init properties */
     mamaBridgeImpl_populateBridgeMetaData (*impl);
 

--- a/mama/c_cpp/src/c/mama/msg.h
+++ b/mama/c_cpp/src/c/mama/msg.h
@@ -1411,7 +1411,7 @@ mamaMsg_updateVectorPrice (
     mamaMsg               msg,
     const char*           fname,
     mama_fid_t            fid,
-    const mamaPrice*      priceList[],
+    const mamaPrice       priceList[],
     mama_size_t           numElements);
 
 /**
@@ -1993,7 +1993,7 @@ mamaMsg_getVectorDateTime (
     const mamaMsg         msg,
     const char*           name,
     mama_fid_t            fid,
-    const mamaDateTime*   result,
+    const mamaDateTime**  result,
     mama_size_t*          resultLen);
 
 /**
@@ -2012,7 +2012,7 @@ mamaMsg_getVectorPrice (
     const mamaMsg         msg,
     const char*           name,
     mama_fid_t            fid,
-    const mamaPrice*      result,
+    const mamaPrice**     result,
     mama_size_t*          resultLen);
 
 /**

--- a/mama/c_cpp/src/c/msg.c
+++ b/mama/c_cpp/src/c/msg.c
@@ -2271,6 +2271,46 @@ mamaMsg_updatePrice(
 }
 
 mama_status
+mamaMsg_updateVectorTime (
+    const mamaMsg         msg,
+    const char*           name,
+    mama_fid_t            fid,
+    const mamaDateTime    value[],
+    mama_size_t           numElements)
+{
+    mamaMsgImpl*    impl    = (mamaMsgImpl*)msg;
+
+    if (!impl || !impl->mPayloadBridge) return MAMA_STATUS_NULL_ARG;
+    CHECK_MODIFY (impl->mMessageOwner);
+
+    return impl->mPayloadBridge->msgPayloadUpdateVectorTime (impl->mPayload,
+                                                             name,
+                                                             fid,
+                                                             value,
+                                                             numElements);
+}
+
+mama_status
+mamaMsg_updateVectorPrice (
+    const mamaMsg         msg,
+    const char*           name,
+    mama_fid_t            fid,
+    const mamaPrice       value[],
+    mama_size_t           numElements)
+{
+    mamaMsgImpl*    impl    = (mamaMsgImpl*)msg;
+
+    if (!impl || !impl->mPayloadBridge) return MAMA_STATUS_NULL_ARG;
+    CHECK_MODIFY (impl->mMessageOwner);
+
+    return impl->mPayloadBridge->msgPayloadUpdateVectorPrice (impl->mPayload,
+                                                              name,
+                                                              fid,
+                                                              value,
+                                                              numElements);
+}
+
+mama_status
 mamaMsg_updateVectorMsg (
     mamaMsg               msg,
     const char*           name,
@@ -3024,7 +3064,7 @@ mamaMsg_getVectorDateTime (
     const mamaMsg         msg,
     const char*           name,
     mama_fid_t            fid,
-    const mamaDateTime*   result,
+    const mamaDateTime**  result,
     mama_size_t*          resultLen)
 {
     mamaMsgImpl*    impl     = (mamaMsgImpl*)msg;
@@ -3048,7 +3088,7 @@ mamaMsg_getVectorPrice (
     const mamaMsg         msg,
     const char*           name,
     mama_fid_t            fid,
-    const mamaPrice*      result,
+    const mamaPrice**     result,
     mama_size_t*          resultLen)
 {
     mamaMsgImpl*    impl     = (mamaMsgImpl*)msg;

--- a/mama/c_cpp/src/c/payload/qpidmsg/payload.c
+++ b/mama/c_cpp/src/c/payload/qpidmsg/payload.c
@@ -1929,7 +1929,73 @@ qpidmsgPayload_addVectorDateTime (msgPayload          msg,
                                   const mamaDateTime  value[],
                                   mama_size_t         size)
 {
-    return MAMA_STATUS_NOT_IMPLEMENTED;
+    mama_size_t             i         = 0;
+    qpidmsgPayloadImpl*     impl      = (qpidmsgPayloadImpl*) msg;
+    pn_timestamp_t          stamp     = 0;
+    mama_u32_t              seconds   = 0;
+    mama_u32_t              micros    = 0;
+    mamaDateTimeHints       hints     = 0;
+    mamaDateTimePrecision   precision = MAMA_DATE_TIME_PREC_UNKNOWN;
+
+    if (NULL == impl || 0 == size || NULL == value
+            || (NULL == name && 0 == fid))
+    {
+        return MAMA_STATUS_NULL_ARG;
+    }
+
+    qpidmsgPayloadImpl_moveDataToInsertLocation (impl->mBody, impl);
+
+    pn_data_put_list (impl->mBody);
+    pn_data_enter    (impl->mBody);
+
+    /* strlen +1 to encode NULL terminator */
+    if(NULL == name)
+    {
+        pn_data_put_string (impl->mBody, pn_bytes (1, "\0"));
+    }
+    else
+    {
+        pn_data_put_string (impl->mBody,
+                            pn_bytes (strlen (name) + 1, (char*) name));
+    }
+
+    pn_data_put_ushort (impl->mBody, fid);
+
+    /* Create an array of lists */
+    pn_data_put_array  (impl->mBody, 0, PN_TIMESTAMP);
+    pn_data_enter      (impl->mBody);
+
+    for (i=0; i != size; i++)
+    {
+        mamaDateTime_getWithHints (value[i],
+                                   &seconds,
+                                   &micros,
+                                   &precision,
+                                   &hints);
+        /*
+         * The timestamp is simply 64 bits of data. Place seconds in leftmost and
+         * microseconds in rightmost 32 bits of format. Expected to be faster than
+         * multiplication.
+         */
+        stamp = micros | ((mama_u64_t) seconds << 32);
+
+        /* add the price value */
+        pn_data_put_timestamp (impl->mBody, stamp);
+
+        /* add the hints value */
+        pn_data_put_ubyte     (impl->mBody, (mama_u8_t) hints);
+
+        /* add the precision value */
+        pn_data_put_ubyte     (impl->mBody, (mama_u8_t) precision);
+
+    }
+
+    pn_data_exit (impl->mBody);
+    pn_data_exit (impl->mBody);
+
+    /* Revert to the previous iterator state if applicable */
+    qpidmsgPayloadImpl_resetToIteratorState (impl);
+    return MAMA_STATUS_OK;
 }
 
 /*
@@ -1943,7 +2009,57 @@ qpidmsgPayload_addVectorPrice (msgPayload      msg,
                                const mamaPrice value[],
                                mama_size_t     size)
 {
-    return MAMA_STATUS_NOT_IMPLEMENTED;
+    mama_size_t             i           = 0;
+    qpidmsgPayloadImpl*     impl        = (qpidmsgPayloadImpl*) msg;
+    double                  priceValue  = 0;
+    mamaPriceHints          priceHints  = 0;
+
+    if (NULL == impl || 0 == size || NULL == value
+            || (NULL == name && 0 == fid))
+    {
+        return MAMA_STATUS_NULL_ARG;
+    }
+
+    qpidmsgPayloadImpl_moveDataToInsertLocation (impl->mBody, impl);
+
+    pn_data_put_list (impl->mBody);
+    pn_data_enter    (impl->mBody);
+
+    /* strlen +1 to encode NULL terminator */
+    if(NULL == name)
+    {
+        pn_data_put_string (impl->mBody, pn_bytes (1, "\0"));
+    }
+    else
+    {
+        pn_data_put_string (impl->mBody,
+                            pn_bytes (strlen (name) + 1, (char*) name));
+    }
+
+    pn_data_put_ushort (impl->mBody, fid);
+
+    /* Create an array of lists */
+    pn_data_put_array  (impl->mBody, 0, PN_DOUBLE);
+    pn_data_enter      (impl->mBody);
+
+    for (i=0; i != size; i++)
+    {
+        mamaPrice_getValue (value[i], &priceValue);
+        mamaPrice_getHints (value[i], &priceHints);
+
+        /* add the price value */
+        pn_data_put_double  (impl->mBody, priceValue);
+
+        /* add the hints value */
+        pn_data_put_ubyte   (impl->mBody, (mama_u8_t)priceHints);
+    }
+
+    pn_data_exit (impl->mBody);
+    pn_data_exit (impl->mBody);
+
+    /* Revert to the previous iterator state if applicable */
+    qpidmsgPayloadImpl_resetToIteratorState (impl);
+    return MAMA_STATUS_OK;
 }
 
 mama_status
@@ -2536,10 +2652,62 @@ mama_status
 qpidmsgPayload_updateVectorPrice (msgPayload          msg,
                                   const char*         name,
                                   mama_fid_t          fid,
-                                  const mamaPrice*    value[],
+                                  const mamaPrice     value[],
                                   mama_size_t         size)
 {
-    return MAMA_STATUS_NOT_IMPLEMENTED;
+    qpidmsgPayloadImpl*     impl        = (qpidmsgPayloadImpl*) msg;
+    mama_status             status      = MAMA_STATUS_OK;
+    mama_size_t             i           = 0;
+    double                  priceValue  = 0;
+    mamaPriceHints          priceHints  = 0;
+
+    if (NULL == impl || NULL == value || 0 == size)
+    {
+        return MAMA_STATUS_NULL_ARG;
+    }
+
+    if (NULL == name && 0 == fid)
+    {
+        return MAMA_STATUS_NULL_ARG;
+    }
+
+    /* Find field - takes us directly to the content */
+    status = qpidmsgPayloadImpl_findField (impl, name, fid);
+
+    /* Create if this does not exist */
+    if (MAMA_STATUS_NOT_FOUND == status)
+    {
+        return qpidmsgPayload_addVectorPrice (msg, name, fid, value, size);
+    }
+    else if (MAMA_STATUS_OK != status)
+    {
+        return status;
+    }
+
+    /* Store value */
+    pn_data_put_array (impl->mBody, 0, PN_DOUBLE);
+    pn_data_enter     (impl->mBody);
+
+    for (i=0; i != size; i++)
+    {
+        mamaPrice_getValue (value[i], &priceValue);
+        mamaPrice_getHints (value[i], &priceHints);
+
+        /* add the price value */
+        pn_data_put_double  (impl->mBody, priceValue);
+
+        /* add the hints value */
+        pn_data_put_ubyte   (impl->mBody, (mama_u8_t)priceHints);
+
+    }
+
+    /* exit array */
+    pn_data_exit (impl->mBody);
+
+    /* Revert to the previous iterator state if applicable */
+    qpidmsgPayloadImpl_resetToIteratorState (impl);
+
+    return MAMA_STATUS_OK;
 }
 
 mama_status
@@ -2549,7 +2717,73 @@ qpidmsgPayload_updateVectorTime (msgPayload          msg,
                                  const mamaDateTime  value[],
                                  mama_size_t         size)
 {
-    return MAMA_STATUS_NOT_IMPLEMENTED;
+    qpidmsgPayloadImpl*     impl        = (qpidmsgPayloadImpl*) msg;
+    mama_status             status      = MAMA_STATUS_OK;
+    mama_size_t             i           = 0;
+    pn_timestamp_t          stamp       = 0;
+    mama_u32_t              seconds     = 0;
+    mama_u32_t              micros      = 0;
+    mamaDateTimeHints       hints       = 0;
+    mamaDateTimePrecision   precision   = MAMA_DATE_TIME_PREC_UNKNOWN;
+
+    if (NULL == impl || NULL == value || 0 == size)
+    {
+        return MAMA_STATUS_NULL_ARG;
+    }
+
+    if (NULL == name && 0 == fid)
+    {
+        return MAMA_STATUS_NULL_ARG;
+    }
+
+    /* Find field - takes us directly to the content */
+    status = qpidmsgPayloadImpl_findField (impl, name, fid);
+
+    /* Create if this does not exist */
+    if (MAMA_STATUS_NOT_FOUND == status)
+    {
+        return qpidmsgPayload_addVectorDateTime (msg, name, fid, value, size);
+    }
+    else if (MAMA_STATUS_OK != status)
+    {
+        return status;
+    }
+
+    /* Store value */
+    pn_data_put_array (impl->mBody, 0, PN_LIST);
+    pn_data_enter     (impl->mBody);
+    for (i=0; i != size; i++)
+    {
+        mamaDateTime_getWithHints (value[i],
+                                   &seconds,
+                                   &micros,
+                                   &precision,
+                                   &hints);
+        /*
+         * The timestamp is simply 64 bits of data. Place seconds in leftmost and
+         * microseconds in rightmost 32 bits of format. Expected to be faster than
+         * multiplication.
+         */
+        stamp = micros | ((mama_u64_t) seconds << 32);
+
+        /* add the price value */
+        pn_data_put_timestamp (impl->mBody, stamp);
+
+        /* add the hints value */
+        pn_data_put_ubyte     (impl->mBody, (mama_u8_t) hints);
+
+        /* add the precision value */
+        pn_data_put_ubyte     (impl->mBody, (mama_u8_t) precision);
+
+    }
+
+    /* exit array */
+    pn_data_exit (impl->mBody);
+
+    /* Revert to the previous iterator state if applicable */
+    qpidmsgPayloadImpl_resetToIteratorState (impl);
+
+    return MAMA_STATUS_OK;
 }
 
 
@@ -3085,23 +3319,194 @@ qpidmsgPayload_getVectorString (const msgPayload    msg,
 }
 
 mama_status
-qpidmsgPayload_getVectorDateTime (const msgPayload    msg,
-                                  const char*         name,
-                                  mama_fid_t          fid,
-                                  const mamaDateTime* result,
-                                  mama_size_t*        size)
+qpidmsgPayload_getVectorDateTime (const msgPayload     msg,
+                                  const char*          name,
+                                  mama_fid_t           fid,
+                                  const mamaDateTime** result,
+                                  mama_size_t*         size)
 {
-    return MAMA_STATUS_NOT_IMPLEMENTED;
+    mama_size_t          i         = 0;
+    qpidmsgPayloadImpl*  impl      = (qpidmsgPayloadImpl*) msg;
+    mama_status          status    = MAMA_STATUS_OK;
+    pn_timestamp_t       stamp     = 0;
+    mama_u8_t            hints     = 0;
+    mama_u8_t            precision = 0;
+    mama_u32_t           micros    = 0;
+    mama_u32_t           seconds   = 0;
+
+    if (NULL == impl || NULL == result || NULL == size)
+    {
+        return MAMA_STATUS_NULL_ARG;
+    }
+
+    /* Find field */
+    status = qpidmsgPayloadImpl_findField (impl, name, fid);
+
+    if (MAMA_STATUS_OK != status)
+    {
+        return status;
+    }
+
+    /* Move onto value[] */
+    pn_data_next (impl->mBody);
+
+    /* get size of array (stamp, precision and hints) */
+    *size  = pn_data_get_array (impl->mBody) / 3;
+
+    /* allocate space for resulting array*/
+    qpidmsgPayloadImpl_allocateBufferMemory ((void**) &impl->mField->mDataVectorDateTime,
+                                             &impl->mField->mDataVectorDateTimeCount,
+                                             (*size) * sizeof (mamaDateTime));
+
+    if (impl->mField->mDataVectorDateTimeCount > impl->mField->mDataMaxVectorDateTimeCount)
+    {
+        impl->mField->mDataMaxVectorDateTimeCount = impl->mField->mDataVectorDateTimeCount;
+    }
+
+    /* enter array */
+    pn_data_enter (impl->mBody);
+
+    for (; i != *size; ++i)
+    {
+        /* Step into the field */
+        pn_data_next (impl->mBody);
+
+        /* Pull out the 64 bit time stamp */
+        stamp = pn_data_get_atom (impl->mBody).u.as_timestamp;
+
+        /* Step into the next field */
+        pn_data_next (impl->mBody);
+
+        /* Extract the hints */
+        hints = pn_data_get_atom (impl->mBody).u.as_ubyte;
+
+        /* Step into the next field */
+        pn_data_next (impl->mBody);
+
+        /* Extract the precision */
+        precision = pn_data_get_atom (impl->mBody).u.as_ubyte;
+
+        /* Perform casts / bitwise operators to extract timestamps */
+        micros  = (mama_u32_t) stamp;
+        seconds   = (mama_u32_t) (stamp >> 32);
+
+        if (NULL == impl->mField->mDataVectorDateTime[i])
+        {
+            mamaDateTime_create(&impl->mField->mDataVectorDateTime[i]);
+        }
+        else
+        {
+            mamaDateTime_clear(impl->mField->mDataVectorDateTime[i]);
+        }
+
+        mamaDateTime_setWithHints (impl->mField->mDataVectorDateTime[i],
+                                   seconds,
+                                   micros,
+                                   (mamaDateTimePrecision) precision,
+                                   hints);
+    }
+    /* exit array */
+    pn_data_exit (impl->mBody);
+
+    /* exit field */
+    pn_data_exit (impl->mBody);
+
+    *result = impl->mField->mDataVectorDateTime;
+
+    /* Revert to the previous iterator state if applicable */
+    qpidmsgPayloadImpl_resetToIteratorState (impl);
+
+    return MAMA_STATUS_OK;
 }
 
 mama_status
 qpidmsgPayload_getVectorPrice (const msgPayload    msg,
                                const char*         name,
                                mama_fid_t          fid,
-                               const mamaPrice*    result,
+                               const mamaPrice**   result,
                                mama_size_t*        size)
 {
-    return MAMA_STATUS_NOT_IMPLEMENTED;
+    mama_size_t          i          = 0;
+    qpidmsgPayloadImpl*  impl       = (qpidmsgPayloadImpl*) msg;
+    mama_status          status     = MAMA_STATUS_OK;
+    double               priceValue = 0;
+    mamaPriceHints       priceHints = 0;
+    pn_atom_t            pnValue;
+    pn_atom_t            pnHints;
+
+    if (NULL == impl || NULL == result || NULL == size)
+    {
+        return MAMA_STATUS_NULL_ARG;
+    }
+
+    /* Find field */
+    status = qpidmsgPayloadImpl_findField (impl, name, fid);
+
+    if (MAMA_STATUS_OK != status)
+    {
+        return status;
+    }
+
+    /* Move onto value[] */
+    pn_data_next (impl->mBody);
+
+    /* get size of array (price and hints = 2) */
+    *size  = pn_data_get_array (impl->mBody) / 2;
+
+    /* allocate space for resulting array*/
+    qpidmsgPayloadImpl_allocateBufferMemory ((void**) &impl->mField->mDataVectorPrice,
+                                             &impl->mField->mDataVectorPriceCount,
+                                             (*size) * sizeof (mamaPrice));
+
+    if (impl->mField->mDataVectorPriceCount > impl->mField->mDataMaxVectorPriceCount)
+    {
+        impl->mField->mDataMaxVectorPriceCount = impl->mField->mDataVectorPriceCount;
+    }
+
+    /* enter array */
+    pn_data_enter (impl->mBody);
+
+    for (; i != *size; ++i)
+    {
+        /* Move onto value and extract */
+        pn_data_next (impl->mBody);
+
+        /* Value will be the first atom */
+        pnValue = pn_data_get_atom (impl->mBody);
+
+        /* then comes the hints */
+        pn_data_next (impl->mBody);
+        pnHints = pn_data_get_atom (impl->mBody);
+
+        /* Map proton types to primitives */
+        priceValue = pnValue.u.as_double;
+        priceHints = pnHints.u.as_ubyte;
+
+        if (NULL == impl->mField->mDataVectorPrice[i])
+        {
+            mamaPrice_create(&impl->mField->mDataVectorPrice[i]);
+        }
+        else
+        {
+            mamaPrice_clear(impl->mField->mDataVectorPrice[i]);
+        }
+
+        /* Update the provided price object */
+        mamaPrice_setValue (impl->mField->mDataVectorPrice[i], priceValue);
+        mamaPrice_setHints (impl->mField->mDataVectorPrice[i], priceHints);
+    }
+    /* exit array */
+    pn_data_exit (impl->mBody);
+
+    /* exit field */
+    pn_data_exit (impl->mBody);
+
+    *result = impl->mField->mDataVectorPrice;
+
+    /* Revert to the previous iterator state if applicable */
+    qpidmsgPayloadImpl_resetToIteratorState (impl);
+
+    return MAMA_STATUS_OK;
 }
 
 mama_status
@@ -3259,6 +3664,9 @@ qpidmsgPayloadImpl_allocateBufferMemory (void**       buffer,
         }
         else
         {
+            /* set newly added bytes to 0 */
+            memset ((uint8_t*) newbuf + *size, 0, newSize - *size);
+
             *buffer = newbuf;
             *size   = newSize;
             return MAMA_STATUS_OK;
@@ -3384,7 +3792,7 @@ qpidmsgPayloadImpl_getFieldFromBuffer (pn_data_t*               buffer,
                 pn_data_exit (buffer);
             }
         }
-        /* If this is a scalar vector */
+        /* If this is a scalar, date time or price vector */
         else
         {
             target->mDataArrayCount  = element_count;
@@ -3394,7 +3802,7 @@ qpidmsgPayloadImpl_getFieldFromBuffer (pn_data_t*               buffer,
             /* If there are elements inside and we know how to interpret */
             if (element_count > 0)
             {
-                mama_size_t i               = 0;
+                mama_size_t i = 0;
                 pn_type_t   secondary_type;
 
                 /* Move onto the first, then second element to inspect */
@@ -3411,13 +3819,10 @@ qpidmsgPayloadImpl_getFieldFromBuffer (pn_data_t*               buffer,
                 if (content_type == PN_DOUBLE && secondary_type == PN_UBYTE)
                 {
                     target->mMamaType = MAMA_FIELD_TYPE_VECTOR_PRICE;
-                    /* Twice as many atoms required for a price */
-                    element_count *= 2;
                 }
 
                 qpidmsgFieldPayloadImpl_setDataArraySize (target,
                                                           element_count);
-
 
                 for (; i < target->mDataArrayCount; i++)
                 {
@@ -3868,7 +4273,7 @@ qpidmsgPayloadImpl_addFieldToPayload (msgPayload                 msg,
         const mamaDateTime* result  = NULL;
         mama_size_t         size    = 0;
 
-        qpidmsgPayload_getVectorDateTime (field, name, fid, result, &size);
+        qpidmsgPayload_getVectorDateTime (field, name, fid, &result, &size);
         return qpidmsgPayload_addVectorDateTime (msg,
                                                  name,
                                                  fid,
@@ -3881,7 +4286,7 @@ qpidmsgPayloadImpl_addFieldToPayload (msgPayload                 msg,
         const mamaPrice* result = NULL;
         mama_size_t      size   = 0;
 
-        qpidmsgPayload_getVectorPrice (field, name, fid, result, &size);
+        qpidmsgPayload_getVectorPrice (field, name, fid, &result, &size);
         return qpidmsgPayload_addVectorPrice (msg,
                                               name,
                                               fid,

--- a/mama/c_cpp/src/c/payload/qpidmsg/qpidcommon.h
+++ b/mama/c_cpp/src/c/payload/qpidmsg/qpidcommon.h
@@ -150,6 +150,20 @@ typedef struct qpidmsgFieldPayloadImpl_
     /* Biggest number of elements in vector */
     mama_size_t     mDataMaxVectorCount;
 
+    /* Data buffer used for vectors of date times */
+    mamaDateTime*   mDataVectorDateTime;
+    /* Number of elements in vector */
+    mama_size_t     mDataVectorDateTimeCount;
+    /* Biggest number of elements in vector */
+    mama_size_t     mDataMaxVectorDateTimeCount;
+
+    /* Data buffer used for vectors of prices */
+    mamaPrice*      mDataVectorPrice;
+    /* Number of elements in vector */
+    mama_size_t     mDataVectorPriceCount;
+    /* Biggest number of elements in vector */
+    mama_size_t     mDataMaxVectorPriceCount;
+
     /* Name of the field */
     pn_bytes_t      mName;
 

--- a/mama/c_cpp/src/c/payload/qpidmsg/qpidpayloadfunctions.h
+++ b/mama/c_cpp/src/c/payload/qpidmsg/qpidpayloadfunctions.h
@@ -970,7 +970,7 @@ mama_status
 qpidmsgPayload_updateVectorPrice (msgPayload          msg,
                                   const char*         fname,
                                   mama_fid_t          fid,
-                                  const mamaPrice*    priceList[],
+                                  const mamaPrice     priceList[],
                                   mama_size_t         size);
 
 /**
@@ -1256,11 +1256,11 @@ qpidmsgPayload_getVectorString  (const msgPayload    msg,
  */
 MAMAExpBridgeDLL
 mama_status
-qpidmsgPayload_getVectorDateTime (const msgPayload    msg,
-                                  const char*         name,
-                                  mama_fid_t          fid,
-                                  const mamaDateTime* result,
-                                  mama_size_t*        size);
+qpidmsgPayload_getVectorDateTime (const msgPayload     msg,
+                                  const char*          name,
+                                  mama_fid_t           fid,
+                                  const mamaDateTime** result,
+                                  mama_size_t*         size);
 
 /**
  * Note: getVectorPrice() is not currently supported by MAMA, so implementation
@@ -1276,7 +1276,7 @@ mama_status
 qpidmsgPayload_getVectorPrice   (const msgPayload    msg,
                                  const char*         name,
                                  mama_fid_t          fid,
-                                 const mamaPrice*    result,
+                                 const mamaPrice**   result,
                                  mama_size_t*        size);
 
 /**
@@ -1713,7 +1713,7 @@ qpidmsgFieldPayload_getVectorString (const msgFieldPayload   field,
 MAMAExpBridgeDLL
 mama_status
 qpidmsgFieldPayload_getVectorDateTime (const msgFieldPayload   field,
-                                       const mamaDateTime*     result,
+                                       const mamaDateTime**    result,
                                        mama_size_t*            size);
 
 /**
@@ -1732,7 +1732,7 @@ qpidmsgFieldPayload_getVectorDateTime (const msgFieldPayload   field,
 MAMAExpBridgeDLL
 mama_status
 qpidmsgFieldPayload_getVectorPrice (const msgFieldPayload   field,
-                                    const mamaPrice*        result,
+                                    const mamaPrice**       result,
                                     mama_size_t*            size);
 
 /**

--- a/mama/c_cpp/src/c/payloadbridge.h
+++ b/mama/c_cpp/src/c/payloadbridge.h
@@ -491,7 +491,7 @@ typedef mama_status
 (*msgPayload_updateVectorPrice)(msgPayload          msg,
                                 const char*         fname,
                                 mama_fid_t          fid,
-                                const mamaPrice*    priceList[],
+                                const mamaPrice     priceList[],
                                 mama_size_t         size);
 typedef mama_status
 (*msgPayload_updateVectorTime) (msgPayload          msg,
@@ -667,13 +667,13 @@ typedef mama_status
 (*msgPayload_getVectorDateTime)(const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
-                                const mamaDateTime* result,
+                                const mamaDateTime** result,
                                 mama_size_t*        size);
 typedef mama_status
 (*msgPayload_getVectorPrice)   (const msgPayload    msg,
                                 const char*         name,
                                 mama_fid_t          fid,
-                                const mamaPrice*    result,
+                                const mamaPrice**   result,
                                 mama_size_t*        size);
 typedef mama_status
 (*msgPayload_getVectorMsg)     (const msgPayload    msg,

--- a/mama/c_cpp/src/c/registerfunctions.c
+++ b/mama/c_cpp/src/c/registerfunctions.c
@@ -252,7 +252,7 @@ mamaInternal_registerPayloadFunctions (LIB_HANDLE         bridgeLib,
     REGISTER_OPTIONAL_BRIDGE_FUNCTION (Payload_updateVectorF32, msgPayloadUpdateVectorF32, msgPayload_updateVectorF32);
     REGISTER_OPTIONAL_BRIDGE_FUNCTION (Payload_updateVectorF64, msgPayloadUpdateVectorF64, msgPayload_updateVectorF64);
     REGISTER_OPTIONAL_BRIDGE_FUNCTION (Payload_updateVectorPrice, msgPayloadUpdateVectorPrice, msgPayload_updateVectorPrice);
-    REGISTER_OPTIONAL_BRIDGE_FUNCTION (Payload_updateVectorPrice, msgPayloadUpdateVectorTime, msgPayload_updateVectorTime);
+    REGISTER_OPTIONAL_BRIDGE_FUNCTION (Payload_updateVectorTime, msgPayloadUpdateVectorTime, msgPayload_updateVectorTime);
 
     /* Get methods */
     REGISTER_BRIDGE_FUNCTION (Payload_getBool, msgPayloadGetBool, msgPayload_getBool);

--- a/mama/c_cpp/src/c/subscription.c
+++ b/mama/c_cpp/src/c/subscription.c
@@ -1738,6 +1738,10 @@ mamaSubscription_setSymbol (
 {
     if (!subscription) return MAMA_STATUS_NULL_ARG;
     checkFree (&self->mUserSymbol);
+    if (!symbol)
+    {
+        symbol = "";
+    }
     self->mUserSymbol = strdup(symbol);
     return MAMA_STATUS_OK;
 }
@@ -2487,6 +2491,11 @@ isEntitledToSymbol (const char *source, const char*symbol, mamaSubscription subs
 
 char* copyString (const char*  str)
 {
+    if (!str)
+    {
+        str = "";
+    }
+
     /* Windows does not like strdup */
     size_t len = strlen (str) + 1;
     char* result = (char*)calloc (len, sizeof (char));

--- a/mama/c_cpp/src/c/subscription.c
+++ b/mama/c_cpp/src/c/subscription.c
@@ -1738,10 +1738,6 @@ mamaSubscription_setSymbol (
 {
     if (!subscription) return MAMA_STATUS_NULL_ARG;
     checkFree (&self->mUserSymbol);
-    if (!symbol)
-    {
-        symbol = "";
-    }
     self->mUserSymbol = strdup(symbol);
     return MAMA_STATUS_OK;
 }
@@ -2491,11 +2487,6 @@ isEntitledToSymbol (const char *source, const char*symbol, mamaSubscription subs
 
 char* copyString (const char*  str)
 {
-    if (!str)
-    {
-        str = "";
-    }
-
     /* Windows does not like strdup */
     size_t len = strlen (str) + 1;
     char* result = (char*)calloc (len, sizeof (char));

--- a/mama/c_cpp/src/gunittest/c/mamamsg/msgvectortests.cpp
+++ b/mama/c_cpp/src/gunittest/c/mamamsg/msgvectortests.cpp
@@ -3546,20 +3546,20 @@ protected:
 // AddVectorDateTime test fixtures
 // *******************************
 
-TEST_F(MsgVectorDateTimeTestsC, DISABLED_AddVectorDateTime)
-// Disabled as mamaMsg_addVectorDateTime is not implemented.
+TEST_F(MsgVectorDateTimeTestsC, AddVectorDateTime)
 {
     mStatus = mamaMsg_addVectorDateTime (mMsg,
                                          NULL,
                                          1,
                                          mIn,
                                          VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     ASSERT_EQ(mStatus, MAMA_STATUS_OK);
 
     mStatus = mamaMsg_getVectorDateTime (mMsg,
                                          NULL,
                                          1,
-                                         (mama_u64_t* const*) &mOut,
+                                         &mOut,
                                          &mOutSize);
     ASSERT_EQ( mStatus, MAMA_STATUS_OK );
     EXPECT_EQ( mOutSize, VECTOR_SIZE );
@@ -3575,14 +3575,14 @@ TEST_F(MsgVectorDateTimeTestsC, DISABLED_AddVectorDateTime)
     }
 }
 
-TEST_F(MsgVectorDateTimeTestsC, DISABLED_AddVectorDateTimeNullAdd)
-// Disabled as mamaMsg_addVectorDateTime is not implemented.
+TEST_F(MsgVectorDateTimeTestsC, AddVectorDateTimeNullAdd)
 {
     mStatus = mamaMsg_addVectorDateTime (mMsg,
                                          NULL,
                                          1,
                                          NULL,
                                          VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     EXPECT_EQ(mStatus, MAMA_STATUS_NULL_ARG);
 }
 
@@ -3593,20 +3593,21 @@ TEST_F(MsgVectorDateTimeTestsC, AddVectorDateTimeNullMsg)
                                          1,
                                          mIn,
                                          VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     EXPECT_EQ(mStatus, MAMA_STATUS_NULL_ARG);
 }
 
 // UpdateVectorDateTime test fixtures
 // **********************************
 
-TEST_F(MsgVectorDateTimeTestsC, DISABLED_UpdateVectorDateTime)
-// Disabled as mamaMsg_updateVectorTime is not implemented.
+TEST_F(MsgVectorDateTimeTestsC, UpdateVectorDateTime)
 {
     mStatus = mamaMsg_addVectorDateTime (mMsg,
                                          NULL,
                                          1,
                                          mIn,
                                          VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     EXPECT_EQ(mStatus, MAMA_STATUS_OK);
 
     if (MAMA_STATUS_OK == mStatus)
@@ -3614,14 +3615,13 @@ TEST_F(MsgVectorDateTimeTestsC, DISABLED_UpdateVectorDateTime)
         mStatus = mamaMsg_getVectorDateTime (mMsg,
                                              NULL,
                                              1,
-                                             (mama_u64_t* const*) &mOut,
+                                             &mOut,
                                              &mOutSize);
         EXPECT_EQ( mStatus, MAMA_STATUS_OK );
         EXPECT_EQ( mOutSize, VECTOR_SIZE );
     }
 
 
-    /*
     mStatus = mamaMsg_updateVectorTime (mMsg,
                                         NULL,
                                         1,
@@ -3632,7 +3632,7 @@ TEST_F(MsgVectorDateTimeTestsC, DISABLED_UpdateVectorDateTime)
     mStatus = mamaMsg_getVectorDateTime (mMsg,
                                          NULL,
                                          1,
-                                         (mama_u64_t* const*) &mOut,
+                                         &mOut,
                                          &mOutSize);
 
     EXPECT_EQ( mStatus, MAMA_STATUS_OK );
@@ -3646,45 +3646,40 @@ TEST_F(MsgVectorDateTimeTestsC, DISABLED_UpdateVectorDateTime)
             EXPECT_EQ(1, eq);
         }
     }
-    */
 }
 
-TEST_F(MsgVectorDateTimeTestsC, DISABLED_UpdateVectorDateTimeNullAdd)
-// Disabled as mamaMsg_updateVectorTime is not implemented.
+TEST_F(MsgVectorDateTimeTestsC, UpdateVectorDateTimeNullAdd)
 {
-    /*
     mStatus = mamaMsg_updateVectorTime (mMsg,
                                         NULL,
                                         1,
                                         NULL,
                                         VECTOR_UPDATE_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     EXPECT_EQ(mStatus, MAMA_STATUS_NULL_ARG);
-    */
 }
 
-TEST_F(MsgVectorDateTimeTestsC, DISABLED_UpdateVectorDateTimeNullMsg)
-// Disabled as mamaMsg_updateVectorTime is not implemented.
+TEST_F(MsgVectorDateTimeTestsC, UpdateVectorDateTimeNullMsg)
 {
-    /*
     mStatus = mamaMsg_updateVectorTime (NULL,
                                         NULL,
                                         1,
                                         mUpdate,
                                         VECTOR_UPDATE_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     EXPECT_EQ(mStatus, MAMA_STATUS_NULL_ARG);
-    */
 }
 
 // GetVectorDateTime test fixtures
 // *******************************
-TEST_F(MsgVectorDateTimeTestsC, DISABLED_GetVectorDateTime)
-// Disabled as mamaMsg_addVectorTime is not implemented.
+TEST_F(MsgVectorDateTimeTestsC, GetVectorDateTime)
 {
     mStatus = mamaMsg_addVectorDateTime (mMsg,
                                          NULL,
                                          1,
                                          mIn,
                                          VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     ASSERT_EQ(mStatus, MAMA_STATUS_OK);
 
     if (MAMA_STATUS_OK == mStatus)
@@ -3692,7 +3687,7 @@ TEST_F(MsgVectorDateTimeTestsC, DISABLED_GetVectorDateTime)
         mStatus = mamaMsg_getVectorDateTime (mMsg,
                                              NULL,
                                              1,
-                                             (mama_u64_t* const*) &mOut,
+                                             &mOut,
                                              &mOutSize);
         ASSERT_EQ( mStatus, MAMA_STATUS_OK );
         EXPECT_EQ( mOutSize, VECTOR_SIZE );
@@ -3732,14 +3727,14 @@ TEST_F(MsgVectorDateTimeTestsC, DISABLED_GetVectorDateTime)
     */
 }
 
-TEST_F(MsgVectorDateTimeTestsC, DISABLED_GetVectorDateTimeNullAdd)
-// Disabled as mamaMsg_addVectorDateTime is not implemented.
+TEST_F(MsgVectorDateTimeTestsC, GetVectorDateTimeNullAdd)
 {
     mStatus = mamaMsg_addVectorDateTime (mMsg,
                                          NULL,
                                          1,
                                          mIn,
                                          VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     ASSERT_EQ(mStatus, MAMA_STATUS_OK);
 
     mStatus = mamaMsg_getVectorDateTime (mMsg,
@@ -3752,25 +3747,25 @@ TEST_F(MsgVectorDateTimeTestsC, DISABLED_GetVectorDateTimeNullAdd)
     mStatus = mamaMsg_getVectorDateTime (mMsg,
                                          NULL,
                                          1,
-                                         (mama_u64_t* const*) &mOut,
+                                         &mOut,
                                          NULL);
     EXPECT_EQ(mStatus, MAMA_STATUS_NULL_ARG);
 }
 
-TEST_F(MsgVectorDateTimeTestsC, DISABLED_GetVectorDateTimeNullMsg)
-// Disabled as mamaMsg_addVectorDateTime is not implemented.
+TEST_F(MsgVectorDateTimeTestsC, GetVectorDateTimeNullMsg)
 {
     mStatus = mamaMsg_addVectorDateTime (mMsg,
                                          NULL,
                                          1,
                                          mIn,
                                          VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     ASSERT_EQ(mStatus, MAMA_STATUS_OK);
 
     mStatus = mamaMsg_getVectorDateTime (NULL,
                                          NULL,
                                          1,
-                                         (mama_u64_t* const*) &mOut,
+                                         &mOut,
                                          &mOutSize);
     EXPECT_EQ(mStatus, MAMA_STATUS_NULL_ARG);
 }
@@ -3836,20 +3831,20 @@ protected:
 // AddVectorPrice test fixtures
 // ****************************
 
-TEST_F(MsgVectorPriceTestsC, DISABLED_AddVectorPrice)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(MsgVectorPriceTestsC, AddVectorPrice)
 {
     mStatus = mamaMsg_addVectorPrice (mMsg,
                                       NULL,
                                       1,
                                       mIn,
                                       VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     ASSERT_EQ(mStatus, MAMA_STATUS_OK);
 
     mStatus = mamaMsg_getVectorPrice (mMsg,
                                       NULL,
                                       1,
-                                      (const mamaPrice*) &mOut,
+                                      &mOut,
                                       &mOutSize);
     ASSERT_EQ( mStatus, MAMA_STATUS_OK );
     EXPECT_EQ( mOutSize, VECTOR_SIZE );
@@ -3865,14 +3860,14 @@ TEST_F(MsgVectorPriceTestsC, DISABLED_AddVectorPrice)
     }
 }
 
-TEST_F(MsgVectorPriceTestsC, DISABLED_AddVectorPriceNullAdd)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(MsgVectorPriceTestsC, AddVectorPriceNullAdd)
 {
     mStatus = mamaMsg_addVectorPrice (mMsg,
                                       NULL,
                                       1,
                                       NULL,
                                       VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     EXPECT_EQ(mStatus, MAMA_STATUS_NULL_ARG);
 }
 
@@ -3883,20 +3878,21 @@ TEST_F(MsgVectorPriceTestsC, AddVectorPriceNullMsg)
                                       1,
                                       mIn,
                                       VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     EXPECT_EQ(mStatus, MAMA_STATUS_NULL_ARG);
 }
 
 // UpdateVectorPrice test fixtures
 // *******************************
 
-TEST_F(MsgVectorPriceTestsC, DISABLED_UpdateVectorPrice)
-// Disabled as  mamaMsg_updateVectorPrice is not implemented.
+TEST_F(MsgVectorPriceTestsC, UpdateVectorPrice)
 {
     mStatus = mamaMsg_addVectorPrice (mMsg,
                                       NULL,
                                       1,
                                       mIn,
                                       VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     ASSERT_EQ(mStatus, MAMA_STATUS_OK);
 
     if (MAMA_STATUS_OK == mStatus)
@@ -3904,24 +3900,23 @@ TEST_F(MsgVectorPriceTestsC, DISABLED_UpdateVectorPrice)
         mStatus = mamaMsg_getVectorPrice (mMsg,
                                           NULL,
                                           1,
-                                          (const mamaPrice*) &mOut,
+                                          &mOut,
                                           &mOutSize);
         ASSERT_EQ( mStatus, MAMA_STATUS_OK );
         EXPECT_EQ( mOutSize, VECTOR_SIZE );
     }
 
-    /*
     mStatus = mamaMsg_updateVectorPrice (mMsg,
                                          NULL,
                                          1,
-                                         (void* const**) &mUpdate,
+                                         mUpdate,
                                          VECTOR_UPDATE_SIZE);
     EXPECT_EQ(mStatus, MAMA_STATUS_OK);
 
     mStatus = mamaMsg_getVectorPrice (mMsg,
                                       NULL,
                                       1,
-                                      (const mamaPrice*) &mOut,
+                                      &mOut,
                                       &mOutSize);
     EXPECT_EQ( mStatus, MAMA_STATUS_OK );
     EXPECT_EQ( mOutSize, VECTOR_UPDATE_SIZE );
@@ -3934,45 +3929,40 @@ TEST_F(MsgVectorPriceTestsC, DISABLED_UpdateVectorPrice)
             EXPECT_EQ(1, eq);
         }
     }
-    */
 }
 
-TEST_F(MsgVectorPriceTestsC, DISABLED_UpdateVectorPriceNullAdd)
-// Disabeld as mamaMsg_updateVectorPrice is not implemented.
+TEST_F(MsgVectorPriceTestsC, UpdateVectorPriceNullAdd)
 {
-    /*
     mStatus = mamaMsg_updateVectorPrice (mMsg,
                                          NULL,
                                          1,
                                          NULL,
                                          VECTOR_UPDATE_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     EXPECT_EQ(mStatus, MAMA_STATUS_NULL_ARG);
-    */
 }
 
-TEST_F(MsgVectorPriceTestsC, DISABLED_UpdateVectorPriceNullMsg)
-// Disabled as mamaMsg_updateVectorPrice is not implemented.
+TEST_F(MsgVectorPriceTestsC, UpdateVectorPriceNullMsg)
 {
-    /*
     mStatus = mamaMsg_updateVectorPrice (NULL,
                                          NULL,
                                          1,
-                                         (void* const**) mUpdate,
+                                         mUpdate,
                                          VECTOR_UPDATE_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     EXPECT_EQ(mStatus, MAMA_STATUS_NULL_ARG);
-    */
 }
 
 // GetVectorPrice test fixtures
 // *******************************
-TEST_F(MsgVectorPriceTestsC, DISABLED_GetVectorPrice)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(MsgVectorPriceTestsC, GetVectorPrice)
 {
     mStatus = mamaMsg_addVectorPrice (mMsg,
                                       NULL,
                                       1,
                                       mIn,
                                       VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     ASSERT_EQ(mStatus, MAMA_STATUS_OK);
 
     if (MAMA_STATUS_OK == mStatus)
@@ -3980,7 +3970,7 @@ TEST_F(MsgVectorPriceTestsC, DISABLED_GetVectorPrice)
         mStatus = mamaMsg_getVectorPrice (mMsg,
                                           NULL,
                                           1,
-                                          (const mamaPrice*) &mOut,
+                                          &mOut,
                                           &mOutSize);
         ASSERT_EQ( mStatus, MAMA_STATUS_OK );
         EXPECT_EQ( mOutSize, VECTOR_SIZE );
@@ -3995,18 +3985,17 @@ TEST_F(MsgVectorPriceTestsC, DISABLED_GetVectorPrice)
         }
     }
 
-    /*
     mStatus = mamaMsg_updateVectorPrice (mMsg,
                                          NULL,
                                          1,
-                                         (void* const**) mUpdate,
+                                         mUpdate,
                                          VECTOR_UPDATE_SIZE);
     EXPECT_EQ(mStatus, MAMA_STATUS_OK);
 
     mStatus = mamaMsg_getVectorPrice (mMsg,
                                       NULL,
                                       1,
-                                      (const mamaPrice*) &mOut,
+                                      &mOut,
                                       &mOutSize);
 
     EXPECT_EQ( mStatus, MAMA_STATUS_OK );
@@ -4015,19 +4004,18 @@ TEST_F(MsgVectorPriceTestsC, DISABLED_GetVectorPrice)
     {
         int eq = mamaPrice_equal( mUpdate[ii],
                                   mOut[ii] );
-        EXPECT_EQ(0, eq);
+        EXPECT_EQ(1, eq);
     }
-    */
 }
 
-TEST_F(MsgVectorPriceTestsC, DISABLED_GetVectorPriceNullAdd)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(MsgVectorPriceTestsC, GetVectorPriceNullAdd)
 {
     mStatus = mamaMsg_addVectorPrice (mMsg,
                                       NULL,
                                       1,
                                       mIn,
                                       VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     ASSERT_EQ(mStatus, MAMA_STATUS_OK);
 
     mStatus = mamaMsg_getVectorPrice (mMsg,
@@ -4040,25 +4028,25 @@ TEST_F(MsgVectorPriceTestsC, DISABLED_GetVectorPriceNullAdd)
     mStatus = mamaMsg_getVectorPrice (mMsg,
                                       NULL,
                                       1,
-                                      (const mamaPrice*) &mOut,
+                                      &mOut,
                                       NULL);
     EXPECT_EQ(mStatus, MAMA_STATUS_NULL_ARG);
 }
 
-TEST_F(MsgVectorPriceTestsC, DISABLED_GetVectorPriceNullMsg)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(MsgVectorPriceTestsC, GetVectorPriceNullMsg)
 {
     mStatus = mamaMsg_addVectorPrice (mMsg,
                                       NULL,
                                       1,
                                       mIn,
                                       VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(mStatus);
     EXPECT_EQ(mStatus, MAMA_STATUS_OK);
 
     mStatus = mamaMsg_getVectorPrice (NULL,
                                       NULL,
                                       1,
-                                      (const mamaPrice*) &mOut,
+                                      &mOut,
                                       &mOutSize);
     EXPECT_EQ(mStatus, MAMA_STATUS_NULL_ARG);
 }

--- a/mama/c_cpp/src/gunittest/c/payload/fieldvectortests.cpp
+++ b/mama/c_cpp/src/gunittest/c/payload/fieldvectortests.cpp
@@ -27,6 +27,8 @@
 #include "MainUnitTestC.h"
 
 #define VECTOR_SIZE 2
+#define MAMA_DATE_TIME_GET_VECTOR_CAST (const mamaDateTime*)
+#define MAMA_PRICE_GET_VECTOR_CAST     (const mamaPrice*)
 
 using namespace ::testing;
 
@@ -960,20 +962,30 @@ protected:
 
 TEST_F(FieldVectorDateTimeTests, GetVectorDateTime)
 {
-    m_status = m_payloadBridge->msgFieldPayloadGetVectorDateTime(m_field, m_out, &m_size);
-    ASSERT_EQ (MAMA_STATUS_NOT_IMPLEMENTED, m_status);
+    size_t i = 0;
+    m_status = m_payloadBridge->msgPayloadGetField(m_msg, NULL, 1, &m_field);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
+    ASSERT_EQ(m_status, MAMA_STATUS_OK);
+    m_status = m_payloadBridge->msgFieldPayloadGetVectorDateTime(m_field, MAMA_DATE_TIME_GET_VECTOR_CAST(&m_out), &m_size);
+    for (i = 0; i < VECTOR_SIZE; i++)
+    {
+        ASSERT_EQ (1, mamaDateTime_equal (m_out[i], m_in[i]));
+    }
+    ASSERT_EQ(m_status, MAMA_STATUS_OK);
 }
 
 TEST_F(FieldVectorDateTimeTests, GetVectorDateTimeNullOut)
 {
     m_status = m_payloadBridge->msgFieldPayloadGetVectorDateTime(m_field, NULL, &m_size);
-    ASSERT_EQ (MAMA_STATUS_NOT_IMPLEMENTED, m_status);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
+    ASSERT_EQ (m_status, MAMA_STATUS_NULL_ARG);
 }
 
 TEST_F(FieldVectorDateTimeTests, GetVectorDateTimeNullSize)
 {
-    m_status = m_payloadBridge->msgFieldPayloadGetVectorDateTime(m_field, m_out, NULL);
-    ASSERT_EQ (MAMA_STATUS_NOT_IMPLEMENTED, m_status);
+    m_status = m_payloadBridge->msgFieldPayloadGetVectorDateTime(m_field, MAMA_DATE_TIME_GET_VECTOR_CAST(&m_out), NULL);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
+    ASSERT_EQ (m_status, MAMA_STATUS_NULL_ARG);
 }
 
 /**
@@ -1038,20 +1050,30 @@ protected:
 
 TEST_F(FieldVectorPriceTests, GetVectorPrice)
 {
-    m_status = m_payloadBridge->msgFieldPayloadGetVectorPrice(m_field, m_out, &m_size);
-    ASSERT_EQ (MAMA_STATUS_NOT_IMPLEMENTED, m_status);
+    size_t i = 0;
+    m_status = m_payloadBridge->msgPayloadGetField(m_msg, NULL, 1, &m_field);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
+    ASSERT_EQ(m_status, MAMA_STATUS_OK);
+    m_status = m_payloadBridge->msgFieldPayloadGetVectorPrice(m_field, MAMA_PRICE_GET_VECTOR_CAST(&m_out), &m_size);
+    ASSERT_EQ(m_status, MAMA_STATUS_OK);
+    for (i = 0; i < VECTOR_SIZE; i++)
+    {
+        ASSERT_EQ (1, mamaPrice_equal (m_out[i], m_in[i]));
+    }
 }
 
 TEST_F(FieldVectorPriceTests, GetVectorPriceNullOut)
 {
     m_status = m_payloadBridge->msgFieldPayloadGetVectorPrice(m_field, NULL, &m_size);
-    ASSERT_EQ (MAMA_STATUS_NOT_IMPLEMENTED, m_status);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
+    ASSERT_EQ (m_status, MAMA_STATUS_NULL_ARG);
 }
 
 TEST_F(FieldVectorPriceTests, GetVectorPriceNullSize)
 {
-    m_status = m_payloadBridge->msgFieldPayloadGetVectorPrice(m_field, m_out, NULL);
-    ASSERT_EQ (MAMA_STATUS_NOT_IMPLEMENTED, m_status);
+    m_status = m_payloadBridge->msgFieldPayloadGetVectorPrice(m_field, MAMA_PRICE_GET_VECTOR_CAST(&m_out), NULL);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
+    ASSERT_EQ (m_status, MAMA_STATUS_NULL_ARG);
 }
 
 /**

--- a/mama/c_cpp/src/gunittest/c/payload/payloadvectortests.cpp
+++ b/mama/c_cpp/src/gunittest/c/payload/payloadvectortests.cpp
@@ -3831,15 +3831,15 @@ protected:
 // AddVectorDateTime test fixtures
 // *******************************
 
-TEST_F(PayloadVectorDateTimeTests, DISABLED_AddVectorDateTime)
-// Disabled as mamaMsg_addVectorDateTime is not implemented.
+TEST_F(PayloadVectorDateTimeTests, AddVectorDateTime)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorDateTime(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
-    m_status = m_payloadBridge->msgPayloadGetVectorDateTime(m_msg, NULL, 1, (mama_u64_t* const*) &m_out, &m_outSize);
-    ASSERT_EQ (MAMA_STATUS_OK , m_status);
-    EXPECT_EQ (VECTOR_SIZE , m_outSize);
+    m_status = m_payloadBridge->msgPayloadGetVectorDateTime(m_msg, NULL, 1, &m_out, &m_outSize);
+    ASSERT_EQ( m_status, MAMA_STATUS_OK );
+    EXPECT_EQ( m_outSize, VECTOR_SIZE );
 
     for( unsigned int ii(0) ; ii < VECTOR_SIZE ; ++ii )
     {
@@ -3852,44 +3852,44 @@ TEST_F(PayloadVectorDateTimeTests, DISABLED_AddVectorDateTime)
     }
 }
 
-TEST_F(PayloadVectorDateTimeTests, DISABLED_AddVectorDateTimeNullDateTime)
-// Disabled as mamaMsg_addVectorDateTime is not implemented.
+TEST_F(PayloadVectorDateTimeTests, AddVectorDateTimeNullDateTime)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorDateTime(m_msg, NULL, 1, NULL, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_NULL_ARG , m_status);
 }
 
-TEST_F(PayloadVectorDateTimeTests, DISABLED_AddVectorDateTimeNullMsg)
-// Disabled as mamaMsg_addVectorDateTime is not implemented.
+TEST_F(PayloadVectorDateTimeTests, AddVectorDateTimeNullMsg)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorDateTime(NULL, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_NULL_ARG, m_status);
 }
 
-TEST_F(PayloadVectorDateTimeTests, DISABLED_AddVectorDateTimeAfterInit)
-// Disabled as mamaMsg_addVectorDateTime is not implemented.
+TEST_F(PayloadVectorDateTimeTests, AddVectorDateTimeAfterInit)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorDateTime(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
     m_status = m_payloadBridge->msgPayloadAddVectorDateTime(m_msg, NULL, 2, m_in, VECTOR_SIZE);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 }
 
-TEST_F(PayloadVectorDateTimeTests, DISABLED_AddVectorDateTimeInvalidName)
-// Disabled as mamaMsg_addVectorDateTime is not implemented.
+TEST_F(PayloadVectorDateTimeTests, AddVectorDateTimeInvalidName)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorDateTime(m_msg, "Bob", 0, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
     m_status = m_payloadBridge->msgPayloadAddVectorDateTime(m_msg, NULL, 0, m_in, VECTOR_SIZE);
     EXPECT_EQ (MAMA_STATUS_NULL_ARG, m_status);
 }
 
-TEST_F(PayloadVectorDateTimeTests, DISABLED_AddVectorDateTimeInvalidFid)
-// Disabled as mamaMsg_addVectorDateTime is not implemented.
+TEST_F(PayloadVectorDateTimeTests, AddVectorDateTimeInvalidFid)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorDateTime(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
     m_status = m_payloadBridge->msgPayloadAddVectorDateTime(m_msg, NULL, 0, m_in, VECTOR_SIZE);
@@ -3899,9 +3899,10 @@ TEST_F(PayloadVectorDateTimeTests, DISABLED_AddVectorDateTimeInvalidFid)
 // UpdateVectorDateTime test fixtures
 // **********************************
 // Disabled as mamaMsg_addVectorDateTime is not implemented.
-TEST_F(PayloadVectorDateTimeTests, DISABLED_UpdateVectorDateTime)
+TEST_F(PayloadVectorDateTimeTests, UpdateVectorDateTime)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorDateTime(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
     //m_status = m_payloadBridge->msgPayloadGetVectorDateTime(m_msg, NULL, 1, (mama_u64_t* const*) &m_out, &m_outSize);
@@ -3948,10 +3949,10 @@ TEST_F(PayloadVectorDateTimeTests, DISABLED_UpdateVectorDateTime)
     */
 }
 
-TEST_F(PayloadVectorDateTimeTests, DISABLED_UpdateVectorDateTimeNullUpdate)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(PayloadVectorDateTimeTests, UpdateVectorDateTimeNullUpdate)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorDateTime(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
     //m_status = m_payloadBridge->msgPayloadGetVectorDateTime(m_msg, NULL, 1, (mama_u64_t* const*) &m_out, &m_outSize);
@@ -3978,10 +3979,10 @@ TEST_F(PayloadVectorDateTimeTests, DISABLED_UpdateVectorDateTimeNullUpdate)
     EXPECT_EQ (MAMA_STATUS_NULL_ARG, m_status);
 }
 
-TEST_F(PayloadVectorDateTimeTests, DISABLED_UpdateVectorDateTimeNullMessage)
-// Disabled as mamaMsg_addVectorDateTime is not implemented.
+TEST_F(PayloadVectorDateTimeTests, UpdateVectorDateTimeNullMessage)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorDateTime(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
     //m_status = m_payloadBridge->msgPayloadGetVectorDateTime(m_msg, NULL, 1, (mama_u64_t* const*) &m_out, &m_outSize);
@@ -4011,14 +4012,14 @@ TEST_F(PayloadVectorDateTimeTests, DISABLED_UpdateVectorDateTimeNullMessage)
 
 // GetVectorDateTime test fixtures
 // *******************************
-TEST_F(PayloadVectorDateTimeTests, DISABLED_GetVectorDateTime)
-// Disabled as mamaMsg_addVectorDateTime is not implemented.
+TEST_F(PayloadVectorDateTimeTests, GetVectorDateTime)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorDateTime(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
     // TODO Check prototype for GetVectorDateTime
-    m_status = m_payloadBridge->msgPayloadGetVectorDateTime(m_msg, NULL, 1, (mama_u64_t* const*) &m_out, &m_outSize);
+    m_status = m_payloadBridge->msgPayloadGetVectorDateTime(m_msg, NULL, 1, &m_out, &m_outSize);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
     EXPECT_EQ ((mama_size_t)VECTOR_SIZE, m_outSize);
 
@@ -4041,7 +4042,7 @@ TEST_F(PayloadVectorDateTimeTests, DISABLED_GetVectorDateTime)
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
     // TODO Check prototype for GetVectorDateTime
-    m_status = m_payloadBridge->msgPayloadGetVectorDateTime(m_msg, NULL, 1, (mama_u64_t* const*) &m_out, &m_outSize);
+    m_status = m_payloadBridge->msgPayloadGetVectorDateTime(m_msg, NULL, 1, &m_out, &m_outSize);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
     EXPECT_EQ ((mama_size_t)VECTOR_UPDATE_SIZE, m_outSize);
 
@@ -4061,25 +4062,23 @@ TEST_F(PayloadVectorDateTimeTests, DISABLED_GetVectorDateTime)
     }
 }
 
-TEST_F(PayloadVectorDateTimeTests, DISABLED_GetVectorDateTimeNullResult)
-// Disabled as mamaMsg_addVectorDateTime is not implemented.
+TEST_F(PayloadVectorDateTimeTests, GetVectorDateTimeNullResult)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorDateTime(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
-    // TODO Check prototype for GetVectorDateTime
     m_status = m_payloadBridge->msgPayloadGetVectorDateTime(m_msg, NULL, 1, NULL, &m_outSize);
     EXPECT_EQ (MAMA_STATUS_NULL_ARG, m_status);
 }
 
-TEST_F(PayloadVectorDateTimeTests, DISABLED_GetVectorDateTimeNullSize)
-// Disabled as mamaMsg_addVectorDateTime is not implemented.
+TEST_F(PayloadVectorDateTimeTests, GetVectorDateTimeNullSize)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorDateTime(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
-    // TODO Check prototype for GetVectorDateTime
-    m_status = m_payloadBridge->msgPayloadGetVectorDateTime(m_msg, NULL, 1, m_out, NULL);
+    m_status = m_payloadBridge->msgPayloadGetVectorDateTime(m_msg, NULL, 1, &m_out, NULL);
     EXPECT_EQ (MAMA_STATUS_NULL_ARG, m_status);
 }
 
@@ -4145,14 +4144,14 @@ protected:
 // AddVectorPrice test fixtures
 // ****************************
 
-TEST_F(PayloadVectorPriceTests, DISABLED_AddVectorPrice)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(PayloadVectorPriceTests, AddVectorPrice)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorPrice(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
     // TODO Check prototype for GetVectorPrice
-    m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 1, (void* const*) &m_out, &m_outSize);
+    m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 1, &m_out, &m_outSize);
     EXPECT_EQ (MAMA_STATUS_OK , m_status);
 
     EXPECT_EQ (VECTOR_SIZE , m_outSize);
@@ -4172,44 +4171,44 @@ TEST_F(PayloadVectorPriceTests, DISABLED_AddVectorPrice)
     }
 }
 
-TEST_F(PayloadVectorPriceTests, DISABLED_AddVectorPriceNullPrice)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(PayloadVectorPriceTests, AddVectorPriceNullPrice)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorPrice(m_msg, NULL, 1, NULL, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_NULL_ARG , m_status);
 }
 
-TEST_F(PayloadVectorPriceTests, DISABLED_AddVectorPriceNullMsg)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(PayloadVectorPriceTests, AddVectorPriceNullMsg)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorPrice(NULL, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_NULL_ARG, m_status);
 }
 
-TEST_F(PayloadVectorPriceTests, DISABLED_AddVectorPriceAfterInit)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(PayloadVectorPriceTests, AddVectorPriceAfterInit)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorPrice(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
     m_status = m_payloadBridge->msgPayloadAddVectorPrice(m_msg, NULL, 2, m_in, VECTOR_SIZE);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 }
 
-TEST_F(PayloadVectorPriceTests, DISABLED_AddVectorPriceInvalidName)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(PayloadVectorPriceTests, AddVectorPriceInvalidName)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorPrice(m_msg, "Bob", 0, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
     m_status = m_payloadBridge->msgPayloadAddVectorPrice(m_msg, NULL, 0, m_in, VECTOR_SIZE);
     EXPECT_EQ (MAMA_STATUS_NULL_ARG, m_status);
 }
 
-TEST_F(PayloadVectorPriceTests, DISABLED_AddVectorPriceInvalidFid)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(PayloadVectorPriceTests, AddVectorPriceInvalidFid)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorPrice(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
     m_status = m_payloadBridge->msgPayloadAddVectorPrice(m_msg, NULL, 0, m_in, VECTOR_SIZE);
@@ -4219,13 +4218,13 @@ TEST_F(PayloadVectorPriceTests, DISABLED_AddVectorPriceInvalidFid)
 // UpdateVectorPrice test fixtures
 // *******************************
 // wmsgPayload_updateVectorPrice not implemented
-TEST_F(PayloadVectorPriceTests, DISABLED_UpdateVectorPrice)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(PayloadVectorPriceTests, UpdateVectorPrice)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorPrice(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
-    m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 1, (void* const*) &m_out, &m_outSize);
+    m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 1, &m_out, &m_outSize);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
     EXPECT_EQ (VECTOR_SIZE, m_outSize);
 
@@ -4244,11 +4243,10 @@ TEST_F(PayloadVectorPriceTests, DISABLED_UpdateVectorPrice)
     }
 
     // TODO Interface inconsistent
-    m_status = m_payloadBridge->msgPayloadUpdateVectorPrice(m_msg, NULL, 1, (void* const**) m_update, VECTOR_UPDATE_SIZE);
+    m_status = m_payloadBridge->msgPayloadUpdateVectorPrice(m_msg, NULL, 1, m_update, VECTOR_UPDATE_SIZE);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
-    /*
-    m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 1, (void* const*) &m_out, &m_outSize);
+    m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 1, &m_out, &m_outSize);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
     EXPECT_EQ (VECTOR_UPDATE_SIZE, m_outSize);
 
@@ -4265,17 +4263,16 @@ TEST_F(PayloadVectorPriceTests, DISABLED_UpdateVectorPrice)
     {
         FAIL();
     }
-    */
 }
 
-TEST_F(PayloadVectorPriceTests, DISABLED_UpdateVectorPriceNullUpdate)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(PayloadVectorPriceTests, UpdateVectorPriceNullUpdate)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorPrice(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
     // TODO Check prototype for GetVectorPrice
-    m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 1, (void* const*) &m_out, &m_outSize);
+    m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 1, &m_out, &m_outSize);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
     EXPECT_EQ ((mama_size_t)VECTOR_SIZE, m_outSize);
 
@@ -4297,14 +4294,14 @@ TEST_F(PayloadVectorPriceTests, DISABLED_UpdateVectorPriceNullUpdate)
     EXPECT_EQ (MAMA_STATUS_NULL_ARG, m_status);
 }
 
-TEST_F(PayloadVectorPriceTests, DISABLED_UpdateVectorPriceNullMessage)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(PayloadVectorPriceTests, UpdateVectorPriceNullMessage)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorPrice(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
     // TODO Check prototype for GetVectorPrice
-    m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 1, (void* const*) &m_out, &m_outSize);
+    m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 1, &m_out, &m_outSize);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
     EXPECT_EQ ((mama_size_t)VECTOR_SIZE, m_outSize);
 
@@ -4323,20 +4320,20 @@ TEST_F(PayloadVectorPriceTests, DISABLED_UpdateVectorPriceNullMessage)
         FAIL();
     }
 
-    m_status = m_payloadBridge->msgPayloadUpdateVectorPrice(NULL, NULL, 1, (void* const**) m_update, VECTOR_UPDATE_SIZE);
+    m_status = m_payloadBridge->msgPayloadUpdateVectorPrice(NULL, NULL, 1, m_update, VECTOR_UPDATE_SIZE);
     EXPECT_EQ (MAMA_STATUS_NULL_ARG, m_status);
 }
 
 // GetVectorPrice test fixtures
 // ****************************
-TEST_F(PayloadVectorPriceTests, DISABLED_GetVectorPrice)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(PayloadVectorPriceTests, GetVectorPrice)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorPrice(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
     // TODO Check prototype for GetVectorPrice
-    m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 1, (void* const*) &m_out, &m_outSize);
+    m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 1, &m_out, &m_outSize);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
     EXPECT_EQ ((mama_size_t)VECTOR_SIZE, m_outSize);
 
@@ -4356,10 +4353,10 @@ TEST_F(PayloadVectorPriceTests, DISABLED_GetVectorPrice)
     }
 
     // TODO Interface Inconsistent
-    m_status = m_payloadBridge->msgPayloadUpdateVectorPrice(m_msg, NULL, 1, (void* const**) m_update, VECTOR_UPDATE_SIZE);
+    m_status = m_payloadBridge->msgPayloadUpdateVectorPrice(m_msg, NULL, 1, m_update, VECTOR_UPDATE_SIZE);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
-    m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 1, (void* const*) &m_out, &m_outSize);
+    m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 1, &m_out, &m_outSize);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
     EXPECT_EQ ((mama_size_t)VECTOR_UPDATE_SIZE, m_outSize);
 
@@ -4379,33 +4376,33 @@ TEST_F(PayloadVectorPriceTests, DISABLED_GetVectorPrice)
     }
 }
 
-TEST_F(PayloadVectorPriceTests, DISABLED_GetVectorPriceNullResult)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(PayloadVectorPriceTests, GetVectorPriceNullResult)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorPrice(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
     m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 1, NULL, &m_outSize);
     EXPECT_EQ (MAMA_STATUS_NULL_ARG, m_status);
 }
 
-TEST_F(PayloadVectorPriceTests, DISABLED_GetVectorPriceNullSize)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(PayloadVectorPriceTests, GetVectorPriceNullSize)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorPrice(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
-    m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 1, (void* const*) &m_out, NULL);
+    m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 1, &m_out, NULL);
     EXPECT_EQ (MAMA_STATUS_NULL_ARG, m_status);
 }
 
-TEST_F(PayloadVectorPriceTests, DISABLED_GetVectorPriceNotFound)
-// Disabled as mamaMsg_addVectorPrice is not implemented.
+TEST_F(PayloadVectorPriceTests, GetVectorPriceNotFound)
 {
     m_status = m_payloadBridge->msgPayloadAddVectorPrice(m_msg, NULL, 1, m_in, VECTOR_SIZE);
+    CHECK_NON_IMPLEMENTED_OPTIONAL(m_status);
     EXPECT_EQ (MAMA_STATUS_OK, m_status);
 
-    m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 2, (void* const*) &m_out, &m_outSize);
+    m_status = m_payloadBridge->msgPayloadGetVectorPrice(m_msg, NULL, 2, &m_out, &m_outSize);
     EXPECT_EQ (MAMA_STATUS_NOT_FOUND, m_status);
 }
 

--- a/mama/jni/src/com/wombat/mama/MamaStatus.java
+++ b/mama/jni/src/com/wombat/mama/MamaStatus.java
@@ -83,6 +83,8 @@ public class MamaStatus
     public static final short MAMA_STATUS_NO_BRIDGE_IMPL              = 26;
     /** Invalid queue */
     public static final short MAMA_STATUS_INVALID_QUEUE               = 27;
+    /** Message Type DELETE  */
+    public static final short MAMA_STATUS_DELETE                      = 29;
     /** Not permissioned for the subject */
     public static final short MAMA_STATUS_NOT_PERMISSIONED            = 4001;
     /** Subscription is in an invalid state. */
@@ -91,7 +93,12 @@ public class MamaStatus
     public static final short MAMA_STATUS_QUEUE_OPEN_OBJECTS          = 5002;
     /** The function isn't supported for this type of subscription. */
     public static final short MAMA_STATUS_SUBSCRIPTION_INVALID_TYPE   = 5003;
-
+    /** A symbol has no subscribers. */
+    public static final short MAMA_STATUS_NO_SUBSCRIBERS              = 5006;
+    /** The symbol has expired. */
+    public static final short MAMA_STATUS_EXPIRED                     = 5007;
+    /** The application's bandwidth limit has been exceeded. */
+    public static final short MAMA_STATUS_BANDWIDTH_EXCEEDED          = 5008;
     /**
      * Return a text description of the message's status.
      *

--- a/mamda/dotnet/src/cs/MamdaAuctionListener.cs
+++ b/mamda/dotnet/src/cs/MamdaAuctionListener.cs
@@ -69,7 +69,7 @@ namespace Wombat
             cache.mEventSeqNum   = 0;
 
 			cache.mUncrossPrice.clear();
-			cache.mUncrossVolume = 0;
+			cache.mUncrossVolume = 0.0;
 			cache.mUncrossPriceIndStr = null;
 
             
@@ -141,9 +141,9 @@ namespace Wombat
 			return mAuctionCache.mUncrossPrice;
 		}
 
-		public long getUncrossVolume()
+		public double getUncrossVolume()
 		{
-			return (long) mAuctionCache.mUncrossVolume;
+			return mAuctionCache.mUncrossVolume;
 		}
 
         public long getUncrossPriceInd()

--- a/mamda/dotnet/src/cs/MamdaAuctionRecap.cs
+++ b/mamda/dotnet/src/cs/MamdaAuctionRecap.cs
@@ -45,7 +45,7 @@ namespace Wombat
 		/// Get the uncross Volume.
 		/// </summary>
 		/// <returns>Indicative Volume or the volume turned over in the auction</returns>
-		long getUncrossVolume();
+		double getUncrossVolume();
 
         /// <summary>
         /// Get the field state

--- a/mamda/dotnet/src/cs/MamdaAuctionUpdate.cs
+++ b/mamda/dotnet/src/cs/MamdaAuctionUpdate.cs
@@ -45,7 +45,7 @@ namespace Wombat
 		/// Get the uncross Volume.
 		/// </summary>
 		/// <returns>Indicative Volume or the volume turned over in the auction</returns>
-		long getUncrossVolume();
+		double getUncrossVolume();
 
         /// <summary>
         /// Get the field state

--- a/mamda/dotnet/src/cs/MamdaSubscription.cs
+++ b/mamda/dotnet/src/cs/MamdaSubscription.cs
@@ -256,8 +256,7 @@ namespace Wombat
 		{
 			if (mSubscription != null)
 			{
-				mSubscription.deallocate();
-				mSubscription = null;
+				mSubscription.destroyEx();
 			}
 		}
 
@@ -486,6 +485,8 @@ namespace Wombat
 			public void onDestroy (
 				MamaSubscription subscription)
 			{
+				subscription.deallocate ();
+				mSubscription = null;
 			}
 		}
 

--- a/mamda/java/com/wombat/mamda/MamdaAuctionListener.java
+++ b/mamda/java/com/wombat/mamda/MamdaAuctionListener.java
@@ -67,7 +67,7 @@ public class MamdaAuctionListener implements MamdaMsgListener,
     public MamaString       mSymbol                = new MamaString();
 
     public MamaPrice            mUncrossPrice      = new MamaPrice();
-    public MamaLong             mUncrossVolume     = new MamaLong();
+    public MamaDouble           mUncrossVolume     = new MamaDouble();
     public MamdaUncrossPriceInd mUncrossPriceInd   = new MamdaUncrossPriceInd();
         
     public MamdaFieldState  mSrcTimeFieldState     = new MamdaFieldState();
@@ -85,9 +85,6 @@ public class MamdaAuctionListener implements MamdaMsgListener,
     public MamdaFieldState  mUncrossVolumeFieldState   = new MamdaFieldState();
     public MamdaFieldState  mUncrossPriceIndFieldState = new MamdaFieldState();
 
-    public MamaPrice        tmpPrice        = new MamaPrice();
-    public MamaDouble       tmpDouble       = new MamaDouble();
-   
     /**
      * clearCache - clears all cached data by resetting to 
      * default values.
@@ -106,7 +103,7 @@ public class MamdaAuctionListener implements MamdaMsgListener,
         mSymbol.setValue      (null);  mSymbolFieldState.setState      (MamdaFieldState.NOT_INITIALISED);
       
         mUncrossPrice.clear     ();
-        mUncrossVolume.setValue (0);
+        mUncrossVolume.setValue (0.0);
         mUncrossPriceInd.set    (MamdaUncrossPriceInd.UNCROSS_NONE);
       
         mUncrossPriceFieldState.setState    (MamdaFieldState.NOT_INITIALISED);
@@ -232,9 +229,9 @@ public class MamdaAuctionListener implements MamdaMsgListener,
      * getUncrossVolume
      * @return mUncrossVolume
      */
-    public long getUncrossVolume()
+    public MamaDouble getUncrossVolume()
     {
-        return mUncrossVolume.getValue();
+        return mUncrossVolume;
     }
 
     /**
@@ -670,7 +667,7 @@ public class MamdaAuctionListener implements MamdaMsgListener,
         public void onUpdate (MamdaAuctionListener listener,
                               MamaMsgField         field)
         {
-            listener.mUncrossVolume.setValue (field.getI64());
+            listener.mUncrossVolume.setValue (field.getF64());
             listener.mUncrossVolumeFieldState.setState (MamdaFieldState.MODIFIED);
         }
 

--- a/mamda/java/com/wombat/mamda/MamdaAuctionRecap.java
+++ b/mamda/java/com/wombat/mamda/MamdaAuctionRecap.java
@@ -39,9 +39,9 @@ public interface MamdaAuctionRecap extends MamdaBasicRecap
     /**
      * Get the uncross vol.
      *
-     * @return Ask price.   The indicative volume, or the volume turned over in the auction 
+     * @return uncross price.   The indicative volume, or the volume turned over in the auction 
      */    
-    long  getUncrossVolume();
+    MamaDouble  getUncrossVolume();
 
     /**
      * Get the uncross price Ind.

--- a/mamda/java/com/wombat/mamda/MamdaAuctionUpdate.java
+++ b/mamda/java/com/wombat/mamda/MamdaAuctionUpdate.java
@@ -43,7 +43,7 @@ public interface MamdaAuctionUpdate extends MamdaBasicEvent
      *
      * @return Ask price.   The indicative volume, or the volume turned over in the auction 
      */    
-    long  getUncrossVolume();
+    MamaDouble  getUncrossVolume();
 
     /**
      * Get the uncross price Ind.

--- a/mamda/java/com/wombat/mamda/MamdaErrorCode.java
+++ b/mamda/java/com/wombat/mamda/MamdaErrorCode.java
@@ -22,6 +22,7 @@
 package com.wombat.mamda;
 
 import com.wombat.mama.MamaMsgStatus;
+import com.wombat.mama.MamaStatus;
 
 /**
  * MamdaErrorCode defines MAMDA error codes.
@@ -108,7 +109,7 @@ public class MamdaErrorCode
         }
     }
 
-    public static short codeForMamaMsgStatus (short wombatStatus)
+    @Deprecated public static short codeForMamaMsgStatus (short wombatStatus)
     {
         switch (wombatStatus)
         {
@@ -129,6 +130,27 @@ public class MamdaErrorCode
         case MamaMsgStatus.STATUS_BANDWIDTH_EXCEEDED:   return MAMDA_ERROR_BANDWIDTH_EXCEEDED;
         case MamaMsgStatus.STATUS_EXCEPTION:            return MAMDA_ERROR_EXCEPTION;
         case MamaMsgStatus.STATUS_DELETE:               return MAMDA_ERROR_DELETE;
+        }
+
+        return -1;
+    }
+
+    public static short codeForMamaStatus (short wombatStatus)
+    {
+        switch (wombatStatus)
+        {
+
+        case MamaStatus.MAMA_STATUS_OK:                 return MAMDA_NO_ERROR;
+        case MamaStatus.MAMA_STATUS_NO_SUBSCRIBERS:     return MAMDA_ERROR_NO_SUBSCRIBERS;
+        case MamaStatus.MAMA_STATUS_BAD_SYMBOL:         return MAMDA_ERROR_BAD_SYMBOL;
+        case MamaStatus.MAMA_STATUS_EXPIRED:            return MAMDA_ERROR_EXPIRED;
+        case MamaStatus.MAMA_STATUS_TIMEOUT:            return MAMDA_ERROR_TIMEOUT;
+        case MamaStatus.MAMA_STATUS_PLATFORM:           return MAMDA_ERROR_PLATFORM_STATUS;
+        case MamaStatus.MAMA_STATUS_NOT_ENTITLED:       return MAMDA_ERROR_NOT_ENTITLED;
+        case MamaStatus.MAMA_STATUS_NOT_FOUND:          return MAMDA_ERROR_NOT_FOUND;
+        case MamaStatus.MAMA_STATUS_NOT_PERMISSIONED:   return MAMDA_ERROR_NOT_PERMISSIONED;
+        case MamaStatus.MAMA_STATUS_BANDWIDTH_EXCEEDED: return MAMDA_ERROR_BANDWIDTH_EXCEEDED;
+        case MamaStatus.MAMA_STATUS_DELETE:             return MAMDA_ERROR_DELETE;
         }
 
         return -1;

--- a/mamda/java/com/wombat/mamda/MamdaSubscription.java
+++ b/mamda/java/com/wombat/mamda/MamdaSubscription.java
@@ -565,7 +565,7 @@ public class MamdaSubscription
                  */
                 MamdaErrorListener listener =
                     (MamdaErrorListener)listeners.elementAt(i);
-                short errorCode = MamdaErrorCode.codeForMamaMsgStatus (wombatStatus);
+                short errorCode = MamdaErrorCode.codeForMamaStatus (wombatStatus);
                 listener.onError (
                     mSubscription,
                     MamdaErrorSeverity.severityForErrorCode (errorCode),

--- a/mamda/java/com/wombat/mamda/MamdaSubscription.java
+++ b/mamda/java/com/wombat/mamda/MamdaSubscription.java
@@ -266,8 +266,7 @@ public class MamdaSubscription
     {
         if( mSubscription != null )
         {
-            mSubscription.destroy();
-            mSubscription = null;
+            mSubscription.destroyEx();
         }
         mValid = false;
     }  
@@ -608,7 +607,8 @@ public class MamdaSubscription
 
         public void onDestroy (MamaSubscription subscription)            
         {
-            // Do nothing
+            subscription.deallocate ();
+            mSubscription = null;
         }
     }
 }


### PR DESCRIPTION
## Summary
Added support for format strings when evaluating properties

## Areas Affected
*Place an 'x' within the braces to check the box*
- [ ] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
Added a new method properties_GetPropertyValueUsingFormatString to allow the
caller to provide a sprintf style format string inline and provide a default
to reduce the amount of code required when performing common property parsing
tasks.

Also simplified properties_GetPropertyValueAsBoolean to use strtobool instead
of duplicating the strings to check for boolean evaluation.

## Testing
I have just added some OpenMAMA ZeroMQ code which makes use of this functionality. Note this is the same code that formerly lived in the qpid bridge so once this gets into next, some qpid changes to make use of it will follow.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/183)
<!-- Reviewable:end -->
