### PR TITLE
Removal of all memory leaks from MAMA and Unit Tests

### DIFF
--- a/common/c_cpp/src/c/mempool.c
+++ b/common/c_cpp/src/c/mempool.c
@@ -198,18 +198,19 @@ memoryPool_destroy (memoryPool* pool, memoryPoolIteratorCb callback)
     tracker = (memoryNode**)pool->mAllocatedNodes.mNodeBuffer;
     for (i = 0; i < pool->mNumNodesTotal; i++)
     {
-        node = tracker[pool->mNumNodesTotal];
+        node = tracker[i];
         if (NULL != node)
         {
             if (NULL != callback)
             {
                 callback (pool, node);
             }
-            memoryNode_empty(node);
+            memoryNode_destroy(node);
         }
     }
     wthread_mutex_unlock(&pool->mLock);
     wthread_mutex_destroy(&pool->mLock);
+    memoryNode_empty(&pool->mAllocatedNodes);
     free (pool);
 }
 

--- a/mama/c_cpp/src/c/bridge.h
+++ b/mama/c_cpp/src/c/bridge.h
@@ -511,6 +511,9 @@ typedef struct mamaBridgeImpl_
     void*     mClosure;
     wLock     mLock;
 
+    /* Track background thread for join if startBackground is used */
+    wthread_t mStartBackgroundThread;
+
     /* The set of methods used to access/populate a message in native format */
     mamaPayloadBridge mNativeMsgBridge;
 

--- a/mama/c_cpp/src/c/bridge/qpid/bridge.c
+++ b/mama/c_cpp/src/c/bridge/qpid/bridge.c
@@ -202,7 +202,7 @@ qpidBridge_stop (mamaQueue defaultEventQueue)
     if (NULL == defaultEventQueue)
     {
       mama_log (MAMA_LOG_LEVEL_FINER,
-                "qpidBridge_start(): defaultEventQueue is NULL");
+                "qpidBridge_stop(): defaultEventQueue is NULL");
       return MAMA_STATUS_NULL_ARG;
     }
 

--- a/mama/c_cpp/src/c/bridge/qpid/io.c
+++ b/mama/c_cpp/src/c/bridge/qpid/io.c
@@ -218,8 +218,8 @@ qpidBridgeMamaIoImpl_stop ()
     /* Alert the semaphore so the dispatch loop can exit */
     wsem_post (&gQpidIoContainer.mResumeDispatching);
 
-    /* Tell the event loop to exit */
-    event_base_loopexit (gQpidIoContainer.mEventBase, NULL);
+    /* Flush until event base is empty */
+    while (0 == event_base_loop(gQpidIoContainer.mEventBase, EVLOOP_ONCE));
 
     /* Join with the dispatch thread - it should exit shortly */
     wthread_join (gQpidIoContainer.mDispatchThread, NULL);

--- a/mama/c_cpp/src/c/entitlement.c
+++ b/mama/c_cpp/src/c/entitlement.c
@@ -29,7 +29,9 @@ mamaEntitlementBridge_createSubscription(mamaEntitlementSubscription* subscripti
 {
     mamaEntitlementSubscription sub = malloc(sizeof(mamaEntitlementSubscription_));
     if (NULL == sub)
-    	return MAMA_STATUS_NOMEM;
+    {
+        return MAMA_STATUS_NOMEM;
+    }
     *subscription = sub;
     return MAMA_STATUS_OK;
 }
@@ -37,10 +39,16 @@ mamaEntitlementBridge_createSubscription(mamaEntitlementSubscription* subscripti
 mama_status
 mamaEntitlementBridge_destroySubscription(mamaEntitlementSubscription subscription)
 {
-    if (NULL != subscription->mImpl)
+    if (NULL != subscription && NULL != subscription->mImpl)
     {
         mamaEntitlementBridge entBridge = (mamaEntitlementBridge) subscription->mEntitlementBridge;
         entBridge->destroySubscription(subscription->mImpl);
+        subscription->mImpl = NULL;
+    }
+
+    if (NULL != subscription)
+    {
+        free (subscription);
     }
     return MAMA_STATUS_OK;
 }

--- a/mama/c_cpp/src/c/mama.c
+++ b/mama/c_cpp/src/c/mama.c
@@ -1196,24 +1196,7 @@ mama_setPropertiesFromFile (const char *path,
     mama_log (MAMA_LOG_LEVEL_NORMAL,
               "Attempting to load additional MAMA properties from %s", path ? path : "");
 
-    fileProperties = properties_Load (path, filename);
-
-    if( fileProperties == 0 )
-    {
-        mama_log (MAMA_LOG_LEVEL_ERROR, "Failed to open additional properties file.\n");
-        return MAMA_STATUS_IO_ERROR;
-    }
-
-    /* We've got file properties, so we need to merge 'em into
-     * anything we've already gotten */
-    properties_Merge( fileProperties, gProperties );
-
-    /* Free the file properties, note that FreeEx2 is called to ensure that the data
-     * isn't freed as the pointers have been copied over to gProperties.
-     */
-    properties_FreeEx2(gProperties);
-    
-    gProperties = fileProperties;
+    mamaInternal_loadProperties (path, filename);
 
     return MAMA_STATUS_OK;
 }

--- a/mama/c_cpp/src/c/mama.c
+++ b/mama/c_cpp/src/c/mama.c
@@ -1532,6 +1532,9 @@ mama_closeCount (unsigned int* count)
         /* Destroy logging */
         mama_logDestroy();
 
+        /* Clean up any timezone related threads which may have been started */
+        mamaTimeZone_cleanUp ();
+
         /* Free application context details. */
         mama_freeAppContext(&appContext);
 

--- a/mama/c_cpp/src/c/mama/timezone.h
+++ b/mama/c_cpp/src/c/mama/timezone.h
@@ -114,6 +114,15 @@ MAMAExpDLL
 extern void
 mamaTimeZone_setScanningInterval (mama_f64_t  seconds);
 
+/**
+ * If you used any timezone functions, you'll need to call this function to
+ * clean up any memory they will have allocated, but hung onto to avoid constant
+ * re-allocation of resources on the critical path.
+ */
+MAMAExpDLL
+extern void
+mamaTimeZone_cleanUp (void);
+
 
 #if defined(__cplusplus)
 }

--- a/mama/c_cpp/src/c/msg.c
+++ b/mama/c_cpp/src/c/msg.c
@@ -174,6 +174,11 @@ mamaMsg_destroy (mamaMsg msg)
         mamaMsg_destroy (impl->mCopy);
         impl->mCopy = NULL;
     }
+    /* Destroy reusable datetime if allocated */
+    if (impl->mCurrentDateTime)
+    {
+        mamaDateTime_destroy(impl->mCurrentDateTime);
+    }
 
     impl->mDqStrategyContext = NULL;
 
@@ -506,6 +511,11 @@ mamaMsg_createForPayloadBridge (mamaMsg* msg, mamaPayloadBridge payloadBridge)
     msgPayload payload;
     mama_status status = MAMA_STATUS_OK;
 
+    if (!msg)
+    {
+        return MAMA_STATUS_NULL_ARG;
+    }
+
     if (MAMA_STATUS_OK !=
        (status = payloadBridge->msgPayloadCreate (&payload)))
     {
@@ -807,6 +817,11 @@ mamaMsg_create (mamaMsg* msg)
     mama_status       status  = MAMA_STATUS_OK;
     mamaPayloadBridge bridge  = mamaInternal_getDefaultPayload ();
     msgPayload        payload = NULL;
+
+    if (!msg)
+    {
+        return MAMA_STATUS_NULL_ARG;
+    }
 
     if (bridge)
     {

--- a/mama/c_cpp/src/c/msg.c
+++ b/mama/c_cpp/src/c/msg.c
@@ -247,18 +247,22 @@ mamaMsg_detach (mamaMsg msg)
                   "Could not detach bridge message.");
         return status;
     }
-    /* Copy the payload */
-    if (MAMA_STATUS_OK != (status =
-       (msg->mPayloadBridge->msgPayloadCopy (impl->mPayload,
-                                             &payload))))
+
+    /* If we don't own the payload yet, detach it */
+    if (0 == impl->mMessageOwner)
     {
-        mama_log(MAMA_LOG_LEVEL_ERROR,
-                 "mamaMsg_detach() Failed. "
-                 "Could not copy native payload [%d]", status);
-        return status;
+        if (MAMA_STATUS_OK != (status =
+           (msg->mPayloadBridge->msgPayloadCopy (impl->mPayload,
+                                                 &payload))))
+        {
+            mama_log(MAMA_LOG_LEVEL_ERROR,
+                     "mamaMsg_detach() Failed. "
+                     "Could not copy native payload [%d]", status);
+            return status;
+        }
+        msg->mPayload = payload;
     }
 
-    msg->mPayload = payload;
     msg->mPayloadBridge->msgPayloadSetParent (impl->mPayload, msg);
     
     /*If this is a dqStrategy cache message*/

--- a/mama/c_cpp/src/c/payload/qpidmsg/payload.c
+++ b/mama/c_cpp/src/c/payload/qpidmsg/payload.c
@@ -978,10 +978,14 @@ qpidmsgPayload_setByteBuffer (const msgPayload    msg,
 
     if (bufferLength == sizeof(pn_message_t*))
     {
-        pn_message_t* qMsg = (pn_message_t*) buffer;
+        /*pn_message_t* qMsg = (pn_message_t*) buffer;*/
 
         /* NB: will delete contents of impl->mBody */
-        pn_data_copy (impl->mBody, pn_message_body (qMsg));
+        /*pn_data_copy (impl->mBody, pn_message_body (qMsg));*/
+
+        impl->mQpidMsg = (pn_message_t*) buffer;
+        impl->mBody    = pn_message_body (impl->mQpidMsg);
+
     }
     else
     {

--- a/mama/c_cpp/src/c/payload/qpidmsg/payload.c
+++ b/mama/c_cpp/src/c/payload/qpidmsg/payload.c
@@ -978,8 +978,10 @@ qpidmsgPayload_setByteBuffer (const msgPayload    msg,
 
     if (bufferLength == sizeof(pn_message_t*))
     {
-        impl->mQpidMsg = (pn_message_t*) buffer;
-        impl->mBody    = pn_message_body (impl->mQpidMsg);
+        pn_message_t* qMsg = (pn_message_t*) buffer;
+
+        /* NB: will delete contents of impl->mBody */
+        pn_data_copy (impl->mBody, pn_message_body (qMsg));
     }
     else
     {

--- a/mama/c_cpp/src/c/payload/qpidmsg/qpidcommon.h
+++ b/mama/c_cpp/src/c/payload/qpidmsg/qpidcommon.h
@@ -219,6 +219,9 @@ typedef struct qpidmsgPayloadImpl_
     /* Parent MAMA message */
     mamaMsg                     mParent;
 
+    /* Child payload for use with getMsg */
+    struct qpidmsgPayloadImpl_*   mChildMsg;
+
 } qpidmsgPayloadImpl;
 
 

--- a/mama/c_cpp/src/c/publisher.c
+++ b/mama/c_cpp/src/c/publisher.c
@@ -867,7 +867,7 @@ static void MAMACALLTYPE mamaPublisher_onPublisherDestroyed(mamaPublisher publis
             impl, source, symbol, mamaPublisher_stringForState(impl->mState));
     }
 
-    if (NULL != impl->mUserCallbacks.onDestroy)
+    if (NULL != *impl->mUserCallbacks.onDestroy)
     {
         (*impl->mUserCallbacks.onDestroy)(publisher, impl->mClosure);
     }

--- a/mama/c_cpp/src/c/subscription.c
+++ b/mama/c_cpp/src/c/subscription.c
@@ -3225,7 +3225,9 @@ void mamaSubscriptionImpl_deallocate(mamaSubscriptionImpl *impl)
 
     /* Destroy the state. */
     wInterlocked_destroy(&impl->mState);
-                    
+
+    mamaEntitlementBridge_destroySubscription (impl->mSubjectContext.mEntitlementSubscription);
+
     /* Free the subscription impl. */
     free(impl);
 }

--- a/mama/c_cpp/src/cpp/MamaPublisher.cpp
+++ b/mama/c_cpp/src/cpp/MamaPublisher.cpp
@@ -198,6 +198,10 @@ namespace Wombat
        {
            destroyed = true;
            mPimpl->destroy ();
+           if (!mCallback)
+           {
+               delete mPimpl;
+           }
        }
     }
 
@@ -300,7 +304,7 @@ namespace Wombat
                                        topic,
                                        source,
                                        root,
-                                       &publisherCallbacks,
+                                       mCallback ? &publisherCallbacks : NULL,
                                        this));
     }
 

--- a/mama/c_cpp/src/cpp/mamacpp.cpp
+++ b/mama/c_cpp/src/cpp/mamacpp.cpp
@@ -27,6 +27,7 @@
 #include <mama/msg.h>
 #include <mama/inbox.h>
 #include <string>
+#include <vector>
 #include "MamaSubscriptionImpl.h"
 #include <mama/queue.h>
 #include <mama/MamaQueue.h>
@@ -180,6 +181,12 @@ namespace Wombat
         if (0 == refCount)
         {
             MamaReservedFields::uninitReservedFields();
+            for (std::vector<MamaQueue*>::iterator iter = Mama::mDefaultQueueWrappers.begin(); iter != Mama::mDefaultQueueWrappers.end(); ++iter)
+            {
+                MamaQueue* defaultQueue = *iter;
+                defaultQueue->setCValue(NULL);  // middleware  bridge's respobsibility to clean up the c-queue
+                delete(defaultQueue);           //delete CPP wrapper
+            }
         }
 
         return refCount;

--- a/mama/c_cpp/src/cpp/mamacpp.cpp
+++ b/mama/c_cpp/src/cpp/mamacpp.cpp
@@ -187,6 +187,7 @@ namespace Wombat
                 defaultQueue->setCValue(NULL);  // middleware  bridge's respobsibility to clean up the c-queue
                 delete(defaultQueue);           //delete CPP wrapper
             }
+            Mama::mDefaultQueueWrappers.clear();
         }
 
         return refCount;

--- a/mama/c_cpp/src/gunittest/c/fieldcache/fieldcacheiteratortest.cpp
+++ b/mama/c_cpp/src/gunittest/c/fieldcache/fieldcacheiteratortest.cpp
@@ -97,9 +97,10 @@ TEST_F(MamaFieldCacheIteratorTestC, iteratorBegin)
     ASSERT_EQ(10, fid);
     
     mamaFieldCacheIterator_destroy(iterator);
-    mamaMsg_destroy(message);
 
     ret = mamaFieldCache_destroy(fieldCache);
+
+    mamaMsg_destroy(message);
     ASSERT_EQ(MAMA_STATUS_OK, ret);
 }
 
@@ -154,9 +155,9 @@ TEST_F(MamaFieldCacheIteratorTestC, iteratorNext)
     ASSERT_FALSE(current);
 
     mamaFieldCacheIterator_destroy(iterator);
-    mamaMsg_destroy(message);
 
     ret = mamaFieldCache_destroy(fieldCache);
+    mamaMsg_destroy(message);
 }
 
 TEST_F(MamaFieldCacheIteratorTestC, iteratorLoop)
@@ -188,7 +189,7 @@ TEST_F(MamaFieldCacheIteratorTestC, iteratorLoop)
     ASSERT_EQ(5, counter);
 
     mamaFieldCacheIterator_destroy(iterator);
-    mamaMsg_destroy(message);
 
     ret = mamaFieldCache_destroy(fieldCache);
+    mamaMsg_destroy(message);
 }

--- a/mama/c_cpp/src/gunittest/c/fieldcache/fieldcachetest.cpp
+++ b/mama/c_cpp/src/gunittest/c/fieldcache/fieldcachetest.cpp
@@ -237,8 +237,7 @@ TEST_F(MamaFieldCacheTestC, applyMsgNew)
     ret = mamaFieldCache_applyMessage(fieldCache, message, NULL);
     
 //    mamaMsg_clear(message);
-    mamaMsg_destroy (message);
-    
+
     ASSERT_EQ(MAMA_STATUS_OK, ret);
     ret = mamaFieldCache_getSize(fieldCache, &size);
     ASSERT_EQ(4, size);
@@ -297,6 +296,8 @@ TEST_F(MamaFieldCacheTestC, applyMsgNew)
     ASSERT_EQ(MAMA_STATUS_NULL_ARG, ret);
     ret = mamaFieldCache_applyMessage(fieldCache, NULL, NULL);
     ASSERT_EQ(MAMA_STATUS_NULL_ARG, ret);
+
+    mamaMsg_destroy (message);
 }
 
 TEST_F(MamaFieldCacheTestC, applyMsgUpdate)
