### PR TITLE
COMMON: Added support for format strings when evaluating properties

### DIFF
--- a/common/c_cpp/src/c/property.c
+++ b/common/c_cpp/src/c/property.c
@@ -21,6 +21,7 @@
 
 #include "wombat/port.h"
 
+#include <stdarg.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -31,6 +32,7 @@
 #include "propertyinternal.h"
 #include "lookup2.h"
 #include "wombat/wtable.h"
+#include "wombat/strutils.h"
 
 #define KEY_BLOCK_SIZE 64
 
@@ -300,21 +302,7 @@ properties_Merge( wproperty_t to, wproperty_t from )
 int
 properties_GetPropertyValueAsBoolean(const char* propertyValue)
 {
-  if (
-      (strcmp(propertyValue,"1")==0) ||
-      (strcmp(propertyValue,"y")==0) ||
-      (strcmp(propertyValue,"Y")==0) ||
-      (strcmp(propertyValue,"yes")==0) ||
-      (strcmp(propertyValue,"YES")==0) ||
-      (strcmp(propertyValue,"true")==0) ||
-      (strcmp(propertyValue,"TRUE")==0) ||
-      (strcmp(propertyValue,"t")==0) ||
-      (strcmp(propertyValue,"T")==0)
-    )
-  {
-    return 1;
-  }
-  return 0;
+    return strtobool(propertyValue);
 }
 
 /**
@@ -337,6 +325,39 @@ properties_Get( wproperty_t handle, const char* name )
     if( gPropertyDebug )fprintf( stderr, "Get property: %s\n", rval );
 
     return rval;
+}
+
+const char*
+properties_GetPropertyValueUsingFormatString (wproperty_t handle,
+                                              const char* defaultVal,
+                                              const char* format,
+                                              ...)
+{
+    char        paramName[PROPERTY_NAME_MAX_LENGTH];
+    const char* returnVal = NULL;
+
+    /* Create list for storing the properties passed in */
+    va_list     arguments;
+
+    /* Populate list with arguments passed in */
+    va_start (arguments, format);
+
+    /* Create the complete transport property string */
+    vsnprintf (paramName, PROPERTY_NAME_MAX_LENGTH, format, arguments);
+
+    /* Get the property out for analysis */
+    returnVal = properties_Get (handle, paramName);
+
+    /* Properties will return NULL if property is not specified in configs */
+    if (returnVal == NULL)
+    {
+        returnVal = defaultVal;
+    }
+
+    /* Clean up the list */
+    va_end(arguments);
+
+    return returnVal;
 }
 
 int

--- a/common/c_cpp/src/c/property.h
+++ b/common/c_cpp/src/c/property.h
@@ -28,7 +28,9 @@
 extern "C" {
 #endif
 
-#define INVALID_PROPERTIES NULL
+#define     INVALID_PROPERTIES              NULL
+#define     PROPERTY_NAME_MAX_LENGTH        1024L
+
 typedef void* wproperty_t;
 
 typedef void( *propertiesCallback) (const char* name, const char* value,
@@ -107,6 +109,13 @@ properties_FreeEx2( wproperty_t handle );
 COMMONExpDLL
 int 
 properties_GetPropertyValueAsBoolean( const char* propertyValue );
+
+COMMONExpDLL
+const char*
+properties_GetPropertyValueUsingFormatString (wproperty_t handle,
+                                              const char* defaultVal,
+                                              const char* format,
+                                              ...);
 
 /**
  * Will escape the chars with a \ found to match in chars array. Returns a 


### PR DESCRIPTION
## Summary
Added support for format strings when evaluating properties

## Areas Affected
*Place an 'x' within the braces to check the box*
- [ ] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
Added a new method properties_GetPropertyValueUsingFormatString to allow the
caller to provide a sprintf style format string inline and provide a default
to reduce the amount of code required when performing common property parsing
tasks.

Also simplified properties_GetPropertyValueAsBoolean to use strtobool instead
of duplicating the strings to check for boolean evaluation.

## Testing
I have just added some OpenMAMA ZeroMQ code which makes use of this functionality. Note this is the same code that formerly lived in the qpid bridge so once this gets into next, some qpid changes to make use of it will follow.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/186)
<!-- Reviewable:end -->
