### PR TITLE
Revert "[PLAT-383] - Additional NULL check before string.h function calls added."

### DIFF
--- a/mama/c_cpp/src/c/subscription.c
+++ b/mama/c_cpp/src/c/subscription.c
@@ -1738,10 +1738,6 @@ mamaSubscription_setSymbol (
 {
     if (!subscription) return MAMA_STATUS_NULL_ARG;
     checkFree (&self->mUserSymbol);
-    if (!symbol)
-    {
-        symbol = "";
-    }
     self->mUserSymbol = strdup(symbol);
     return MAMA_STATUS_OK;
 }
@@ -2491,11 +2487,6 @@ isEntitledToSymbol (const char *source, const char*symbol, mamaSubscription subs
 
 char* copyString (const char*  str)
 {
-    if (!str)
-    {
-        str = "";
-    }
-
     /* Windows does not like strdup */
     size_t len = strlen (str) + 1;
     char* result = (char*)calloc (len, sizeof (char));


### PR DESCRIPTION
Reverts OpenMAMA/OpenMAMA#177

Mixed declaration is introduced on windows with this change which causes build failure:

http://ci.openmama.org:8080/job/OpenMAMA_Next_Branch_VS_2012/55/console

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/184)
<!-- Reviewable:end -->