@@ -454,9 +455,9 @@ TEST_F(MamaFieldCacheTestC, applyMsgUsingNames)
     mamaFieldCacheField_getName(field, &name);
     ASSERT_STREQ("test_string", name);
 
-    mamaMsg_destroy (message);
-
     ret = mamaFieldCache_destroy(fieldCache);
+
+    mamaMsg_destroy (message);
 }
 
 TEST_F(MamaFieldCacheTestC, getFullMsg1)
@@ -468,26 +469,31 @@ TEST_F(MamaFieldCacheTestC, getFullMsg1)
     mamaFieldCacheField_create(&field, 10, MAMA_FIELD_TYPE_BOOL, NULL);
     mamaFieldCacheField_setBool(field, 1);
     mamaFieldCache_applyField(fieldCache, field);
+    mamaFieldCacheField_destroy(field);
 
     /* This field must never be published */
     mamaFieldCacheField_create(&field, 25, MAMA_FIELD_TYPE_F64, NULL);
     mamaFieldCacheField_setF64(field, 3.1);
     mamaFieldCacheField_setPublish(field, 0);
     mamaFieldCache_applyField(fieldCache, field);
+    mamaFieldCacheField_destroy(field);
 
     mamaFieldCacheField_create(&field, 66, MAMA_FIELD_TYPE_I32, NULL);
     mamaFieldCacheField_setI32(field, -100);
     mamaFieldCache_applyField(fieldCache, field);
+    mamaFieldCacheField_destroy(field);
 
     // Creating a string field without a value. Even if this field is added to the
     // cache, it will not be added to the message because we cannot add a NULL
     // string to a mama message
     mamaFieldCacheField_create(&field, 110, MAMA_FIELD_TYPE_STRING, NULL);
     mamaFieldCache_applyField(fieldCache, field);
+    mamaFieldCacheField_destroy(field);
 
     mamaFieldCacheField_create(&field, 90, MAMA_FIELD_TYPE_STRING, NULL);
     mamaFieldCacheField_setString(field, "hello world", 0);
     mamaFieldCache_applyField(fieldCache, field);
+    mamaFieldCacheField_destroy(field);
 
     mamaMsg message;
     mamaMsg_create(&message);
@@ -526,27 +532,32 @@ TEST_F(MamaFieldCacheTestC, getFullMsg2)
     mamaFieldCacheField_setBool(field, 1);
 //    mamaFieldCacheField_setModified(field, 0); // Set this field to unmodified
     mamaFieldCache_applyField(fieldCache, field);
-    
+    mamaFieldCacheField_destroy(field);
+
     /* This field must never be published */
     mamaFieldCacheField_create(&field, 25, MAMA_FIELD_TYPE_F64, NULL);
     mamaFieldCacheField_setF64(field, 3.1);
     mamaFieldCacheField_setPublish(field, 0);
     mamaFieldCache_applyField(fieldCache, field);
-    
+    mamaFieldCacheField_destroy(field);
+
     mamaFieldCacheField_create(&field, 66, MAMA_FIELD_TYPE_I32, NULL);
     mamaFieldCacheField_setI32(field, -100);
     mamaFieldCache_applyField(fieldCache, field);
-    
+    mamaFieldCacheField_destroy(field);
+
     // Creating a string field without a value. Even if this field is added to the
     // cache, it will not be added to the message because we cannot add a NULL
     // string to a mama message
     mamaFieldCacheField_create(&field, 110, MAMA_FIELD_TYPE_STRING, NULL);
     mamaFieldCache_applyField(fieldCache, field);
-    
+    mamaFieldCacheField_destroy(field);
+
     mamaFieldCacheField_create(&field, 90, MAMA_FIELD_TYPE_STRING, NULL);
     mamaFieldCacheField_setString(field, "hello world", 0);
     mamaFieldCache_applyField(fieldCache, field);
-    
+    mamaFieldCacheField_destroy(field);
+
     mamaMsg message;
     mamaMsg_create(&message);
 
@@ -1088,4 +1099,5 @@ TEST_F(MamaFieldCacheTestC, applyRecordUpdate)
     ret = mamaFieldCache_destroy(fieldCache);
     mamaFieldCacheRecord_destroy(record20);
     mamaFieldCacheRecord_destroy(record10);
+    mamaMsg_destroy(msg);
 }

--- a/mama/c_cpp/src/gunittest/c/iotest.cpp
+++ b/mama/c_cpp/src/gunittest/c/iotest.cpp
@@ -95,6 +95,8 @@ TEST_F (MamaIoTestC, CreateDestroy)
 
     ASSERT_EQ (MAMA_STATUS_OK,
                mamaIo_destroy (io));
+
+    ASSERT_EQ (MAMA_STATUS_OK, mamaQueue_destroy (queue));
 }
 
 /*  Description:  Create a mamaIo, get it's descriptor then destory it.
@@ -121,6 +123,8 @@ TEST_F (MamaIoTestC, getDescriptor)
     
     ASSERT_EQ (MAMA_STATUS_OK,
                mamaIo_destroy (io));
+
+    ASSERT_EQ (MAMA_STATUS_OK, mamaQueue_destroy (queue));
 
     ASSERT_EQ (descriptor, testDescriptor);
 }

--- a/mama/c_cpp/src/gunittest/c/mamadatetime/datetimerangetest.cpp
+++ b/mama/c_cpp/src/gunittest/c/mamadatetime/datetimerangetest.cpp
@@ -86,7 +86,6 @@ private:
 
 DateTimeRangeTests::DateTimeRangeTests() : ::testing::Test()
 {
-   MakeTestData();
 }
 
 DateTimeRangeTests::~DateTimeRangeTests()
@@ -180,11 +179,13 @@ DateTimeRangeTests::DestroyTestData()
 void
 DateTimeRangeTests::SetUp(void)
 {
+    MakeTestData();
 }
 
 void
 DateTimeRangeTests::TearDown(void)
 {
+    DestroyTestData();
 }
 
 

--- a/mama/c_cpp/src/gunittest/c/mamadatetime/datetimetest.cpp
+++ b/mama/c_cpp/src/gunittest/c/mamadatetime/datetimetest.cpp
@@ -40,6 +40,7 @@ protected:
 
     virtual void SetUp(void);
     virtual void TearDown(void);
+    mamaBridge mBridge;
 };
 
 MamaDateTimeTestC::MamaDateTimeTestC(void)
@@ -53,11 +54,14 @@ MamaDateTimeTestC::~MamaDateTimeTestC(void)
 void
 MamaDateTimeTestC::SetUp(void)
 {
+    mama_loadBridge (&mBridge, getMiddleware());
+    mama_open();
 }
 
 void
 MamaDateTimeTestC::TearDown(void)
 {
+    mama_close();
 }
 
 // Test Create function will valid and NULL parameters
@@ -1416,6 +1420,8 @@ TEST_F (MamaDateTimeTestC, NullArguments)
     /* NULL for both */
     ASSERT_EQ (MAMA_STATUS_NULL_ARG, 
                mamaDateTime_getEpochTimeSecondsWithCheck (NULL, NULL));
+
+    mamaDateTime_destroy (m_DateTime);
 }
 
 /*  Description:     Get the number of seconds since epoch from:
@@ -1473,4 +1479,5 @@ TEST_F (MamaDateTimeTestC, CompareDates)
     
     /* These must be the same */
     ASSERT_EQ (completeDateSeconds, timeSeconds);
+    ASSERT_EQ (MAMA_STATUS_OK, mamaDateTime_destroy (m_cDateTime));
 }

--- a/mama/c_cpp/src/gunittest/c/mamamsg/msgcompositetests.cpp
+++ b/mama/c_cpp/src/gunittest/c/mamamsg/msgcompositetests.cpp
@@ -433,15 +433,24 @@ protected:
 
     MsgSubMsgTestsC() : m_out(NULL)
     {
-        mamaMsg_create(&m_in);
-        mamaMsg_create(&m_update);
     }
 
     ~MsgSubMsgTestsC()
     {
+    }
+    virtual void SetUp(void)
+    {
+        MsgCompositeTestsC::SetUp();
+        ASSERT_EQ(MAMA_STATUS_OK, mamaMsg_create(&m_in));
+        ASSERT_EQ(MAMA_STATUS_OK, mamaMsg_create(&m_update));
+    };
+
+    virtual void TearDown(void)
+    {
         mamaMsg_destroy(m_in);
         mamaMsg_destroy(m_update);
-    }
+        MsgCompositeTestsC::TearDown();
+    };
 };
 /* addMsg tests */
 TEST_F(MsgSubMsgTestsC, addSubMsgValid)

--- a/mama/c_cpp/src/gunittest/c/mamamsg/msgcompositetests.cpp
+++ b/mama/c_cpp/src/gunittest/c/mamamsg/msgcompositetests.cpp
@@ -252,6 +252,7 @@ TEST_F(MsgOpaqueTests, getOpaqueInValidMessage)
         {
             mamaDateTime_destroy(m_in);
             mamaDateTime_destroy(m_update);
+            mamaDateTime_destroy(m_out);
 
             MsgCompositeTestsC::TearDown();
         }
@@ -353,6 +354,7 @@ protected:
     {
         mamaPrice_destroy(m_in);
         mamaPrice_destroy(m_update);
+        mamaPrice_destroy(m_out);
 
         MsgCompositeTestsC::TearDown();
     }
@@ -437,8 +439,8 @@ protected:
 
     ~MsgSubMsgTestsC()
     {
-        //mamaMsg_destroy(m_in);
-        //mamaMsg_destroy(m_update);
+        mamaMsg_destroy(m_in);
+        mamaMsg_destroy(m_update);
     }
 };
 /* addMsg tests */

--- a/mama/c_cpp/src/gunittest/c/mamamsg/msgfieldatomictests.cpp
+++ b/mama/c_cpp/src/gunittest/c/mamamsg/msgfieldatomictests.cpp
@@ -41,7 +41,6 @@ protected:
     {
         mama_loadPayloadBridge (&mPayloadBridge, getPayload());
         mamaMsg_create (&mMsg);
-        mamaMsgField_create (&mMsgField);
     };
 
     virtual void TearDown(void) 
@@ -132,6 +131,11 @@ protected:
         MsgFieldAtomicTestsC::SetUp();
 
         mamaMsg_addChar( mMsg, "name", 1, mUpdate);
+    }
+
+    virtual void TearDown()
+    {
+        MsgFieldAtomicTestsC::TearDown();
     }
 };
 
@@ -629,6 +633,11 @@ protected:
         MsgFieldAtomicTestsC::SetUp();
         mamaMsg_addF32( mMsg, "name", 1, mUpdate );
     }
+
+    virtual void TearDown()
+    {
+        MsgFieldAtomicTestsC::TearDown();
+    }
 };
 
 TEST_F (MsgFieldF32Tests, updateF32Valid)
@@ -683,6 +692,11 @@ protected:
     {
         MsgFieldAtomicTestsC::SetUp();
         mamaMsg_addF64( mMsg, "name", 1, mUpdate );
+    }
+
+    virtual void TearDown()
+    {
+        MsgFieldAtomicTestsC::TearDown();
     }
 };
 

--- a/mama/c_cpp/src/gunittest/c/mamamsg/msgfieldcompositetests.cpp
+++ b/mama/c_cpp/src/gunittest/c/mamamsg/msgfieldcompositetests.cpp
@@ -77,7 +77,6 @@ TEST_F (MsgFieldCompositeTestsC, msgFieldGetAsStringValid)
     char              buffer[5];
 
     //Create & add fields to msg
-    mamaMsg_create (&mMsg);
     mamaMsg_addString( mMsg, "name", 1, "test");
     mamaMsg_getField (mMsg, "name", 1, &mMsgField);
 
@@ -91,7 +90,6 @@ TEST_F (MsgFieldCompositeTestsC, msgFieldGetAsStringInValidMsgField)
     size_t            len        = 0;
 
     //Create & add fields to msg
-    mamaMsg_create (&mMsg);
     mamaMsg_addString( mMsg, "name", 1, "test");
     mamaMsg_getField (mMsg, "name", 1, &mMsgField);
 
@@ -104,7 +102,6 @@ TEST_F (MsgFieldCompositeTestsC, msgFieldGetAsStringInValidBuffer)
     size_t            len        = 0;
 
     //Create & add fields to msg
-    mamaMsg_create (&mMsg);
     mamaMsg_addString( mMsg, "name", 1, "test");
     mamaMsg_getField (mMsg, "name", 1, &mMsgField);
 
@@ -117,7 +114,6 @@ TEST_F (MsgFieldCompositeTestsC, msgFieldGetAsStringInValidLen)
     char*             buffer     = NULL;
 
     //Create & add fields to msg
-    mamaMsg_create (&mMsg);
     mamaMsg_addString( mMsg, "name", 1, "test");
     mamaMsg_getField (mMsg, "name", 1, &mMsgField);
 
@@ -138,7 +134,6 @@ TEST_F (MsgFieldCompositeTestsC, msgFieldGetDescriptorValid)
                     &original));
 
     //Create & add fields to msg
-    mamaMsg_create (&mMsg);
     mamaMsg_addString( mMsg, name, fid, "test");
 
     /* iterate through the msg's fields to populate dictionary */
@@ -152,7 +147,6 @@ TEST_F (MsgFieldCompositeTestsC, msgFieldGetDescriptorInValidMsgField)
     mamaFieldDescriptor*  result     = NULL;
 
     //Create & add fields to msg
-    mamaMsg_create (&mMsg);
     mamaMsg_addString( mMsg, "name", 1, "test");
     mamaMsg_getField (mMsg, "name", 1, &mMsgField);
 
@@ -164,7 +158,6 @@ TEST_F (MsgFieldCompositeTestsC, msgFieldGetDescriptorInValidResult)
     mamaMsgField          mMsgField  = NULL;
 
     //Create & add fields to msg
-    mamaMsg_create (&mMsg);
     mamaMsg_addString( mMsg, "name", 1, "test");
     mamaMsg_getField (mMsg, "name", 1, &mMsgField);
 
@@ -177,7 +170,6 @@ TEST_F (MsgFieldCompositeTestsC, msgFieldGetFidValid)
     uint16_t         result     = 0;
 
     //Create & add fields to msg
-    mamaMsg_create (&mMsg);
     mamaMsg_addString( mMsg, "name", 1, "test");
     mamaMsg_getField (mMsg, "name", 1, &mMsgField);
 
@@ -190,7 +182,6 @@ TEST_F (MsgFieldCompositeTestsC, msgFieldGetFidInValidMsgField)
     uint16_t*         result     = 0;
 
     //Create & add fields to msg
-    mamaMsg_create (&mMsg);
     mamaMsg_addString( mMsg, "name", 1, "test");
     mamaMsg_getField (mMsg, "name", 1, &mMsgField);
 
@@ -203,7 +194,6 @@ TEST_F (MsgFieldCompositeTestsC, msgFieldGetFidInValidResult)
     uint16_t*         result     = 0;
 
     //Create & add fields to msg
-    mamaMsg_create (&mMsg);
     mamaMsg_addString( mMsg, "name", 1, "test");
     mamaMsg_getField (mMsg, "name", 1, &mMsgField);
 
@@ -216,7 +206,6 @@ TEST_F (MsgFieldCompositeTestsC, msgFieldGetNameValid)
     const char*       result     = "";
 
     //Create & add fields to msg
-    mamaMsg_create (&mMsg);
     mamaMsg_addString( mMsg, "name", 1, "test");
     mamaMsg_getField (mMsg, "name", 1, &mMsgField);
 
@@ -229,7 +218,6 @@ TEST_F (MsgFieldCompositeTestsC, msgFieldGetNameInValidMsgField)
     const char*       result     = "";
 
     //Create & add fields to msg
-    mamaMsg_create (&mMsg);
     mamaMsg_addString( mMsg, "name", 1, "test");
     mamaMsg_getField (mMsg, "name", 1, &mMsgField);
 
@@ -241,7 +229,6 @@ TEST_F (MsgFieldCompositeTestsC, msgFieldGetNameInValidResult)
     mamaMsgField      mMsgField  = NULL;
 
     //Create & add fields to msg
-    mamaMsg_create (&mMsg);
     mamaMsg_addString( mMsg, "name", 1, "test");
     mamaMsg_getField (mMsg, "name", 1, &mMsgField);
 
@@ -254,7 +241,6 @@ TEST_F (MsgFieldCompositeTestsC, msgFieldGetTypeValid)
     mamaFieldType     result;
 
     //Create & add fields to msg
-    mamaMsg_create (&mMsg);
     mamaMsg_addString( mMsg, "name", 1, "test");
     mamaMsg_getField (mMsg, "name", 1, &mMsgField);
 
