### PR TITLE
MAMAMSG: Fixed leak in detach and mamaMsg_getMsg

### DIFF
--- a/mama/c_cpp/src/c/msg.c
+++ b/mama/c_cpp/src/c/msg.c
@@ -242,18 +242,22 @@ mamaMsg_detach (mamaMsg msg)
                   "Could not detach bridge message.");
         return status;
     }
-    /* Copy the payload */
-    if (MAMA_STATUS_OK != (status =
-       (msg->mPayloadBridge->msgPayloadCopy (impl->mPayload,
-                                             &payload))))
+
+    /* If we don't own the payload yet, detach it */
+    if (0 == impl->mMessageOwner)
     {
-        mama_log(MAMA_LOG_LEVEL_ERROR,
-                 "mamaMsg_detach() Failed. "
-                 "Could not copy native payload [%d]", status);
-        return status;
+        if (MAMA_STATUS_OK != (status =
+           (msg->mPayloadBridge->msgPayloadCopy (impl->mPayload,
+                                                 &payload))))
+        {
+            mama_log(MAMA_LOG_LEVEL_ERROR,
+                     "mamaMsg_detach() Failed. "
+                     "Could not copy native payload [%d]", status);
+            return status;
+        }
+        msg->mPayload = payload;
     }
 
-    msg->mPayload = payload;
     msg->mPayloadBridge->msgPayloadSetParent (impl->mPayload, msg);
     
     /*If this is a dqStrategy cache message*/

--- a/mama/c_cpp/src/c/payload/qpidmsg/payload.c
+++ b/mama/c_cpp/src/c/payload/qpidmsg/payload.c
@@ -660,10 +660,15 @@ qpidmsgPayload_destroy (msgPayload msg)
     }
 
     /* Release the underlying payload object */
-    if(NULL != impl->mQpidMsg)
+    if (NULL != impl->mQpidMsg)
     {
         pn_message_free (impl->mQpidMsg);
         impl->mQpidMsg = NULL;
+    }
+
+    if (NULL != impl->mChildMsg)
+    {
+        qpidmsgPayload_destroy ((msgPayload)impl->mChildMsg);
     }
 
     /* Finally, release the payload implementation object */
@@ -3087,7 +3092,6 @@ qpidmsgPayload_getMsg (const msgPayload    msg,
 {
     qpidmsgPayloadImpl*  impl       = (qpidmsgPayloadImpl*) msg;
     mama_status          status     = MAMA_STATUS_OK;
-    msgPayload           childMsg   = NULL;
 
     if (NULL == impl)
     {
@@ -3102,7 +3106,14 @@ qpidmsgPayload_getMsg (const msgPayload    msg,
         return status;
     }
 
-    status = qpidmsgPayload_create (&childMsg);
+    if (NULL == impl->mChildMsg)
+    {
+        status = qpidmsgPayload_create ((msgPayload*)&impl->mChildMsg);
+    }
+    else
+    {
+        status = qpidmsgPayload_clear ((msgPayload)impl->mChildMsg);
+    }
 
     if (MAMA_STATUS_OK != status)
     {
@@ -3118,7 +3129,7 @@ qpidmsgPayload_getMsg (const msgPayload    msg,
     pn_data_enter    (impl->mBody);
 
     status = qpidmsgPayloadImpl_getMessageFromBuffer (impl->mBody,
-		             (qpidmsgPayloadImpl*) childMsg);
+		             (qpidmsgPayloadImpl*) impl->mChildMsg);
 
     if (MAMA_STATUS_OK != status)
     {
@@ -3128,7 +3139,7 @@ qpidmsgPayload_getMsg (const msgPayload    msg,
         return status;
     }
 
-    *result = childMsg;
+    *result = impl->mChildMsg;
 
     /* Revert to the previous iterator state if applicable */
     qpidmsgPayloadImpl_resetToIteratorState (impl);

--- a/mama/c_cpp/src/c/payload/qpidmsg/qpidcommon.h
+++ b/mama/c_cpp/src/c/payload/qpidmsg/qpidcommon.h
@@ -219,6 +219,9 @@ typedef struct qpidmsgPayloadImpl_
     /* Parent MAMA message */
     mamaMsg                     mParent;
 
+    /* Child payload for use with getMsg */
+    struct qpidmsgPayloadImpl_*   mChildMsg;
+
 } qpidmsgPayloadImpl;
 
 


### PR DESCRIPTION
## Summary
MAMAMSG: Fixed leak in detach and mamaMsg_getMsg 

## Areas Affected
*Place an 'x' within the braces to check the box*
- [x] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
Payload will now track sub messages created, and detach will now
only copy a message if the payload is not currently owned by the
MAMA Message.

## Testing
Passes all unit tests and capture / replay with market data subscriptions work without issue.

Payload will now track sub messages created, and detach will now
only copy a message if the payload is not currently owned by the
MAMA Message.