@@ -267,7 +253,6 @@ TEST_F (MsgFieldCompositeTestsC, msgFieldGetTypeInValidMsgField)
     mamaFieldType*    result     = NULL;
 
     //Create & add fields to msg
-    mamaMsg_create (&mMsg);
     mamaMsg_addString( mMsg, "name", 1, "test");
     mamaMsg_getField (mMsg, "name", 1, &mMsgField);
 
@@ -279,7 +264,6 @@ TEST_F (MsgFieldCompositeTestsC, msgFieldGetTypeInValidResult)
     mamaMsgField      mMsgField  = NULL;
 
     //Create & add fields to msg
-    mamaMsg_create (&mMsg);
     mamaMsg_addString( mMsg, "name", 1, "test");
     mamaMsg_getField (mMsg, "name", 1, &mMsgField);
 
@@ -292,7 +276,6 @@ TEST_F (MsgFieldCompositeTestsC, msgFieldGetTypeNameValid)
     const char*       result     = "";
 
     //Create & add fields to msg
-    mamaMsg_create (&mMsg);
     mamaMsg_addString( mMsg, "name", 1, "test");
     mamaMsg_getField (mMsg, "name", 1, &mMsgField);
 
@@ -305,7 +288,6 @@ TEST_F (MsgFieldCompositeTestsC, msgFieldGetTypeNameInValidMsgField)
     const char*       result     = "";
 
     //Create & add fields to msg
-    mamaMsg_create (&mMsg);
     mamaMsg_addString( mMsg, "name", 1, "test");
     mamaMsg_getField (mMsg, "name", 1, &mMsgField);
 
@@ -317,7 +299,6 @@ TEST_F (MsgFieldCompositeTestsC, DISABLED_msgFieldGetTypeNameInValidResult)
     mamaMsgField      mMsgField  = NULL;
 
     //Create & add fields to msg
-    mamaMsg_create (&mMsg);
     mamaMsg_addString( mMsg, "name", 1, "test");
     mamaMsg_getField (mMsg, "name", 1, &mMsgField);
 

--- a/mama/c_cpp/src/gunittest/c/mamamsg/msgfieldcompositetests.cpp
+++ b/mama/c_cpp/src/gunittest/c/mamamsg/msgfieldcompositetests.cpp
@@ -451,10 +451,10 @@ TEST_F (FieldDateTimeTestsC, updateDateTimeInValidValue)
 TEST_F (FieldDateTimeTestsC, getDateTimeValid)
 {
     mamaDateTime_create(&mOut);
-
     ASSERT_EQ (mamaMsg_addDateTime(mMsg, "Gary", 10101, mIn), MAMA_STATUS_OK);
     ASSERT_EQ (mamaMsg_getField(mMsg, "Gary", 10101, &mField), MAMA_STATUS_OK);
     ASSERT_EQ (mamaMsgField_getDateTime(mField, mOut), MAMA_STATUS_OK);
+    mamaDateTime_destroy(mOut);
 }
 
 TEST_F (FieldDateTimeTestsC, getDateTimeInValidField)

--- a/mama/c_cpp/src/gunittest/c/mamamsg/msgfieldvectortests.cpp
+++ b/mama/c_cpp/src/gunittest/c/mamamsg/msgfieldvectortests.cpp
@@ -56,12 +56,14 @@ protected:
     {
         mama_loadPayloadBridge (&mPayloadBridge, getPayload());
         mamaMsg_create (&mMsg);
-        mamaMsgField_create (&mField);
+        //mamaMsgField_create (&mField);
     };
 
     virtual void TearDown(void) 
     {
         mamaMsg_destroy(mMsg);
+        //mamaMsgField_destroy(mField);
+        //mama_close();
     };
 };
 
@@ -991,6 +993,10 @@ protected:
     virtual void TearDown()
     {
         MsgFieldVectorTestsC::TearDown();
+        for (uint32_t i = 0 ; i < VECTOR_SIZE ; i++)
+        {
+            mamaMsg_destroy (mIn[i]);
+        }
     }
 };
 

--- a/mama/c_cpp/src/gunittest/c/mamamsg/msggeneraltests.cpp
+++ b/mama/c_cpp/src/gunittest/c/mamamsg/msggeneraltests.cpp
@@ -353,7 +353,7 @@ TEST_F (MsgGeneralTestsC, msgGetPayloadTypeInValidMsg)
 TEST_F (MsgGeneralTestsC, msgImplSetMessageOwnerValid)
 {
     const char*  testString = "test"; 
-    short        owner      = (short) NULL;
+    short        owner      = 1;
 
     //add fields to msg
     mamaMsg_addString (mMsg, "name0", 101, testString);

--- a/mama/c_cpp/src/gunittest/c/mamamsg/msggeneraltests.cpp
+++ b/mama/c_cpp/src/gunittest/c/mamamsg/msggeneraltests.cpp
@@ -87,7 +87,9 @@ TEST_F (MsgGeneralTestsC, payloadConvertToString)
 
 TEST_F (MsgGeneralTestsC, msgCreateValid)
 {
-    ASSERT_EQ (mamaMsg_create(&mMsg), MAMA_STATUS_OK);
+    mamaMsg createMsg = NULL;
+    ASSERT_EQ (mamaMsg_create(&createMsg), MAMA_STATUS_OK);
+    mamaMsg_destroy(createMsg);
 }
 
 TEST_F (MsgGeneralTestsC, msgCreateInValid)
@@ -97,7 +99,9 @@ TEST_F (MsgGeneralTestsC, msgCreateInValid)
 
 TEST_F (MsgGeneralTestsC, msgCreateForPayloadBridgeValid)
 {
+    mamaMsg createMsg = NULL;
     ASSERT_EQ (mamaMsg_createForPayloadBridge(&mMsg, mPayloadBridge), MAMA_STATUS_OK);
+    mamaMsg_destroy(createMsg);
 }
 
 TEST_F (MsgGeneralTestsC, msgCreateForPayloadBridgeInValid)
@@ -219,6 +223,7 @@ TEST_F (MsgGeneralTestsC, msgCreateFromByteBufferValid)
 
     //create mamaMsg using byteBuffer
     ASSERT_EQ (mamaMsg_createFromByteBuffer(&newMsg, buffer, bufferLength), MAMA_STATUS_OK);
+    mamaMsg_destroy (newMsg);
 }
 
 TEST_F (MsgGeneralTestsC, DISABLED_msgCreateFromByteBufferInValidMsg)
@@ -662,6 +667,8 @@ TEST_F (MsgGeneralTestsC, msgGetDateTimeMSecValid)
     mamaMsg_addDateTime(mMsg, name, fid, dateTime);
 
     ASSERT_EQ (mamaMsg_getDateTimeMSec(mMsg, name, fid, &milliseconds), MAMA_STATUS_OK);
+
+    mamaDateTime_destroy(dateTime);
 }
 
 TEST_F (MsgGeneralTestsC, DISABLED_msgGetDateTimeMSecInValidMsg)
@@ -677,11 +684,14 @@ TEST_F (MsgGeneralTestsC, DISABLED_msgGetDateTimeMSecInValidMsg)
     mamaDateTime_create(&dateTime);
     mamaDateTime_create(&m_out);
     mamaDateTime_setToNow(dateTime);
-    
+
     mamaMsg_addDateTime(mMsg, NULL, 102, dateTime);
     mamaMsg_getDateTime(mMsg, NULL, 102, m_out);
 
     ASSERT_EQ (mamaMsg_getDateTimeMSec(NULL, name, fid, milliseconds), MAMA_STATUS_NULL_ARG); 
+
+    mamaDateTime_destroy(dateTime);
+    mamaDateTime_destroy(m_out);
 }
 
 TEST_F (MsgGeneralTestsC, msgGetDateTimeMSecInValidName)
@@ -701,6 +711,9 @@ TEST_F (MsgGeneralTestsC, msgGetDateTimeMSecInValidName)
 
     /* Invalid name is ok, as long as fid is specified */
     ASSERT_EQ (MAMA_STATUS_OK, mamaMsg_getDateTimeMSec(mMsg, NULL, fid, &milliseconds));
+
+    mamaDateTime_destroy(dateTime);
+    mamaDateTime_destroy(m_out);
 }
 
 TEST_F (MsgGeneralTestsC, msgGetDateTimeMSecInValidFid)
@@ -714,11 +727,14 @@ TEST_F (MsgGeneralTestsC, msgGetDateTimeMSecInValidFid)
     mamaDateTime_create(&dateTime);
     mamaDateTime_create(&m_out);
     mamaDateTime_setToNow(dateTime);
-    
+
     mamaMsg_addDateTime(mMsg, NULL, 102, dateTime);
     mamaMsg_getDateTime(mMsg, NULL, 102, m_out);
-    
+
     ASSERT_EQ (mamaMsg_getDateTimeMSec(mMsg, name, 0, milliseconds), MAMA_STATUS_INVALID_ARG);
+
+    mamaDateTime_destroy(dateTime);
+    mamaDateTime_destroy(m_out);
 }
 
 TEST_F (MsgGeneralTestsC, msgGetDateTimeMSecInValidMilliseconds)
@@ -732,11 +748,14 @@ TEST_F (MsgGeneralTestsC, msgGetDateTimeMSecInValidMilliseconds)
     mamaDateTime_create(&dateTime);
     mamaDateTime_create(&m_out);
     mamaDateTime_setToNow(dateTime);
-    
+
     mamaMsg_addDateTime(mMsg, NULL, 102, dateTime);
     mamaMsg_getDateTime(mMsg, NULL, 102, m_out);
-    
+
     ASSERT_EQ (mamaMsg_getDateTimeMSec(mMsg, name, fid, 0), MAMA_STATUS_INVALID_ARG);
+
+    mamaDateTime_destroy(dateTime);
+    mamaDateTime_destroy(m_out);
 }
 
 
@@ -745,7 +764,6 @@ TEST_F (MsgGeneralTestsC, msgGetEntitleCodeValid)
     mama_i32_t             entitleCode  = 100;
 
     //add fields to msg
-    mamaMsg_create (&mMsg);
     mamaMsg_addI32 (mMsg, ENTITLE_FIELD_NAME, ENTITLE_FIELD_ID, entitleCode);
 
     ASSERT_EQ (mamaMsg_getEntitleCode(mMsg, &entitleCode), MAMA_STATUS_OK);
@@ -996,12 +1014,14 @@ TEST_F(MsgCopyTests, Copy)
     mStatus = mamaMsg_create (&mCopy);
     mStatus = mamaMsg_copy (mMsg, &mCopy);
     ASSERT_EQ (mStatus, MAMA_STATUS_OK);
+    mamaMsg_destroy (mCopy);
 }
 
 TEST_F(MsgCopyTests, CopyNoCreate)
 {
     mStatus = mamaMsg_copy (mMsg, &mCopy);
     ASSERT_EQ (mStatus, MAMA_STATUS_OK);
+    mamaMsg_destroy (mCopy);
 }
 
 TEST_F(MsgCopyTests, CopyNullMsg)
@@ -1106,19 +1126,20 @@ protected:
     MsgApplyMsgTests()
         : mApplyMsg (NULL)
     {
-        mamaMsg_create (&mApplyMsg);
-        mamaMsg_addU8 (mApplyMsg, NULL, 1, 255);
     }
     ~MsgApplyMsgTests() {};
 
     virtual void SetUp (void)
     {
         MsgGeneralTestsC::SetUp();
+        mamaMsg_create (&mApplyMsg);
+        mamaMsg_addU8 (mApplyMsg, NULL, 1, 255);
     }
 
     virtual void TearDown (void)
     {
         MsgGeneralTestsC::TearDown();
+        mamaMsg_destroy (mApplyMsg);
     }
 };
 

--- a/mama/c_cpp/src/gunittest/c/mamamsg/msggeneraltests.cpp
+++ b/mama/c_cpp/src/gunittest/c/mamamsg/msggeneraltests.cpp
@@ -100,7 +100,7 @@ TEST_F (MsgGeneralTestsC, msgCreateInValid)
 TEST_F (MsgGeneralTestsC, msgCreateForPayloadBridgeValid)
 {
     mamaMsg createMsg = NULL;
-    ASSERT_EQ (mamaMsg_createForPayloadBridge(&mMsg, mPayloadBridge), MAMA_STATUS_OK);
+    ASSERT_EQ (mamaMsg_createForPayloadBridge(&createMsg, mPayloadBridge), MAMA_STATUS_OK);
     mamaMsg_destroy(createMsg);
 }
 

--- a/mama/c_cpp/src/gunittest/c/mamamsg/msgiterationtests.cpp
+++ b/mama/c_cpp/src/gunittest/c/mamamsg/msgiterationtests.cpp
@@ -237,6 +237,8 @@ TEST_F (MsgIterateTestC, CreateIterator)
         }
     }
 
+    mamaMsgIterator_destroy (iterator);
+
     /* destroy the message. */
     mamaMsg_destroy (msg);
 }

--- a/mama/c_cpp/src/gunittest/c/middleware/middlewareGeneralTests.cpp
+++ b/mama/c_cpp/src/gunittest/c/middleware/middlewareGeneralTests.cpp
@@ -52,11 +52,13 @@ MiddlewareGeneralTests::~MiddlewareGeneralTests(void)
 
 void MiddlewareGeneralTests::SetUp(void)
 {
-	mama_loadBridge (&mBridge,getMiddleware());
+    mama_loadBridge (&mBridge,getMiddleware());
+    mama_open ();
 }
 
 void MiddlewareGeneralTests::TearDown(void)
 {
+    mama_close ();
 }
 
 

--- a/mama/c_cpp/src/gunittest/c/middleware/middlewareInboxTests.cpp
+++ b/mama/c_cpp/src/gunittest/c/middleware/middlewareInboxTests.cpp
@@ -114,6 +114,7 @@ TEST_F (MiddlewareInboxTests, create)
     ASSERT_EQ (MAMA_STATUS_OK, mBridge->bridgeMamaInboxDestroy(bridge));
     ASSERT_EQ (MAMA_STATUS_OK, mamaInbox_destroy(parent));
     ASSERT_EQ (MAMA_STATUS_OK, mamaTransport_destroy(transport));
+    ASSERT_EQ (MAMA_STATUS_OK, mamaQueue_destroy(queue));
 }
 
 TEST_F (MiddlewareInboxTests, createInvalidBridge)
@@ -329,6 +330,10 @@ TEST_F (MiddlewareInboxTests, CreateDestroy)
 
     ASSERT_EQ (MAMA_STATUS_OK, 
                mBridge->bridgeMamaInboxDestroy(bridge));
+
+    ASSERT_EQ (MAMA_STATUS_OK, mamaInbox_destroy(parent));
+
+    ASSERT_EQ (MAMA_STATUS_OK, mamaQueue_destroy(queue));
 
     mamaTransport_destroy (transport);
 }

--- a/mama/c_cpp/src/gunittest/c/middleware/middlewareIoTests.cpp
+++ b/mama/c_cpp/src/gunittest/c/middleware/middlewareIoTests.cpp
@@ -52,11 +52,13 @@ MiddlewareIoTests::~MiddlewareIoTests(void)
 
 void MiddlewareIoTests::SetUp(void)
 {
-	mama_loadBridge (&mBridge,getMiddleware());
+    mama_loadBridge (&mBridge,getMiddleware());
+    mama_open();
 }
 
 void MiddlewareIoTests::TearDown(void)
 {
+    mama_close();
 }
 
 void onIo(mamaIo io, mamaIoType ioType, void* closure)
@@ -77,14 +79,17 @@ TEST_F (MiddlewareIoTests, create)
 
     ASSERT_EQ(MAMA_STATUS_OK,
               mamaQueue_create(&queue, mBridge));
-                  
+
     ASSERT_EQ(MAMA_STATUS_OK,
               mamaIo_create(&parent, queue, descriptor, onIo, ioType, closure));
-    
 
     ASSERT_EQ(MAMA_STATUS_OK,
               mBridge->bridgeMamaIoCreate(&io,queue, descriptor,
                                           onIo, ioType, parent, closure));
+    ASSERT_EQ(MAMA_STATUS_OK, mBridge->bridgeMamaIoDestroy(io));
+
+    ASSERT_EQ(MAMA_STATUS_OK, mamaIo_destroy(parent));
+    ASSERT_EQ(MAMA_STATUS_OK, mamaQueue_destroy(queue));
 }
 
 TEST_F (MiddlewareIoTests, createInvalidResult)
@@ -111,6 +116,7 @@ TEST_F (MiddlewareIoTests, createInvalidDescriptor)
     ASSERT_EQ(MAMA_STATUS_OK,
               mBridge->bridgeMamaIoCreate(&io,queue, 0,
                                           onIo, ioType, parent, closure));
+    ASSERT_EQ(MAMA_STATUS_OK, mBridge->bridgeMamaIoDestroy(io));
 }
 /* THIS WAS COMMENTED OUT BECAUSE mamaIoType CANNOT BE CAST AS NULL.
 TEST_F (MiddlewareIoTests, createInvalidType)
@@ -137,6 +143,7 @@ TEST_F (MiddlewareIoTests, createInvalidParent)
     ASSERT_EQ(MAMA_STATUS_OK,
               mBridge->bridgeMamaIoCreate(&io,queue, descriptor,
                                           onIo, ioType, NULL, closure));
+    ASSERT_EQ(MAMA_STATUS_OK, mBridge->bridgeMamaIoDestroy(io));
 }
 
 TEST_F (MiddlewareIoTests, createInvalidQueue)
@@ -150,6 +157,7 @@ TEST_F (MiddlewareIoTests, createInvalidQueue)
     ASSERT_EQ(MAMA_STATUS_OK,
               mBridge->bridgeMamaIoCreate(&io,NULL, descriptor,
                                           onIo, ioType, parent, closure));
+    ASSERT_EQ(MAMA_STATUS_OK, mBridge->bridgeMamaIoDestroy(io));
 }
 
 TEST_F (MiddlewareIoTests, createInvalidCb)
@@ -164,6 +172,7 @@ TEST_F (MiddlewareIoTests, createInvalidCb)
     ASSERT_EQ(MAMA_STATUS_OK,
               mBridge->bridgeMamaIoCreate(&io,queue, descriptor,
                                           NULL, ioType, parent, closure));
+    ASSERT_EQ(MAMA_STATUS_OK, mBridge->bridgeMamaIoDestroy(io));
 }
 
 
@@ -179,19 +188,24 @@ TEST_F (MiddlewareIoTests, getDescriptor)
 
     ASSERT_EQ(MAMA_STATUS_OK,
               mamaQueue_create(&queue, mBridge));
-                  
+
     ASSERT_EQ(MAMA_STATUS_OK,
               mamaIo_create(&parent, queue, descriptor, onIo, ioType, closure));
-    
+
     ASSERT_EQ(MAMA_STATUS_OK,
               mBridge->bridgeMamaIoCreate(&io,queue, descriptor,
                                           onIo, ioType, parent, closure));
-   
+
     ASSERT_EQ (MAMA_STATUS_OK, 
                mBridge->bridgeMamaIoGetDescriptor(io,&result));
 
+    ASSERT_EQ(MAMA_STATUS_OK, mBridge->bridgeMamaIoDestroy(io));
+
+    ASSERT_EQ(MAMA_STATUS_OK, mamaIo_destroy(parent));
+
     ASSERT_EQ (descriptor, result);
-    
+
+    ASSERT_EQ(MAMA_STATUS_OK, mamaQueue_destroy(queue));
 }
 
 TEST_F (MiddlewareIoTests, getDescriptorInvalidIoBridge)
@@ -218,19 +232,20 @@ TEST_F (MiddlewareIoTests, createDestroy)
     void*      closure           = NULL;
     mamaQueue  queue             = NULL;
 
-    ASSERT_EQ(MAMA_STATUS_OK,
-              mamaQueue_create(&queue, mBridge));
-                  
+    ASSERT_EQ(MAMA_STATUS_OK, mamaQueue_create(&queue, mBridge));
+
     ASSERT_EQ(MAMA_STATUS_OK,
               mamaIo_create(&parent, queue, descriptor, onIo, ioType, closure));
-    
 
     ASSERT_EQ(MAMA_STATUS_OK,
               mBridge->bridgeMamaIoCreate(&io,queue, descriptor,
                                           onIo, ioType, parent, closure));
 
-    ASSERT_EQ (MAMA_STATUS_OK, 
-               mBridge->bridgeMamaIoDestroy(io));
+    ASSERT_EQ (MAMA_STATUS_OK, mBridge->bridgeMamaIoDestroy(io));
+
+    ASSERT_EQ(MAMA_STATUS_OK, mamaIo_destroy(parent));
+
+    ASSERT_EQ(MAMA_STATUS_OK, mamaQueue_destroy(queue));
 
 }
 

--- a/mama/c_cpp/src/gunittest/c/middleware/middlewareMsgTests.cpp
+++ b/mama/c_cpp/src/gunittest/c/middleware/middlewareMsgTests.cpp
@@ -73,8 +73,9 @@ TEST_F (MiddlewareMsgTests, create)
 
     mamaMsg_create(&parent);
 
-    ASSERT_EQ (MAMA_STATUS_OK, 
-               mBridge->bridgeMamaMsgCreate(&msg,parent));
+    ASSERT_EQ (MAMA_STATUS_OK, mBridge->bridgeMamaMsgCreate(&msg,parent));
+    ASSERT_EQ (MAMA_STATUS_OK, mBridge->bridgeMamaMsgDestroy(msg, 1));
+    ASSERT_EQ (MAMA_STATUS_OK, mamaMsg_destroy(parent));
 }
 
 TEST_F (MiddlewareMsgTests, createInvalidMsgBridge)
@@ -100,11 +101,10 @@ TEST_F (MiddlewareMsgTests, isFromInbox)
 
     mamaMsg_create(&parent);
 
-    ASSERT_EQ (MAMA_STATUS_OK, 
-               mBridge->bridgeMamaMsgCreate(&msg,parent));
-    
-    ASSERT_EQ (0, 
-               mBridge->bridgeMamaMsgIsFromInbox(msg));
+    ASSERT_EQ (MAMA_STATUS_OK, mBridge->bridgeMamaMsgCreate(&msg,parent));
+    ASSERT_EQ (0, mBridge->bridgeMamaMsgIsFromInbox(msg));
+    ASSERT_EQ (MAMA_STATUS_OK, mBridge->bridgeMamaMsgDestroy(msg, 1));
+    ASSERT_EQ (MAMA_STATUS_OK, mamaMsg_destroy(parent));
 
 }
 
@@ -128,6 +128,7 @@ TEST_F (MiddlewareMsgTests, destroy)
 
     ASSERT_EQ(MAMA_STATUS_OK,
               mBridge->bridgeMamaMsgDestroy(msg,destroyMsg));
+    ASSERT_EQ (MAMA_STATUS_OK, mamaMsg_destroy(parent));
 }
 
 TEST_F (MiddlewareMsgTests, destroyInvalidMsgBridge)
@@ -161,6 +162,7 @@ TEST_F (MiddlewareMsgTests, detach)
 
     ASSERT_EQ(MAMA_STATUS_OK,
               mBridge->bridgeMamaMsgDestroy(msg,destroyMsg));
+    ASSERT_EQ (MAMA_STATUS_OK, mamaMsg_destroy(parent));
 }
 
 TEST_F (MiddlewareMsgTests, detachInvalid)
@@ -179,18 +181,23 @@ TEST_F (MiddlewareMsgTests, getPlatformError)
 
     ASSERT_EQ(MAMA_STATUS_OK,mamaMsg_create(&parent));
 
-    ASSERT_EQ(MAMA_STATUS_OK,
-              mBridge->bridgeMamaMsgCreate(&msg,parent));
-    
+    ASSERT_EQ(MAMA_STATUS_OK, mBridge->bridgeMamaMsgCreate(&msg, parent));
 
     status = mBridge->bridgeMamaMsgGetPlatformError(msg, &error);
+
+    if (MAMA_STATUS_NOT_IMPLEMENTED == status)
+    {
+        mBridge->bridgeMamaMsgDestroy (msg, destroyMsg);
+        mamaMsg_destroy (parent);
+    }
 
     CHECK_NON_IMPLEMENTED_OPTIONAL(status);
 
     ASSERT_EQ(MAMA_STATUS_OK, status);
-    
-    ASSERT_EQ(MAMA_STATUS_OK,
-              mBridge->bridgeMamaMsgDestroy(msg,destroyMsg));
+
+    ASSERT_EQ(MAMA_STATUS_OK, mBridge->bridgeMamaMsgDestroy(msg, destroyMsg));
+
+    ASSERT_EQ (MAMA_STATUS_OK, mamaMsg_destroy(parent));
 
 }
 
@@ -235,6 +242,8 @@ TEST_F (MiddlewareMsgTests,setSendSubject )
     ASSERT_EQ(MAMA_STATUS_OK,
               mBridge->bridgeMamaMsgDestroy(msg, destroyMsg));
 
+    ASSERT_EQ (MAMA_STATUS_OK, mamaMsg_destroy(parent));
+
 }
 
 TEST_F (MiddlewareMsgTests, setSendSubjectInvalidMsgBridge)
@@ -272,6 +281,7 @@ TEST_F (MiddlewareMsgTests, getNativeHandle)
 
     ASSERT_EQ(MAMA_STATUS_OK,
               mBridge->bridgeMamaMsgDestroy(msg,destroyMsg));
+    ASSERT_EQ (MAMA_STATUS_OK, mamaMsg_destroy(parent));
 }
 
 TEST_F (MiddlewareMsgTests, getNativeHandleInvalidMsgBridge)

--- a/mama/c_cpp/src/gunittest/c/middleware/middlewareQueueTests.cpp
+++ b/mama/c_cpp/src/gunittest/c/middleware/middlewareQueueTests.cpp
@@ -52,11 +52,13 @@ MiddlewareQueueTests::~MiddlewareQueueTests(void)
 
 void MiddlewareQueueTests::SetUp(void)
 {
-	mama_loadBridge (&mBridge,getMiddleware());
+    mama_loadBridge (&mBridge,getMiddleware());
+    mama_open();
 }
 
 void MiddlewareQueueTests::TearDown(void)
 {
+    mama_close();
 }
 
 static void onEvent(mamaQueue queue, void* closure)
@@ -76,9 +78,11 @@ TEST_F (MiddlewareQueueTests, create)
     mamaQueue   parent = NULL;
 
     mamaQueue_create(&parent,mBridge);
-    
+
     ASSERT_EQ(MAMA_STATUS_OK, 
               mBridge->bridgeMamaQueueCreate(&queue, parent));
+    mBridge->bridgeMamaQueueDestroy(queue);
+    ASSERT_EQ(MAMA_STATUS_OK, mamaQueue_destroy(parent));
 }
 
 TEST_F (MiddlewareQueueTests, createInvalidQueueBridge)
@@ -138,8 +142,8 @@ TEST_F (MiddlewareQueueTests, destroy)
     mamaQueue_create(&parent,mBridge);
     mBridge->bridgeMamaQueueCreate(&queue, parent);
 
-    ASSERT_EQ (MAMA_STATUS_OK, 
-               mBridge->bridgeMamaQueueDestroy(queue));
+    ASSERT_EQ (MAMA_STATUS_OK, mBridge->bridgeMamaQueueDestroy(queue));
+    ASSERT_EQ(MAMA_STATUS_OK, mamaQueue_destroy(parent));
 }
 
 TEST_F (MiddlewareQueueTests, destroyInvalid)
@@ -159,6 +163,8 @@ TEST_F (MiddlewareQueueTests, getEventCount)
     
     ASSERT_EQ (MAMA_STATUS_OK, 
                mBridge->bridgeMamaQueueGetEventCount(queue,&count));
+    ASSERT_EQ(MAMA_STATUS_OK, mBridge->bridgeMamaQueueDestroy(queue));
+    ASSERT_EQ(MAMA_STATUS_OK, mamaQueue_destroy(parent));
 }
 
 TEST_F (MiddlewareQueueTests, getEventCountInvalidQueueBridge)
@@ -193,6 +199,7 @@ TEST_F (MiddlewareQueueTests, DISABLED_dispatch)
     
     ASSERT_EQ (MAMA_STATUS_OK, 
                mBridge->bridgeMamaQueueDispatch(queue));
+    ASSERT_EQ(MAMA_STATUS_OK, mBridge->bridgeMamaQueueDestroy(queue));
 }
 
 TEST_F (MiddlewareQueueTests, DISABLED_dispatchMany)
@@ -218,6 +225,7 @@ TEST_F (MiddlewareQueueTests, DISABLED_dispatchMany)
         ASSERT_EQ(MAMA_STATUS_OK, 
                   mBridge->bridgeMamaQueueDispatch(queue));
     }
+    ASSERT_EQ(MAMA_STATUS_OK, mBridge->bridgeMamaQueueDestroy(queue));
 }
 
 TEST_F (MiddlewareQueueTests, DISABLED_dispatchManyQueues)
@@ -247,6 +255,7 @@ TEST_F (MiddlewareQueueTests, DISABLED_dispatchManyQueues)
             ASSERT_EQ(MAMA_STATUS_OK, 
                       mBridge->bridgeMamaQueueDispatch(queue[counter]));
         }
+        ASSERT_EQ(MAMA_STATUS_OK, mBridge->bridgeMamaQueueDestroy(queue[counter]));
 
     }
 
@@ -278,6 +287,8 @@ TEST_F (MiddlewareQueueTests, timedDispatch)
 
     ASSERT_EQ(MAMA_STATUS_OK, 
               mBridge->bridgeMamaQueueTimedDispatch(queue,timeout));
+    ASSERT_EQ(MAMA_STATUS_OK, mBridge->bridgeMamaQueueDestroy(queue));
+    ASSERT_EQ(MAMA_STATUS_OK, mamaQueue_destroy(parent));
 }
 
 TEST_F (MiddlewareQueueTests, timedDispatchInvalidQueueBridge)
@@ -310,7 +321,7 @@ TEST_F (MiddlewareQueueTests, enqueueEvent)
     queueBridge queue   = NULL;
     mamaQueue   parent  = NULL;
     void*       closure = NOT_NULL;
-    
+
     mamaQueue_create(&parent,mBridge);
     mBridge->bridgeMamaQueueCreate(&queue, parent);
    
@@ -318,6 +329,8 @@ TEST_F (MiddlewareQueueTests, enqueueEvent)
                mBridge->bridgeMamaQueueEnqueueEvent(queue,
                                                     onEvent,
                                                     closure));
+    ASSERT_EQ(MAMA_STATUS_OK, mBridge->bridgeMamaQueueDestroy(queue));
+    ASSERT_EQ(MAMA_STATUS_OK, mamaQueue_destroy(parent));
 }
 
 TEST_F (MiddlewareQueueTests, enqueueEventInvalidQueueBridge)
@@ -451,6 +464,8 @@ TEST_F (MiddlewareQueueTests, setHighWatermark)
     ASSERT_EQ(MAMA_STATUS_OK,
               mBridge->bridgeMamaQueueSetHighWatermark(queue,
                                                        highWatermark));
+    ASSERT_EQ(MAMA_STATUS_OK, mBridge->bridgeMamaQueueDestroy(queue));
+    ASSERT_EQ(MAMA_STATUS_OK, mamaQueue_destroy(parent));
 }
 
 TEST_F (MiddlewareQueueTests, setHighWatermarkInvalidQueueBridge)
@@ -481,6 +496,8 @@ TEST_F (MiddlewareQueueTests, setLowWatermark)
 
     ASSERT_EQ(MAMA_STATUS_OK,
               mBridge->bridgeMamaQueueSetLowWatermark(queue, lowWatermark));
+    ASSERT_EQ(MAMA_STATUS_OK, mBridge->bridgeMamaQueueDestroy(queue));
+    ASSERT_EQ(MAMA_STATUS_OK, mamaQueue_destroy(parent));
 }
 
 TEST_F (MiddlewareQueueTests, setLowWatermarkInvalidQueueBridge)

--- a/mama/c_cpp/src/gunittest/c/middleware/middlewareSubscriptionTests.cpp
+++ b/mama/c_cpp/src/gunittest/c/middleware/middlewareSubscriptionTests.cpp
@@ -121,6 +121,7 @@ void MiddlewareSubscriptionTests::TearDown(void)
 {
     mamaSubscription_deallocate(parent);
     mamaQueue_destroy (queue);
+    mamaSource_destroy(source);
     mamaTransport_destroy (tport);
     mama_close();
 }
@@ -217,6 +218,7 @@ TEST_F (MiddlewareSubscriptionTests, createInvalidSourceName)
               mBridge->bridgeMamaSubscriptionCreate(&subscriber, NULL, symbol,
                                                     tport, queue, callbacks,
                                                     parent, closure));
+    ASSERT_EQ(MAMA_STATUS_OK, mBridge->bridgeMamaSubscriptionDestroy(subscriber));
 }
 
 TEST_F (MiddlewareSubscriptionTests, createInvalidSymbol)
@@ -225,6 +227,7 @@ TEST_F (MiddlewareSubscriptionTests, createInvalidSymbol)
               mBridge->bridgeMamaSubscriptionCreate(&subscriber, sourceName, NULL,
                                                     tport, queue, callbacks,
                                                     parent, closure));
+    ASSERT_EQ(MAMA_STATUS_OK, mBridge->bridgeMamaSubscriptionDestroy(subscriber));
 }
 
 TEST_F (MiddlewareSubscriptionTests, createInvalidQueue)
@@ -233,6 +236,7 @@ TEST_F (MiddlewareSubscriptionTests, createInvalidQueue)
               mBridge->bridgeMamaSubscriptionCreate(&subscriber, sourceName, symbol,
                                                     tport, NULL, callbacks,
                                                     parent, closure));
+    ASSERT_EQ(MAMA_STATUS_OK, mBridge->bridgeMamaSubscriptionDestroy(subscriber));
 }
 
 TEST_F (MiddlewareSubscriptionTests, createInvalidParent)
@@ -336,6 +340,7 @@ TEST_F (MiddlewareSubscriptionTests, mute)
 
     ASSERT_EQ(MAMA_STATUS_OK,
               mBridge->bridgeMamaSubscriptionDestroy(subscriber));
+    ASSERT_EQ(MAMA_STATUS_OK, mamaSubscription_destroy(parent));
 }
 
 TEST_F (MiddlewareSubscriptionTests, muteInvalid)
@@ -364,8 +369,8 @@ TEST_F (MiddlewareSubscriptionTests, isValid)
     res = mBridge->bridgeMamaSubscriptionIsValid(subscriber);
     ASSERT_TRUE(res != 0);
 
-    ASSERT_EQ(MAMA_STATUS_OK,
-              mamaSubscription_destroy(parent));
+    ASSERT_EQ(MAMA_STATUS_OK, mamaSubscription_destroy(parent));
+    ASSERT_EQ(MAMA_STATUS_OK, mBridge->bridgeMamaSubscriptionDestroy(subscriber));
 }
 
 TEST_F (MiddlewareSubscriptionTests, isValidInvalid)
@@ -403,6 +408,7 @@ TEST_F (MiddlewareSubscriptionTests, getPlatformError)
 
     ASSERT_EQ(MAMA_STATUS_OK,
               mBridge->bridgeMamaSubscriptionDestroy(subscriber));
+    ASSERT_EQ(MAMA_STATUS_OK, mamaSubscription_destroy(parent));
 
     CHECK_NON_IMPLEMENTED_OPTIONAL(status);
 
@@ -451,6 +457,7 @@ TEST_F (MiddlewareSubscriptionTests, setTopicClosure)
 
     ASSERT_EQ(MAMA_STATUS_OK,
               mBridge->bridgeMamaSubscriptionDestroy(subscriber));
+    ASSERT_EQ(MAMA_STATUS_OK, mamaSubscription_destroy(parent));
 
     CHECK_NON_IMPLEMENTED_OPTIONAL(status);
 
@@ -486,6 +493,7 @@ TEST_F (MiddlewareSubscriptionTests, muteCurrentTopic)
 
     ASSERT_EQ(MAMA_STATUS_OK,
               mBridge->bridgeMamaSubscriptionDestroy(subscriber));
+    ASSERT_EQ(MAMA_STATUS_OK, mamaSubscription_destroy(parent));
 }
 
 TEST_F (MiddlewareSubscriptionTests, muteCurrentTopicInvalid)

--- a/mama/c_cpp/src/gunittest/c/middleware/middlewareTransportTests.cpp
+++ b/mama/c_cpp/src/gunittest/c/middleware/middlewareTransportTests.cpp
@@ -52,25 +52,26 @@ MiddlewareTransportTests::MiddlewareTransportTests(void)
       parentName ("test_tport"),
       parentTport (NULL)
 {
+}
 
+MiddlewareTransportTests::~MiddlewareTransportTests(void)
+{
+}
+
+void MiddlewareTransportTests::SetUp(void)
+{
     mama_loadBridge (&mBridge, getMiddleware());
+    mama_open();
     mamaTransport_allocate (&parentTport);
 
     mamaTransport_create (parentTport, parentName, mBridge);
     mamaTransport_getNativeTransport (parentTport, 0, (void**)&tport);
 }
 
-MiddlewareTransportTests::~MiddlewareTransportTests(void)
-{
-    mamaTransport_destroy (parentTport);
-}
-
-void MiddlewareTransportTests::SetUp(void)
-{
-}
-
 void MiddlewareTransportTests::TearDown(void)
 {
+    mamaTransport_destroy (parentTport);
+    mama_close();
 }
 
 

--- a/mama/c_cpp/src/gunittest/c/payload/fieldatomictests.cpp
+++ b/mama/c_cpp/src/gunittest/c/payload/fieldatomictests.cpp
@@ -90,6 +90,7 @@ TEST_F(FieldBoolTests, UpdateBoolValid)
 
     ret = aBridge->msgFieldPayloadUpdateBool(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_OK, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldBoolTests, UpdateBoolInvalidType)
@@ -107,6 +108,7 @@ TEST_F(FieldBoolTests, UpdateBoolInvalidType)
 
     ret = aBridge->msgFieldPayloadUpdateBool(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_WRONG_FIELD_TYPE, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldBoolTests, UpdateBoolInValid)
@@ -145,6 +147,7 @@ TEST_F(FieldBoolTests, GetBoolValid)
 
     ret = aBridge->msgFieldPayloadGetBool(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_OK, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldBoolTests, GetBoolInvalidType)
@@ -162,6 +165,7 @@ TEST_F(FieldBoolTests, GetBoolInvalidType)
 
     ret = aBridge->msgFieldPayloadGetBool(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_WRONG_FIELD_TYPE, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldBoolTests, GetBoolInValid)
@@ -179,6 +183,7 @@ TEST_F(FieldBoolTests, GetBoolInValid)
     /*Null Underlying field*/
     ret = aBridge->msgFieldPayloadGetBool(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_INVALID_ARG, ret);
+    aBridge->msgFieldPayloadDestroy(field);
 }
 
 /**********************************************************************
@@ -215,6 +220,7 @@ TEST_F(FieldCharTests, UpdateCharValid)
 
     ret = aBridge->msgFieldPayloadUpdateChar(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_OK, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldCharTests, UpdateCharInvalidType)
@@ -232,6 +238,7 @@ TEST_F(FieldCharTests, UpdateCharInvalidType)
 
     ret = aBridge->msgFieldPayloadUpdateChar(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_WRONG_FIELD_TYPE, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldCharTests, UpdateCharInValid)
@@ -250,6 +257,7 @@ TEST_F(FieldCharTests, UpdateCharInValid)
     /*Null Underlying field*/
     ret = aBridge->msgFieldPayloadUpdateChar(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_NULL_ARG, ret);
+    aBridge->msgFieldPayloadDestroy(field);
 }
 
 TEST_F(FieldCharTests, GetCharValid)
@@ -267,6 +275,7 @@ TEST_F(FieldCharTests, GetCharValid)
 
     ret = aBridge->msgFieldPayloadGetChar(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_OK, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldCharTests, GetCharInvalidType)
@@ -284,6 +293,7 @@ TEST_F(FieldCharTests, GetCharInvalidType)
 
     ret = aBridge->msgFieldPayloadGetChar(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_WRONG_FIELD_TYPE, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldCharTests, GetCharInValid)
@@ -301,6 +311,7 @@ TEST_F(FieldCharTests, GetCharInValid)
     /*Null Underlying field*/
     ret = aBridge->msgFieldPayloadGetChar(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_INVALID_ARG, ret);
+    aBridge->msgFieldPayloadDestroy(field);
 }
 
 /**********************************************************************
@@ -337,6 +348,7 @@ TEST_F(FieldI8Tests, UpdateI8Valid)
 
     ret = aBridge->msgFieldPayloadUpdateI8(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_OK, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldI8Tests, UpdateI8InvalidType)
@@ -354,6 +366,7 @@ TEST_F(FieldI8Tests, UpdateI8InvalidType)
 
     ret = aBridge->msgFieldPayloadUpdateI8(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_WRONG_FIELD_TYPE, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldI8Tests, UpdateI8InValid)
@@ -372,6 +385,7 @@ TEST_F(FieldI8Tests, UpdateI8InValid)
     /*Null Underlying field*/
     ret = aBridge->msgFieldPayloadUpdateI8(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_NULL_ARG, ret);
+    aBridge->msgFieldPayloadDestroy(field);
 }
 
 TEST_F(FieldI8Tests, GetI8Valid)
@@ -389,6 +403,7 @@ TEST_F(FieldI8Tests, GetI8Valid)
 
     ret = aBridge->msgFieldPayloadGetI8(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_OK, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldI8Tests, GetI8InvalidType)
@@ -406,6 +421,7 @@ TEST_F(FieldI8Tests, GetI8InvalidType)
 
     ret = aBridge->msgFieldPayloadGetI8(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_WRONG_FIELD_TYPE, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldI8Tests, GetI8InValid)
@@ -423,6 +439,7 @@ TEST_F(FieldI8Tests, GetI8InValid)
     /*Null Underlying field*/
     ret = aBridge->msgFieldPayloadGetI8(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_INVALID_ARG, ret);
+    aBridge->msgFieldPayloadDestroy(field);
 }
 
 /**********************************************************************
@@ -459,6 +476,7 @@ TEST_F(FieldU8Tests, UpdateU8Valid)
 
     ret = aBridge->msgFieldPayloadUpdateU8(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_OK, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldU8Tests, UpdateU8InvalidType)
@@ -476,6 +494,7 @@ TEST_F(FieldU8Tests, UpdateU8InvalidType)
 
     ret = aBridge->msgFieldPayloadUpdateU8(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_WRONG_FIELD_TYPE, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldU8Tests, UpdateU8InValid)
@@ -494,6 +513,7 @@ TEST_F(FieldU8Tests, UpdateU8InValid)
     /*Null Underlying field*/
     ret = aBridge->msgFieldPayloadUpdateU8(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_NULL_ARG, ret);
+    aBridge->msgFieldPayloadDestroy(field);
 }
 
 TEST_F(FieldU8Tests, GetU8Valid)
@@ -511,6 +531,7 @@ TEST_F(FieldU8Tests, GetU8Valid)
 
     ret = aBridge->msgFieldPayloadGetU8(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_OK, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldU8Tests, GetU8InvalidType)
@@ -528,6 +549,7 @@ TEST_F(FieldU8Tests, GetU8InvalidType)
 
     ret = aBridge->msgFieldPayloadGetU8(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_WRONG_FIELD_TYPE, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldU8Tests, GetU8InValid)
@@ -545,6 +567,7 @@ TEST_F(FieldU8Tests, GetU8InValid)
     /*Null Underlying field*/
     ret = aBridge->msgFieldPayloadGetU8(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_INVALID_ARG, ret);
+    aBridge->msgFieldPayloadDestroy(field);
 }
 
 /**********************************************************************
@@ -581,6 +604,7 @@ TEST_F(FieldI16Tests, UpdateI16Valid)
 
     ret = aBridge->msgFieldPayloadUpdateI16(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_OK, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldI16Tests, UpdateI16InvalidType)
@@ -598,6 +622,7 @@ TEST_F(FieldI16Tests, UpdateI16InvalidType)
 
     ret = aBridge->msgFieldPayloadUpdateI16(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_WRONG_FIELD_TYPE, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldI16Tests, UpdateI16InValid)
@@ -616,6 +641,7 @@ TEST_F(FieldI16Tests, UpdateI16InValid)
     /*Null Underlying field*/
     ret = aBridge->msgFieldPayloadUpdateI16(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_NULL_ARG, ret);
+    aBridge->msgFieldPayloadDestroy(field);
 }
 
 TEST_F(FieldI16Tests, GetI16Valid)
@@ -633,6 +659,7 @@ TEST_F(FieldI16Tests, GetI16Valid)
 
     ret = aBridge->msgFieldPayloadGetI16(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_OK, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldI16Tests, GetI16InvalidType)
@@ -650,6 +677,7 @@ TEST_F(FieldI16Tests, GetI16InvalidType)
 
     ret = aBridge->msgFieldPayloadGetI16(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_WRONG_FIELD_TYPE, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldI16Tests, GetI16InValid)
@@ -667,6 +695,7 @@ TEST_F(FieldI16Tests, GetI16InValid)
     /*Null Underlying field*/
     ret = aBridge->msgFieldPayloadGetI16(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_INVALID_ARG, ret);
+    aBridge->msgFieldPayloadDestroy(field);
 }
 
 /**********************************************************************
@@ -703,6 +732,7 @@ TEST_F(FieldU16Tests, UpdateU16Valid)
 
     ret = aBridge->msgFieldPayloadUpdateU16(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_OK, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldU16Tests, UpdateU16InvalidType)
@@ -720,6 +750,7 @@ TEST_F(FieldU16Tests, UpdateU16InvalidType)
 
     ret = aBridge->msgFieldPayloadUpdateU16(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_WRONG_FIELD_TYPE, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldU16Tests, UpdateU16InValid)
@@ -738,6 +769,7 @@ TEST_F(FieldU16Tests, UpdateU16InValid)
     /*Null Underlying field*/
     ret = aBridge->msgFieldPayloadUpdateU16(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_NULL_ARG, ret);
+    aBridge->msgFieldPayloadDestroy(field);
 }
 
 TEST_F(FieldU16Tests, GetU16Valid)
@@ -755,6 +787,7 @@ TEST_F(FieldU16Tests, GetU16Valid)
 
     ret = aBridge->msgFieldPayloadGetU16(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_OK, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldU16Tests, GetU16InvalidType)
@@ -772,6 +805,7 @@ TEST_F(FieldU16Tests, GetU16InvalidType)
 
     ret = aBridge->msgFieldPayloadGetU16(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_WRONG_FIELD_TYPE, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldU16Tests, GetU16InValid)
@@ -789,6 +823,7 @@ TEST_F(FieldU16Tests, GetU16InValid)
     /*Null Underlying field*/
     ret = aBridge->msgFieldPayloadGetU16(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_INVALID_ARG, ret);
+    aBridge->msgFieldPayloadDestroy(field);
 }
 
 /**********************************************************************
@@ -825,6 +860,7 @@ TEST_F(FieldI32Tests, UpdateI32Valid)
 
     ret = aBridge->msgFieldPayloadUpdateI32(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_OK, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldI32Tests, UpdateI32InvalidType)
@@ -842,6 +878,7 @@ TEST_F(FieldI32Tests, UpdateI32InvalidType)
 
     ret = aBridge->msgFieldPayloadUpdateI32(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_WRONG_FIELD_TYPE, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldI32Tests, UpdateI32InValid)
@@ -860,6 +897,7 @@ TEST_F(FieldI32Tests, UpdateI32InValid)
     /*Null Underlying field*/
     ret = aBridge->msgFieldPayloadUpdateI32(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_NULL_ARG, ret);
+    aBridge->msgFieldPayloadDestroy(field);
 }
 
 TEST_F(FieldI32Tests, GetI32Valid)
@@ -877,6 +915,7 @@ TEST_F(FieldI32Tests, GetI32Valid)
 
     ret = aBridge->msgFieldPayloadGetI32(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_OK, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldI32Tests, GetI32InvalidType)
@@ -894,6 +933,7 @@ TEST_F(FieldI32Tests, GetI32InvalidType)
 
     ret = aBridge->msgFieldPayloadGetI32(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_WRONG_FIELD_TYPE, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldI32Tests, GetI32InValid)
@@ -911,6 +951,7 @@ TEST_F(FieldI32Tests, GetI32InValid)
     /*Null Underlying field*/
     ret = aBridge->msgFieldPayloadGetI32(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_INVALID_ARG, ret);
+    aBridge->msgFieldPayloadDestroy(field);
 }
 
 /**********************************************************************
@@ -947,6 +988,7 @@ TEST_F(FieldU32Tests, UpdateU32Valid)
 
     ret = aBridge->msgFieldPayloadUpdateU32(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_OK, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldU32Tests, UpdateU32InvalidType)
@@ -964,6 +1006,7 @@ TEST_F(FieldU32Tests, UpdateU32InvalidType)
 
     ret = aBridge->msgFieldPayloadUpdateU32(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_WRONG_FIELD_TYPE, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldU32Tests, UpdateU32InValid)
@@ -982,6 +1025,7 @@ TEST_F(FieldU32Tests, UpdateU32InValid)
     /*Null Underlying field*/
     ret = aBridge->msgFieldPayloadUpdateU32(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_NULL_ARG, ret);
+    aBridge->msgFieldPayloadDestroy(field);
 }
 
 TEST_F(FieldU32Tests, GetU32Valid)
@@ -999,6 +1043,7 @@ TEST_F(FieldU32Tests, GetU32Valid)
 
     ret = aBridge->msgFieldPayloadGetU32(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_OK, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldU32Tests, GetU32InvalidType)
@@ -1016,6 +1061,7 @@ TEST_F(FieldU32Tests, GetU32InvalidType)
 
     ret = aBridge->msgFieldPayloadGetU32(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_WRONG_FIELD_TYPE, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldU32Tests, GetU32InValid)
@@ -1033,6 +1079,7 @@ TEST_F(FieldU32Tests, GetU32InValid)
     /*Null Underlying field*/
     ret = aBridge->msgFieldPayloadGetU32(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_INVALID_ARG, ret);
+    aBridge->msgFieldPayloadDestroy(field);
 }
 
 /**********************************************************************
@@ -1069,6 +1116,7 @@ TEST_F(FieldI64Tests, UpdateI64Valid)
 
     ret = aBridge->msgFieldPayloadUpdateI64(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_OK, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldI64Tests, UpdateI64InvalidType)
@@ -1086,6 +1134,7 @@ TEST_F(FieldI64Tests, UpdateI64InvalidType)
 
     ret = aBridge->msgFieldPayloadUpdateI64(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_WRONG_FIELD_TYPE, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldI64Tests, UpdateI64InValid)
@@ -1104,6 +1153,7 @@ TEST_F(FieldI64Tests, UpdateI64InValid)
     /*Null Underlying field*/
     ret = aBridge->msgFieldPayloadUpdateI64(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_NULL_ARG, ret);
+    aBridge->msgFieldPayloadDestroy(field);
 }
 
 TEST_F(FieldI64Tests, GetI64Valid)
@@ -1121,6 +1171,7 @@ TEST_F(FieldI64Tests, GetI64Valid)
 
     ret = aBridge->msgFieldPayloadGetI64(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_OK, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldI64Tests, GetI64InvalidType)
@@ -1138,6 +1189,7 @@ TEST_F(FieldI64Tests, GetI64InvalidType)
 
     ret = aBridge->msgFieldPayloadGetI64(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_WRONG_FIELD_TYPE, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldI64Tests, GetI64InValid)
@@ -1155,6 +1207,7 @@ TEST_F(FieldI64Tests, GetI64InValid)
     /*Null Underlying field*/
     ret = aBridge->msgFieldPayloadGetI64(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_INVALID_ARG, ret);
+    aBridge->msgFieldPayloadDestroy(field);
 }
 
 /**********************************************************************
@@ -1191,6 +1244,7 @@ TEST_F(FieldU64Tests, UpdateU64Valid)
 
     ret = aBridge->msgFieldPayloadUpdateU64(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_OK, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldU64Tests, UpdateU64InvalidType)
@@ -1208,6 +1262,7 @@ TEST_F(FieldU64Tests, UpdateU64InvalidType)
 
     ret = aBridge->msgFieldPayloadUpdateU64(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_WRONG_FIELD_TYPE, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldU64Tests, UpdateU64InValid)
@@ -1226,6 +1281,7 @@ TEST_F(FieldU64Tests, UpdateU64InValid)
     /*Null Underlying field*/
     ret = aBridge->msgFieldPayloadUpdateU64(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_NULL_ARG, ret);
+    aBridge->msgFieldPayloadDestroy(field);
 }
 
 TEST_F(FieldU64Tests, GetU64Valid)
@@ -1243,6 +1299,7 @@ TEST_F(FieldU64Tests, GetU64Valid)
 
     ret = aBridge->msgFieldPayloadGetU64(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_OK, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldU64Tests, GetU64InvalidType)
@@ -1260,6 +1317,7 @@ TEST_F(FieldU64Tests, GetU64InvalidType)
 
     ret = aBridge->msgFieldPayloadGetU64(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_WRONG_FIELD_TYPE, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldU64Tests, GetU64InValid)
@@ -1277,6 +1335,7 @@ TEST_F(FieldU64Tests, GetU64InValid)
     /*Null Underlying field*/
     ret = aBridge->msgFieldPayloadGetU64(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_INVALID_ARG, ret);
+    aBridge->msgFieldPayloadDestroy(field);
 }
 /**********************************************************************
  * F32 Tests
@@ -1312,6 +1371,7 @@ TEST_F(FieldF32Tests, UpdateF32Valid)
 
     ret = aBridge->msgFieldPayloadUpdateF32(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_OK, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldF32Tests, UpdateF32InvalidType)
@@ -1329,6 +1389,7 @@ TEST_F(FieldF32Tests, UpdateF32InvalidType)
 
     ret = aBridge->msgFieldPayloadUpdateF32(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_WRONG_FIELD_TYPE, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldF32Tests, UpdateF32InValid)
@@ -1347,6 +1408,7 @@ TEST_F(FieldF32Tests, UpdateF32InValid)
     /*Null Underlying field*/
     ret = aBridge->msgFieldPayloadUpdateF32(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_NULL_ARG, ret);
+    aBridge->msgFieldPayloadDestroy(field);
 }
 
 TEST_F(FieldF32Tests, GetF32Valid)
@@ -1364,6 +1426,7 @@ TEST_F(FieldF32Tests, GetF32Valid)
 
     ret = aBridge->msgFieldPayloadGetF32(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_OK, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldF32Tests, GetF32InvalidType)
@@ -1381,6 +1444,7 @@ TEST_F(FieldF32Tests, GetF32InvalidType)
 
     ret = aBridge->msgFieldPayloadGetF32(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_WRONG_FIELD_TYPE, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldF32Tests, GetF32InValid)
@@ -1398,6 +1462,7 @@ TEST_F(FieldF32Tests, GetF32InValid)
     /*Null Underlying field*/
     ret = aBridge->msgFieldPayloadGetF32(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_INVALID_ARG, ret);
+    aBridge->msgFieldPayloadDestroy(field);
 }
 
 /**********************************************************************
@@ -1434,6 +1499,7 @@ TEST_F(FieldF64Tests, UpdateF64Valid)
 
     ret = aBridge->msgFieldPayloadUpdateF64(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_OK, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldF64Tests, UpdateF64InvalidType)
@@ -1451,6 +1517,7 @@ TEST_F(FieldF64Tests, UpdateF64InvalidType)
 
     ret = aBridge->msgFieldPayloadUpdateF64(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_WRONG_FIELD_TYPE, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldF64Tests, UpdateF64InValid)
@@ -1469,6 +1536,7 @@ TEST_F(FieldF64Tests, UpdateF64InValid)
     /*Null Underlying field*/
     ret = aBridge->msgFieldPayloadUpdateF64(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_NULL_ARG, ret);
+    aBridge->msgFieldPayloadDestroy(field);
 }
 
 TEST_F(FieldF64Tests, GetF64Valid)
@@ -1486,6 +1554,7 @@ TEST_F(FieldF64Tests, GetF64Valid)
 
     ret = aBridge->msgFieldPayloadGetF64(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_OK, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldF64Tests, GetF64InvalidType)
@@ -1503,6 +1572,7 @@ TEST_F(FieldF64Tests, GetF64InvalidType)
 
     ret = aBridge->msgFieldPayloadGetF64(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_WRONG_FIELD_TYPE, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldF64Tests, GetF64InValid)
@@ -1520,4 +1590,5 @@ TEST_F(FieldF64Tests, GetF64InValid)
     /*Null Underlying field*/
     ret = aBridge->msgFieldPayloadGetF64(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_INVALID_ARG, ret);
+    aBridge->msgFieldPayloadDestroy(field);
 }

--- a/mama/c_cpp/src/gunittest/c/payload/fieldcompositetests.cpp
+++ b/mama/c_cpp/src/gunittest/c/payload/fieldcompositetests.cpp
@@ -100,6 +100,7 @@ TEST_F(FieldStringTests, UpdateStringValid)
 
     ret = aBridge->msgFieldPayloadUpdateString(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_OK, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldStringTests, UpdateStringInvalidType)
@@ -117,6 +118,8 @@ TEST_F(FieldStringTests, UpdateStringInvalidType)
 
     ret = aBridge->msgFieldPayloadUpdateString(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_WRONG_FIELD_TYPE, ret);
+
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldStringTests, UpdateStringInValid)
@@ -135,6 +138,8 @@ TEST_F(FieldStringTests, UpdateStringInValid)
     /*Null Underlying field*/
     ret = aBridge->msgFieldPayloadUpdateString(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_NULL_ARG, ret);
+
+    aBridge->msgFieldPayloadDestroy(field);
 }
 
 TEST_F(FieldStringTests, GetStringValid)
@@ -152,6 +157,8 @@ TEST_F(FieldStringTests, GetStringValid)
 
     ret = aBridge->msgFieldPayloadGetString(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_OK, ret);
+
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldStringTests, GetStringInvalidType)
@@ -169,6 +176,7 @@ TEST_F(FieldStringTests, GetStringInvalidType)
 
     ret = aBridge->msgFieldPayloadGetString(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_WRONG_FIELD_TYPE, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldStringTests, GetStringInValid)
@@ -186,6 +194,7 @@ TEST_F(FieldStringTests, GetStringInValid)
     /*Null Underlying field*/
     ret = aBridge->msgFieldPayloadGetString(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_INVALID_ARG, ret);
+    aBridge->msgFieldPayloadDestroy(field);
 }
 
 /**********************************************************************
@@ -218,8 +227,9 @@ protected:
 
     ~FieldDateTimeTests()
     {
-        free (m_in);
-        free (m_update);
+        mamaDateTime_destroy (m_in);
+        mamaDateTime_destroy (m_update);
+        mamaDateTime_destroy (m_out);
     }
 
 };
@@ -239,6 +249,7 @@ TEST_F(FieldDateTimeTests, UpdateDateTimeValid)
 
     ret = aBridge->msgFieldPayloadUpdateDateTime(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_OK, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldDateTimeTests, UpdateDateTimeInvalidType)
@@ -256,6 +267,7 @@ TEST_F(FieldDateTimeTests, UpdateDateTimeInvalidType)
 
     ret = aBridge->msgFieldPayloadUpdateDateTime(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_WRONG_FIELD_TYPE, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldDateTimeTests, UpdateDateTimeInValid)
@@ -274,6 +286,7 @@ TEST_F(FieldDateTimeTests, UpdateDateTimeInValid)
     /*Null Underlying field*/
     ret = aBridge->msgFieldPayloadUpdateDateTime(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_NULL_ARG, ret);
+    aBridge->msgFieldPayloadDestroy(field);
 }
 
 TEST_F(FieldDateTimeTests, GetDateTimeValid)
@@ -338,6 +351,7 @@ TEST_F(FieldDateTimeTests, GetDateTimeInvalidType)
 
     ret = aBridge->msgFieldPayloadGetDateTime(field, m_out);
     ASSERT_EQ (MAMA_STATUS_WRONG_FIELD_TYPE, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldDateTimeTests, GetDateTimeInValid)
@@ -392,6 +406,7 @@ TEST_F(FieldOpaqueTests, GetOpaqueValid)
 
     ret = aBridge->msgFieldPayloadGetOpaque(field, &m_out, &out_size);
     ASSERT_EQ (MAMA_STATUS_OK, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldOpaqueTests, GetOpaqueInvalidType)
@@ -409,6 +424,8 @@ TEST_F(FieldOpaqueTests, GetOpaqueInvalidType)
 
     ret = aBridge->msgFieldPayloadGetOpaque(field, &m_out, &out_size);
     ASSERT_EQ (MAMA_STATUS_WRONG_FIELD_TYPE, ret);
+
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldOpaqueTests, GetOpaqueInValid)
@@ -426,6 +443,7 @@ TEST_F(FieldOpaqueTests, GetOpaqueInValid)
     /*Null Underlying field*/
     ret = aBridge->msgFieldPayloadGetOpaque(field, &m_out, &out_size);
     ASSERT_EQ (MAMA_STATUS_INVALID_ARG, ret);
+    aBridge->msgFieldPayloadDestroy(field);
 }
 
 /**********************************************************************
@@ -454,6 +472,9 @@ protected:
 
     ~FieldPriceTests()
     {
+        mamaPrice_destroy(m_in);
+        mamaPrice_destroy(m_update);
+        mamaPrice_destroy(m_out);
     }
 
 };
@@ -473,6 +494,7 @@ TEST_F(FieldPriceTests, UpdatePriceValid)
 
     ret = aBridge->msgFieldPayloadUpdatePrice(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_OK, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldPriceTests, UpdatePriceInvalidType)
@@ -490,6 +512,7 @@ TEST_F(FieldPriceTests, UpdatePriceInvalidType)
 
     ret = aBridge->msgFieldPayloadUpdatePrice(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_WRONG_FIELD_TYPE, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldPriceTests, UpdatePriceInValid)
@@ -508,6 +531,7 @@ TEST_F(FieldPriceTests, UpdatePriceInValid)
     /*Null Underlying field*/
     ret = aBridge->msgFieldPayloadUpdatePrice(field, msg, m_update);
     ASSERT_EQ (MAMA_STATUS_NULL_ARG, ret);
+    aBridge->msgFieldPayloadDestroy(field);
 }
 
 TEST_F(FieldPriceTests, GetPriceValid)
@@ -532,6 +556,7 @@ TEST_F(FieldPriceTests, GetPriceValid)
     EXPECT_EQ (MAMA_STATUS_OK, ret);
     ret = aBridge->msgFieldPayloadGetPrice(field, m_out);
     ASSERT_EQ (MAMA_STATUS_OK, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldPriceTests, GetPriceInvalidType)
@@ -549,6 +574,7 @@ TEST_F(FieldPriceTests, GetPriceInvalidType)
 
     ret = aBridge->msgFieldPayloadGetPrice(field, m_out);
     ASSERT_EQ (MAMA_STATUS_WRONG_FIELD_TYPE, ret);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldPriceTests, GetPriceInValid)
@@ -623,6 +649,7 @@ TEST_F(FieldMsgTests, GetMsgInvalidType)
     ASSERT_EQ (MAMA_STATUS_WRONG_FIELD_TYPE, ret);
 
     aBridge->msgPayloadDestroy(m_in);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldMsgTests, GetMsgInValid)
@@ -642,6 +669,8 @@ TEST_F(FieldMsgTests, GetMsgInValid)
     /*Null Underlying field*/
     ret = aBridge->msgFieldPayloadGetMsg(field, &m_out);
     ASSERT_EQ (MAMA_STATUS_INVALID_ARG, ret);
+
+    aBridge->msgFieldPayloadDestroy(field);
 
     aBridge->msgPayloadDestroy(m_in);
 }

--- a/mama/c_cpp/src/gunittest/c/payload/fieldcompositetests.cpp
+++ b/mama/c_cpp/src/gunittest/c/payload/fieldcompositetests.cpp
@@ -320,10 +320,7 @@ TEST_F(FieldDateTimeTests, GetDateTimeValid)
     ret = aBridge->msgFieldPayloadGetDateTime(field, m_out);
     ASSERT_EQ (MAMA_STATUS_OK, ret);
 
-
-
-
-
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldDateTimeTests, GetDateTimeInvalidType)
@@ -605,6 +602,7 @@ TEST_F(FieldMsgTests, GetMsgValid)
     ASSERT_EQ (MAMA_STATUS_OK, ret);
 
     aBridge->msgPayloadDestroy(m_in);
+    aBridge->msgPayloadDestroy(msg);
 }
 
 TEST_F(FieldMsgTests, GetMsgInvalidType)

--- a/mama/c_cpp/src/gunittest/c/payload/fieldvectortests.cpp
+++ b/mama/c_cpp/src/gunittest/c/payload/fieldvectortests.cpp
@@ -1126,6 +1126,10 @@ protected:
     virtual void TearDown()
     {
         FieldVectorTests::TearDown();
+        for( uint32_t ii(0) ; ii < VECTOR_SIZE ; ++ii )
+        {
+            mamaMsg_destroy ( m_in[ii] );
+        }
     }
 };
 

--- a/mama/c_cpp/src/gunittest/c/payload/payloadcompositetests.cpp
+++ b/mama/c_cpp/src/gunittest/c/payload/payloadcompositetests.cpp
@@ -58,6 +58,7 @@ protected:
         //ForkedTest::SetUp();
 
         mama_loadPayloadBridge(&m_payloadBridge, m_payload.c_str());
+        mama_open();
         m_status = m_payloadBridge->msgPayloadCreate(&m_msg);
         ASSERT_EQ (MAMA_STATUS_OK, m_status);
     }
@@ -67,6 +68,7 @@ protected:
     {
         m_status = m_payloadBridge->msgPayloadDestroy(m_msg);
         EXPECT_EQ (MAMA_STATUS_OK, m_status);
+        mama_close();
 
         //ForkedTest::TearDown();
     }
@@ -602,8 +604,9 @@ protected:
     virtual void TearDown()
     {
         // Cores
-        // m_payloadBridge->msgPayloadDestroy(m_in);
-        
+        m_payloadBridge->msgPayloadDestroy(m_in);
+        m_payloadBridge->msgPayloadDestroy(m_update);
+
         PayloadCompositeTests::TearDown();
     }
 };

--- a/mama/c_cpp/src/gunittest/c/payload/payloadcompositetests.cpp
+++ b/mama/c_cpp/src/gunittest/c/payload/payloadcompositetests.cpp
@@ -347,7 +347,7 @@ protected:
         mamaDateTime_create(&m_in);
         mamaDateTime_create(&m_update);
         mamaDateTime_create(&m_out);
-        
+
         mamaDateTime_setTime (m_in, 12, 35, 40, 30);
         mamaDateTime_setTime (m_update, 13, 59, 1, 35);
     }
@@ -356,6 +356,7 @@ protected:
     {
         mamaDateTime_destroy(m_in);
         mamaDateTime_destroy(m_update);
+        mamaDateTime_destroy(m_out);
         
         PayloadCompositeTests::TearDown();
     }
@@ -475,7 +476,7 @@ protected:
         mamaPrice_create(&m_in);
         mamaPrice_create(&m_update);
         mamaPrice_create(&m_out);
-        
+
         mamaPrice_setValue(m_in, 1.0f);
         mamaPrice_setValue(m_update, 2.0f);
     }
@@ -484,7 +485,8 @@ protected:
     {
         mamaPrice_destroy(m_in);
         mamaPrice_destroy(m_update);
-        
+        mamaPrice_destroy(m_out);
+
         PayloadCompositeTests::TearDown();
     }
 };

--- a/mama/c_cpp/src/gunittest/c/payload/payloadgeneraltests.cpp
+++ b/mama/c_cpp/src/gunittest/c/payload/payloadgeneraltests.cpp
@@ -1094,8 +1094,7 @@ TEST_F(PayloadGeneralTests, CreateFromByteBufferInValidBridge)
     mama_size_t         testBufferLength = 0;
 
     result = aBridge->msgPayloadCreate(&testPayload);
-    result = aBridge->msgPayloadCreate(&testPayloadNew);
-	EXPECT_EQ (MAMA_STATUS_OK, result);
+    EXPECT_EQ (MAMA_STATUS_OK, result);
 
     aBridge->msgPayloadAddString (testPayload, "name2", 101, "Unit");
     aBridge->msgPayloadAddString (testPayload, "name3", 101, "Testing");
@@ -1119,8 +1118,7 @@ TEST_F(PayloadGeneralTests, CreateFromByteBufferInValidBuffer)
     mama_size_t         testBufferLength = 0;
 
     result = aBridge->msgPayloadCreate(&testPayload);
-    result = aBridge->msgPayloadCreate(&testPayloadNew);
-	EXPECT_EQ (MAMA_STATUS_OK, result);
+    EXPECT_EQ (MAMA_STATUS_OK, result);
 
     aBridge->msgPayloadAddString (testPayload, "name2", 101, "Unit");
     aBridge->msgPayloadAddString (testPayload, "name3", 101, "Testing");
@@ -1144,8 +1142,7 @@ TEST_F(PayloadGeneralTests, CreateFromByteBufferInValidBufferLength)
     mama_size_t         testBufferLength = 0;
 
     result = aBridge->msgPayloadCreate(&testPayload);
-    result = aBridge->msgPayloadCreate(&testPayloadNew);
-	EXPECT_EQ (MAMA_STATUS_OK, result);
+    EXPECT_EQ (MAMA_STATUS_OK, result);
 
     aBridge->msgPayloadAddString (testPayload, "name2", 101, "Unit");
     aBridge->msgPayloadAddString (testPayload, "name3", 101, "Testing");

--- a/mama/c_cpp/src/gunittest/c/payload/payloadgeneraltests.cpp
+++ b/mama/c_cpp/src/gunittest/c/payload/payloadgeneraltests.cpp
@@ -303,8 +303,6 @@ TEST_F(PayloadGeneralTests, SerializeRoundtrip)
         ret = aBridge->msgPayloadGetNumFields (testPayloadInSub, &numFieldsInSub);
         EXPECT_EQ (MAMA_STATUS_OK, ret);
         EXPECT_EQ (2, numFieldsInSub);
-
-        EXPECT_EQ (MAMA_STATUS_OK, aBridge->msgPayloadDestroy (testPayloadInSub));
     }
 
     EXPECT_EQ (MAMA_STATUS_OK, mamaDateTime_destroy (dt));

--- a/mama/c_cpp/src/gunittest/c/payload/payloadgeneraltests.cpp
+++ b/mama/c_cpp/src/gunittest/c/payload/payloadgeneraltests.cpp
@@ -952,6 +952,7 @@ TEST_F(PayloadGeneralTests, SetByteBufferValid)
     msgPayload          testPayload = NULL;
     const char*         testBuffer = NULL;
     mama_size_t         testBufferLength = 100;
+    msgPayload          testPayloadNew = NULL;
 
     result = aBridge->msgPayloadCreate(&testPayload);
 	EXPECT_EQ (MAMA_STATUS_OK, result);
@@ -964,13 +965,14 @@ TEST_F(PayloadGeneralTests, SetByteBufferValid)
 	result = aBridge->msgPayloadGetByteBuffer(testPayload, (const void**)&testBuffer, &testBufferLength);
 	EXPECT_EQ (MAMA_STATUS_OK, result);
 
-	result = aBridge->msgPayloadCreateFromByteBuffer(&testPayload, aBridge, (const void*)testBuffer, testBufferLength);
+	result = aBridge->msgPayloadCreateFromByteBuffer(&testPayloadNew, aBridge, (const void*)testBuffer, testBufferLength);
 	EXPECT_EQ (MAMA_STATUS_OK, result);
 
-    result = aBridge->msgPayloadSetByteBuffer(testPayload, aBridge, (const void*)testBuffer, testBufferLength);
+    result = aBridge->msgPayloadSetByteBuffer(testPayloadNew, aBridge, (const void*)testBuffer, testBufferLength);
     EXPECT_EQ (MAMA_STATUS_OK, result);
 
     aBridge->msgPayloadDestroy(testPayload);
+    aBridge->msgPayloadDestroy(testPayloadNew);
 }
 
 TEST_F(PayloadGeneralTests, SetByteBufferInValidPayload)
@@ -1061,7 +1063,7 @@ TEST_F(PayloadGeneralTests, CreateFromByteBufferValid)
 	result = aBridge->msgPayloadCreateFromByteBuffer(&testPayloadNew, aBridge, testBuffer, testBufferLength);
 	EXPECT_EQ (MAMA_STATUS_OK, result);
 
-    //aBridge->msgPayloadDestroy(testPayloadNew);
+    aBridge->msgPayloadDestroy(testPayloadNew);
     aBridge->msgPayloadDestroy(testPayload);
 
 }
@@ -1106,6 +1108,7 @@ TEST_F(PayloadGeneralTests, CreateFromByteBufferInValidBridge)
 	EXPECT_EQ (MAMA_STATUS_OK, result);
 
     aBridge->msgPayloadDestroy(testPayload);
+    aBridge->msgPayloadDestroy(testPayloadNew);
 }
 
 TEST_F(PayloadGeneralTests, CreateFromByteBufferInValidBuffer)
@@ -1130,6 +1133,7 @@ TEST_F(PayloadGeneralTests, CreateFromByteBufferInValidBuffer)
     EXPECT_EQ (MAMA_STATUS_NULL_ARG, result);
 
     aBridge->msgPayloadDestroy(testPayload);
+    aBridge->msgPayloadDestroy(testPayloadNew);
 }
 
 TEST_F(PayloadGeneralTests, CreateFromByteBufferInValidBufferLength)

--- a/mama/c_cpp/src/gunittest/c/payload/payloadgeneraltests.cpp
+++ b/mama/c_cpp/src/gunittest/c/payload/payloadgeneraltests.cpp
@@ -85,6 +85,7 @@ TEST_F(PayloadGeneralTests, CreateValid)
    result = aBridge->msgPayloadCreate(&testPayload);
 
    EXPECT_EQ (MAMA_STATUS_OK, result);
+   aBridge->msgPayloadDestroy(testPayload);
 }
 
 TEST_F(PayloadGeneralTests, CreateInValid)
@@ -351,6 +352,8 @@ TEST_F(PayloadGeneralTests, CopyValid)
 
     result = aBridge->msgPayloadCopy(testPayload, &copyPayload);
     EXPECT_EQ (MAMA_STATUS_OK, result);
+    aBridge->msgPayloadDestroy(testPayload);
+    aBridge->msgPayloadDestroy(copyPayload);
 }
 
 TEST_F(PayloadGeneralTests, CopyInValidPayload)
@@ -379,6 +382,8 @@ TEST_F(PayloadGeneralTests, CopyInValidCopy)
 
    result = aBridge->msgPayloadCopy(testPayload, &copyPayload);
    EXPECT_EQ (MAMA_STATUS_OK, result);
+   aBridge->msgPayloadDestroy(testPayload);
+   aBridge->msgPayloadDestroy(copyPayload);
 }
 
 TEST_F(PayloadGeneralTests, ClearValid)
@@ -390,6 +395,8 @@ TEST_F(PayloadGeneralTests, ClearValid)
 
    result = aBridge->msgPayloadClear(testPayload);
    EXPECT_EQ (MAMA_STATUS_OK, result);
+
+   aBridge->msgPayloadDestroy(testPayload);
 }
 
 TEST_F(PayloadGeneralTests, ClearInValid)
@@ -418,6 +425,8 @@ TEST_F(PayloadGeneralTests, DestroyInValid)
 
    result = aBridge->msgPayloadDestroy(NULL);
    EXPECT_EQ (MAMA_STATUS_NULL_ARG, result);
+
+   aBridge->msgPayloadDestroy(testPayload);
 }
 
 TEST_F(PayloadGeneralTests, SetParentValid)
@@ -430,6 +439,8 @@ TEST_F(PayloadGeneralTests, SetParentValid)
 
    result = aBridge->msgPayloadSetParent(testPayload, testParent);
    EXPECT_EQ (MAMA_STATUS_OK, result);
+
+   aBridge->msgPayloadDestroy(testPayload);
 }
 
 TEST_F(PayloadGeneralTests, SetParentInValidPayload)
@@ -527,8 +538,9 @@ TEST_F(PayloadGeneralTests, GetNumberFieldsInValidNumFields)
 	aBridge->msgPayloadCreate(&testPayload);
 	aBridge->msgPayloadAddChar(testPayload, NULL, 1, 'a');
 
-	result = aBridge->msgPayloadGetNumFields(testPayload, NULL);
-	EXPECT_EQ (MAMA_STATUS_NULL_ARG, result);
+    result = aBridge->msgPayloadGetNumFields(testPayload, NULL);
+    EXPECT_EQ (MAMA_STATUS_NULL_ARG, result);
+    aBridge->msgPayloadDestroy(testPayload);
 }
 
 TEST_F(PayloadGeneralTests, GetSendSubjectValid)
@@ -573,12 +585,12 @@ TEST_F(PayloadGeneralTests, GetSendSubjectInValidSubject)
     result = aBridge->msgPayloadCreate(&testPayload);
 	EXPECT_EQ (MAMA_STATUS_OK, result);
 
-	result = aBridge->msgPayloadGetSendSubject(testPayload, NULL);
+    result = aBridge->msgPayloadGetSendSubject(testPayload, NULL);
+    aBridge->msgPayloadDestroy(testPayload);
 
     CHECK_NON_IMPLEMENTED_OPTIONAL(result);
 
     EXPECT_EQ (MAMA_STATUS_NULL_ARG, result);
-    aBridge->msgPayloadDestroy(testPayload);
 }
 
 TEST_F(PayloadGeneralTests, ToStringValid)
@@ -633,6 +645,7 @@ TEST_F(PayloadGeneralTests, ToStringInValid)
 
 	char_result = aBridge->msgPayloadToString(NULL);
 	EXPECT_STREQ (char_result, NULL);
+	aBridge->msgPayloadDestroy(testPayload);
 }
 
 /*
@@ -659,6 +672,8 @@ TEST_F(PayloadGeneralTests, IterateFieldsValid)
 			NULL);
 
 	EXPECT_EQ (MAMA_STATUS_OK, result);
+    aBridge->msgPayloadDestroy(testPayload);
+    aBridge->msgFieldPayloadDestroy(testMamaField);
 }
 
 /* TODO: This test should return NULL, but  needs to have the parent msg, 
@@ -688,8 +703,9 @@ TEST_F(PayloadGeneralTests, IterateFieldsInValidParent)
     result = aBridge->msgPayloadCreate(&testPayload);
 	EXPECT_EQ (MAMA_STATUS_OK, result);
 
-	result = aBridge->msgPayloadIterateFields(testPayload, NULL, testMamaField, testMamaMsgIteratorCb, &testClosure);
-	EXPECT_EQ (MAMA_STATUS_NULL_ARG, result);
+    result = aBridge->msgPayloadIterateFields(testPayload, NULL, testMamaField, testMamaMsgIteratorCb, &testClosure);
+    EXPECT_EQ (MAMA_STATUS_NULL_ARG, result);
+    aBridge->msgPayloadDestroy(testPayload);
 }
 
 /* TODO: This test should return NULL, but  needs to have the parent msg and 
@@ -705,8 +721,9 @@ TEST_F(PayloadGeneralTests, IterateFieldsInValidMamaField)
     result = aBridge->msgPayloadCreate(&testPayload);
 	EXPECT_EQ (MAMA_STATUS_OK, result);
 
-	result = aBridge->msgPayloadIterateFields(testPayload, testMamaMsg, NULL, testMamaMsgIteratorCb, &testClosure);
-	EXPECT_EQ (MAMA_STATUS_NULL_ARG, result);
+    result = aBridge->msgPayloadIterateFields(testPayload, testMamaMsg, NULL, testMamaMsgIteratorCb, &testClosure);
+    EXPECT_EQ (MAMA_STATUS_NULL_ARG, result);
+    aBridge->msgPayloadDestroy(testPayload);
 }
 
 /* TODO: This test should return NULL, but  needs to have the parent msg and 
@@ -850,7 +867,8 @@ TEST_F(PayloadGeneralTests, UnSerializeInValidBufferLength)
 	EXPECT_EQ (MAMA_STATUS_OK, result);
 
     result = aBridge->msgPayloadUnSerialize(testPayload, &testBuffer, 0);
-	EXPECT_EQ (MAMA_STATUS_NULL_ARG, result);
+    EXPECT_EQ (MAMA_STATUS_NULL_ARG, result);
+    aBridge->msgPayloadDestroy(testPayload);
 }
 
 TEST_F(PayloadGeneralTests, GetByteBufferValid)
@@ -871,8 +889,9 @@ TEST_F(PayloadGeneralTests, GetByteBufferValid)
     aBridge->msgPayloadAddString (testPayload, "name4", 101, "Is");
     aBridge->msgPayloadAddString (testPayload, "name5", 101, "Fun");
 
-	result = aBridge->msgPayloadGetByteBuffer(testPayload, (const void**)&testBuffer, &testBufferLength);
-	EXPECT_EQ (MAMA_STATUS_OK, result);
+    result = aBridge->msgPayloadGetByteBuffer(testPayload, (const void**)&testBuffer, &testBufferLength);
+    EXPECT_EQ (MAMA_STATUS_OK, result);
+    aBridge->msgPayloadDestroy(testPayload);
 }
 
 TEST_F(PayloadGeneralTests, GetByteBufferInValidPayload)
@@ -889,8 +908,9 @@ TEST_F(PayloadGeneralTests, GetByteBufferInValidPayload)
     aBridge->msgPayloadAddString (testPayload, "name4", 101, "Is");
     aBridge->msgPayloadAddString (testPayload, "name5", 101, "Fun");
 
-	result = aBridge->msgPayloadGetByteBuffer(NULL, (const void**)&testBuffer, &testBufferLength);
-	EXPECT_EQ (MAMA_STATUS_NULL_ARG, result);
+    result = aBridge->msgPayloadGetByteBuffer(NULL, (const void**)&testBuffer, &testBufferLength);
+    EXPECT_EQ (MAMA_STATUS_NULL_ARG, result);
+    aBridge->msgPayloadDestroy(testPayload);
 }
 
 TEST_F(PayloadGeneralTests, GetByteBufferInValidBuffer)
@@ -906,8 +926,9 @@ TEST_F(PayloadGeneralTests, GetByteBufferInValidBuffer)
     aBridge->msgPayloadAddString (testPayload, "name4", 101, "Is");
     aBridge->msgPayloadAddString (testPayload, "name5", 101, "Fun");
 
-	result = aBridge->msgPayloadGetByteBuffer(testPayload, NULL, &testBufferLength);
-	EXPECT_EQ (MAMA_STATUS_NULL_ARG, result);
+    result = aBridge->msgPayloadGetByteBuffer(testPayload, NULL, &testBufferLength);
+    EXPECT_EQ (MAMA_STATUS_NULL_ARG, result);
+    aBridge->msgPayloadDestroy(testPayload);
 }
 
 TEST_F(PayloadGeneralTests, GetByteBufferInValidBufferLength)
@@ -923,8 +944,9 @@ TEST_F(PayloadGeneralTests, GetByteBufferInValidBufferLength)
     aBridge->msgPayloadAddString (testPayload, "name4", 101, "Is");
     aBridge->msgPayloadAddString (testPayload, "name5", 101, "Fun");
 
-	result = aBridge->msgPayloadGetByteBuffer(testPayload, (const void**)&testBuffer, NULL);
-	EXPECT_EQ (MAMA_STATUS_NULL_ARG, result);
+    result = aBridge->msgPayloadGetByteBuffer(testPayload, (const void**)&testBuffer, NULL);
+    EXPECT_EQ (MAMA_STATUS_NULL_ARG, result);
+    aBridge->msgPayloadDestroy(testPayload);
 }
 
 TEST_F(PayloadGeneralTests, SetByteBufferValid)
@@ -948,7 +970,9 @@ TEST_F(PayloadGeneralTests, SetByteBufferValid)
 	EXPECT_EQ (MAMA_STATUS_OK, result);
 
     result = aBridge->msgPayloadSetByteBuffer(testPayload, aBridge, (const void*)testBuffer, testBufferLength);
-	EXPECT_EQ (MAMA_STATUS_OK, result);
+    EXPECT_EQ (MAMA_STATUS_OK, result);
+
+    aBridge->msgPayloadDestroy(testPayload);
 }
 
 TEST_F(PayloadGeneralTests, SetByteBufferInValidPayload)
@@ -961,7 +985,8 @@ TEST_F(PayloadGeneralTests, SetByteBufferInValidPayload)
 	EXPECT_EQ (MAMA_STATUS_OK, result);
 
     result = aBridge->msgPayloadSetByteBuffer(NULL, aBridge, (const void*)testBuffer, testBufferLength);
-	EXPECT_EQ (MAMA_STATUS_NULL_ARG, result);
+    EXPECT_EQ (MAMA_STATUS_NULL_ARG, result);
+    aBridge->msgPayloadDestroy(testPayload);
 }
 
 TEST_F(PayloadGeneralTests, SetByteBufferInValidBridge)
@@ -979,7 +1004,9 @@ TEST_F(PayloadGeneralTests, SetByteBufferInValidBridge)
     aBridge->msgPayloadAddString (testPayload, "name5", 105, "Fun");
 
     result = aBridge->msgPayloadSetByteBuffer(testPayload, NULL, (const void*)testBuffer, testBufferLength);
-	EXPECT_EQ (MAMA_STATUS_NULL_ARG, result);
+    EXPECT_EQ (MAMA_STATUS_NULL_ARG, result);
+
+    aBridge->msgPayloadDestroy(testPayload);
 }
 
 TEST_F(PayloadGeneralTests, SetByteBufferInValidBuffer)
@@ -992,6 +1019,7 @@ TEST_F(PayloadGeneralTests, SetByteBufferInValidBuffer)
 
     result = aBridge->msgPayloadSetByteBuffer(testPayload, aBridge, NULL, testBufferLength);
 	EXPECT_EQ (MAMA_STATUS_NULL_ARG, result);
+	aBridge->msgPayloadDestroy(testPayload);
 }
 
 TEST_F(PayloadGeneralTests, SetByteBufferInValidBufferLength)
@@ -1009,6 +1037,7 @@ TEST_F(PayloadGeneralTests, SetByteBufferInValidBufferLength)
 
     result = aBridge->msgPayloadSetByteBuffer(testPayload, aBridge, (const void*)testBuffer, 0);
 	EXPECT_EQ (MAMA_STATUS_NULL_ARG, result);
+	aBridge->msgPayloadDestroy(testPayload);
 }
 
 /* TODO: Check the values in the created payload.
@@ -1382,9 +1411,6 @@ TEST_F(PayloadGeneralTests, GetFieldValid)
     aBridge->msgPayloadAddString (testPayload, "name4", 104, "Is");
     aBridge->msgPayloadAddString (testPayload, "name5", 105, "Fun");
 
-    result = aBridge->msgFieldPayloadCreate(&testResult);
-    EXPECT_EQ (MAMA_STATUS_OK, result);
-
     result = aBridge->msgPayloadGetField(testPayload, &testName, testFid, &testResult);
     EXPECT_EQ (MAMA_STATUS_OK, result);
 
@@ -1456,8 +1482,6 @@ TEST_F(PayloadGeneralTests, GetFieldInValidResult)
     msgPayload          testPayload = NULL;
     char                testName;
     mama_fid_t          testFid = 105;
-    msgFieldPayload     testField = NULL;
-    //mama_bool_t         value = 1;
 
     result = aBridge->msgPayloadCreate(&testPayload);
 	EXPECT_EQ (MAMA_STATUS_OK, result);
@@ -1466,12 +1490,6 @@ TEST_F(PayloadGeneralTests, GetFieldInValidResult)
     aBridge->msgPayloadAddString (testPayload, "name3", 103, "Testing");
     aBridge->msgPayloadAddString (testPayload, "name4", 104, "Is");
     aBridge->msgPayloadAddString (testPayload, "name5", 105, "Fun");
-
-    result = aBridge->msgFieldPayloadCreate(&testField);
-    EXPECT_EQ (MAMA_STATUS_OK, result);
-
-    //result = aBridge->msgFieldPayloadUpdateBool(testField, testPayload, value);
-	//EXPECT_EQ (MAMA_STATUS_NULL_ARG, result);
 
     result = aBridge->msgPayloadGetField(testPayload, &testName, testFid, NULL);
     EXPECT_EQ (MAMA_STATUS_NULL_ARG, result);
@@ -1764,6 +1782,7 @@ TEST_F(PayloadGeneralTests, IterNextInValidPayload)
     output = aBridge->msgPayloadIterNext(testIter, testField, NULL);
 
     aBridge->msgPayloadIterDestroy(testIter);
+    aBridge->msgFieldPayloadDestroy(testField);
     aBridge->msgPayloadDestroy(testPayload);
     if (output != NULL)
         FAIL();
@@ -1822,6 +1841,7 @@ TEST_F(PayloadGeneralTests, IterBeginInValidIter)
 
     output = aBridge->msgPayloadIterBegin(NULL, testField, testPayload);
     aBridge->msgPayloadIterDestroy(testIter);
+    aBridge->msgFieldPayloadDestroy(testField);
     aBridge->msgPayloadDestroy(testPayload);
     if (output != NULL)
         FAIL();
@@ -1850,6 +1870,7 @@ TEST_F(PayloadGeneralTests, IterBeginInValidField)
 
     output = aBridge->msgPayloadIterBegin(testIter, NULL, testPayload);
     aBridge->msgPayloadIterDestroy(testIter);
+    aBridge->msgFieldPayloadDestroy(testField);
     aBridge->msgPayloadDestroy(testPayload);
     if (output == NULL)
         FAIL();
@@ -1879,6 +1900,7 @@ TEST_F(PayloadGeneralTests, IterBeginInValidPayload)
     output = aBridge->msgPayloadIterBegin(testIter, testField, NULL);
 
     aBridge->msgPayloadIterDestroy(testIter);
+    aBridge->msgFieldPayloadDestroy(testField);
     aBridge->msgPayloadDestroy(testPayload);
     if (output != NULL)
         FAIL();

--- a/mama/c_cpp/src/gunittest/c/publishertest.cpp
+++ b/mama/c_cpp/src/gunittest/c/publishertest.cpp
@@ -232,6 +232,8 @@ TEST_F (MamaPublisherTestC, Send)
     ASSERT_EQ (MAMA_STATUS_OK,
                mamaTransport_destroy (tport));
 
+    ASSERT_EQ (MAMA_STATUS_OK, mamaMsg_destroy (msg));
+
     ASSERT_EQ (MAMA_STATUS_OK, mama_close());
 
     ASSERT_EQ (0, pubOnCreateCount);
@@ -299,6 +301,8 @@ TEST_F (MamaPublisherTestC, EventSendWithCallbacks)
 
     ASSERT_EQ (MAMA_STATUS_OK,
                mamaTransport_destroy (tport));
+
+    ASSERT_EQ (MAMA_STATUS_OK, mamaMsg_destroy (msg));
 
     ASSERT_EQ (MAMA_STATUS_OK, mama_close());
 
@@ -443,6 +447,8 @@ TEST_F (MamaPublisherTestC, EventSendWithCallbacksNoErrorCallback)
     ASSERT_EQ (MAMA_STATUS_OK,
                mamaTransport_destroy (tport));
 
+    ASSERT_EQ (MAMA_STATUS_OK, mamaMsg_destroy (msg));
+
     ASSERT_EQ (MAMA_STATUS_OK, mama_close());
 
     ASSERT_EQ (1, pubOnCreateCount);
@@ -514,6 +520,8 @@ TEST_F (MamaPublisherTestC, EventSendWithCallbacksNoCallbacks)
 
     ASSERT_EQ (MAMA_STATUS_OK,
                mamaTransport_destroy (tport));
+
+    ASSERT_EQ (MAMA_STATUS_OK, mamaMsg_destroy (msg));
 
     ASSERT_EQ (MAMA_STATUS_OK, mama_close());
 

--- a/mama/c_cpp/src/gunittest/c/subscriptiontest.cpp
+++ b/mama/c_cpp/src/gunittest/c/subscriptiontest.cpp
@@ -191,5 +191,7 @@ TEST_F (MamaSubscriptionTest, SubscriptionCreateDestroy)
 
         /* Deallocate subscription memory */
         ASSERT_EQ (MAMA_STATUS_OK, mamaSubscription_deallocate (subscription));
+
+        ASSERT_EQ (MAMA_STATUS_OK, mamaSource_destroy (testSource));
     }
 }

--- a/mama/c_cpp/src/gunittest/cpp/MamaDateTimeTest.cpp
+++ b/mama/c_cpp/src/gunittest/cpp/MamaDateTimeTest.cpp
@@ -30,6 +30,7 @@
 /* Includes */
 /* ************************************************************************* */
 #include "MamaDateTimeTest.h"
+#include <mama/mamacpp.h>
 
 /* ************************************************************************* */
 /* Construction and Destruction */
@@ -53,6 +54,9 @@ void MamaDateTimeTest::SetUp(void)
 {
 	// Create the date time
 	//ASSERT_EQ(mamaDateTime_create(&m_DateTime), MAMA_STATUS_OK);
+    Mama::loadBridge(getMiddleware());
+    Mama::open();
+
     m_DateTime = new MamaDateTime();
 }
 
@@ -60,6 +64,7 @@ void MamaDateTimeTest::TearDown(void)
 {
 	// Destroy the date time
 	//ASSERT_EQ(mamaDateTime_destroy(m_DateTime), MAMA_STATUS_OK);
+    Mama::close();
     delete m_DateTime;
 }
 

--- a/mama/c_cpp/src/gunittest/cpp/MamaPublisherTest.cpp
+++ b/mama/c_cpp/src/gunittest/cpp/MamaPublisherTest.cpp
@@ -146,6 +146,7 @@ TEST_F(MamaPublisherTest, Publish)
 
     // Delete the publisher
     delete publisher;
+    delete msg;
 
     Mama::stop(m_bridge);
 }
@@ -199,6 +200,7 @@ TEST_F(MamaPublisherTest, PublishWithCallbacks)
 
     delete publisher;
     delete queue;
+    delete msg;
 
     Mama::stop(m_bridge);
 
@@ -256,6 +258,7 @@ TEST_F(MamaPublisherTest, DISABLED_PublishWithCallbacksBadSource)
     delete publisher;
     delete queue;
     delete testCallback;
+    delete msg;
 
     Mama::stop(m_bridge);
 
@@ -299,6 +302,7 @@ TEST_F(MamaPublisherTest, PublishWithNullCallback)
 
     delete publisher;
     delete queue;
+    delete msg;
 
     Mama::stop(m_bridge);
 }

--- a/mama/c_cpp/src/gunittest/cpp/MamaPublisherTest.cpp
+++ b/mama/c_cpp/src/gunittest/cpp/MamaPublisherTest.cpp
@@ -188,7 +188,7 @@ TEST_F(MamaPublisherTest, PublishWithCallbacks)
     sleep(1);
 
     // Destroy the publisher
-    publisher->destroy();            
+    publisher->destroy();
 
     // Wait for onDestroy
 	while (testCallback->getOnDestroyCount() == 0)
@@ -199,7 +199,6 @@ TEST_F(MamaPublisherTest, PublishWithCallbacks)
     ASSERT_EQ(1, testCallback->getOnDestroyCount());
 
     delete publisher;
-    delete queue;
     delete msg;
 
     Mama::stop(m_bridge);
@@ -256,7 +255,6 @@ TEST_F(MamaPublisherTest, DISABLED_PublishWithCallbacksBadSource)
     ASSERT_EQ(1, testCallback->getOnDestroyCount());
 
     delete publisher;
-    delete queue;
     delete testCallback;
     delete msg;
 
@@ -298,10 +296,9 @@ TEST_F(MamaPublisherTest, PublishWithNullCallback)
     sleep (1);
 
     // Destroy the publisher
-    publisher->destroy();            
+    publisher->destroy();
 
     delete publisher;
-    delete queue;
     delete msg;
 
     Mama::stop(m_bridge);

--- a/mama/c_cpp/src/gunittest/cpp/MamaTimerTest.cpp
+++ b/mama/c_cpp/src/gunittest/cpp/MamaTimerTest.cpp
@@ -44,7 +44,7 @@ MamaTimerTestCPP::MamaTimerTestCPP(void)
     m_numberForCallbacks        = 0;
     m_numberForTimers           = 1000;
     m_numberRecursiveCallbacks  = 0;
-    m_timerInterval             = 0.0001;    
+    m_timerInterval             = 0.1;
 }
 
 MamaTimerTestCPP::~MamaTimerTestCPP(void)
@@ -144,14 +144,12 @@ void MamaTimerTestCPP::OnForRecursiveTick::onDestroy(MamaTimer* timer, void * cl
 
 void MamaTimerTestCPP::OnForTwoTimerTick::onTimer(MamaTimer* timer)
 {
-    //printf("on timer tick\n");
+    timer->destroy();
 
 }
 
 void MamaTimerTestCPP::OnForTwoTimerTick::onDestroy(MamaTimer* timer, void * closure)
 {
-    // Cast the closure to a test fixture
-    //printf("in TwoTick onDestroy\n");
 }
 
 /* ************************************************************************* */
@@ -208,12 +206,9 @@ TEST_F(MamaTimerTestCPP, TwoTimer)
     mtarray[1].create(m_defaultQueue, timerCb, m_timerInterval*2, m_this); //use same callback
 
     //this timer calls stop destroy on tick and Mama::stop on destroy
-    mtarray[2].create(m_defaultQueue, stopperCb, 3, m_this); //3 secs
+    mtarray[2].create(m_defaultQueue, stopperCb, m_timerInterval*3, m_this);
 
     Mama::start(m_bridge);
-    
-    mtarray[0].destroy();
-    mtarray[1].destroy();
 
     // Cleanup
     delete timerCb;


### PR DESCRIPTION
## Summary
There are many small leaks right across MAMA, qpid, common code and unit tests - too many to describe here. The commits in this pull request are all atomic and should tell the story better.

## Areas Affected
*Place an 'x' within the braces to check the box*
- [x] MAMAC
- [x] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [x] Unit Tests
- [ ] Examples

## Details
See individual commits for more details. Note this includes the mamaMsg_detach issue from #12.

History of work and changes in memory leak can be seen here: http://ci.openmama.org:8080/job/feature-leak-cull/

## Testing
All unit tests pass, capture / mamalistenc work without issue or memory leaks.
