### PR TITLE
PLAT-438: Implementing a seperate timeout for subscription recaps.

### DIFF
--- a/mama/c_cpp/src/c/dqstrategy.c
+++ b/mama/c_cpp/src/c/dqstrategy.c
@@ -463,7 +463,7 @@ dqStrategy_sendRecapRequest (dqStrategyImpl* strategy, mamaMsg srcMsg, mamaDqCon
         mamaSubscription_getSubscSymbol (self->mSubscription,&symbol);
     }
 
-    mamaSubscription_getTimeout (self->mSubscription, &timeout);
+    mamaSubscription_getRecapTimeout (self->mSubscription, &timeout);
     mamaSubscription_getRetries (self->mSubscription, &retries);
 
     /* Send a request to the publisher to resend. */

--- a/mama/c_cpp/src/c/mama/subscription.h
+++ b/mama/c_cpp/src/c/mama/subscription.h
@@ -940,6 +940,22 @@ mamaSubscription_getTimeout(
     double *timeout);
 
 /**
+ * @brief Retrieve the recap timeout.
+ *
+ * @param[in] subscription The subscription.
+ * @param[out] timeout A pointer to a double to hold the value.
+ *
+ * @return mama_status return code can be one of:
+ *              MAMA_STATUS_NULL_ARG
+ *              MAMA_STATUS_OK
+ */
+MAMAExpDLL
+extern mama_status
+mamaSubscription_getRecapTimeout(
+    mamaSubscription subscription,
+    double *timeout);
+
+/**
  * @brief Return the <code>mamaTransport</code> for this subscription.
  *
  * @param[in] subscription  The subscription.
@@ -1260,7 +1276,7 @@ mamaSubscription_setSymbol (
 
 /**
  * @brief Set the timeout for this subscription. The timeout is used for
- * requesting recaps.
+ * requesting initials.
  *
  * @param[in] subscription The subscription.
  * @param[in] timeout The timeout in seconds.
@@ -1272,6 +1288,23 @@ mamaSubscription_setSymbol (
 MAMAExpDLL
 extern mama_status
 mamaSubscription_setTimeout (
+    mamaSubscription subscription,
+    double timeout);
+
+/**
+ * @brief Set the timeout for this subscription. The timeout is used for
+ * requesting recaps.
+ *
+ * @param[in] subscription The subscription.
+ * @param[in] timeout The timeout in seconds.
+ *
+ * @return mama_status return code can be one of:
+ *              MAMA_STATUS_NULL_ARG
+ *              MAMA_STATUS_OK
+ */
+MAMAExpDLL
+extern mama_status
+mamaSubscription_setRecapTimeout (
     mamaSubscription subscription,
     double timeout);
 

--- a/mama/c_cpp/src/c/subscription.c
+++ b/mama/c_cpp/src/c/subscription.c
@@ -107,6 +107,7 @@ typedef struct mamaSubscriptionImpl_
     imageRequest            mRecapRequest;
     int                     mRespondToNextRefresh; /* boolean */
     double                  mTimeout;
+    double                  mRecapTimeout;
     int                     mRetries;
     int                     mAcceptMultipleInitials;
     int                     mRecoverGaps; /* boolean */
@@ -383,6 +384,7 @@ mamaSubscription_allocate (
     impl->mRecapRequest           = NULL;
     impl->mRespondToNextRefresh   = 1;
     impl->mTimeout                = MAMA_SUBSCRIPTION_DEFAULT_TIMEOUT;
+    impl->mRecapTimeout           = MAMA_SUBSCRIPTION_DEFAULT_RECAP_TIMEOUT;
     impl->mRetries                = MAMA_SUBSCRIPTION_DEFAULT_RETRIES;
     impl->mAcceptMultipleInitials = 0;
     impl->mRecoverGaps            = 1;
@@ -1915,6 +1917,38 @@ mamaSubscription_getTimeout (mamaSubscription subscription, double *val)
         return MAMA_STATUS_INVALID_ARG;
     }
     *val = self->mTimeout;
+    return MAMA_STATUS_OK;
+}
+
+mama_status
+mamaSubscription_setRecapTimeout ( mamaSubscription subscription,
+                                   double timeout)
+{
+    if (!self) return MAMA_STATUS_NULL_ARG;
+    if ( self->mType == MAMA_SUBSC_TYPE_BASIC)
+    {
+        return MAMA_STATUS_INVALID_ARG;
+    }
+    self->mRecapTimeout = timeout;
+    return MAMA_STATUS_OK;
+}
+
+mama_status
+mamaSubscription_getRecapTimeout (mamaSubscription subscription, double *val)
+{
+    if (!self) return MAMA_STATUS_NULL_ARG;
+    if ( self->mType == MAMA_SUBSC_TYPE_BASIC)
+    {
+        return MAMA_STATUS_INVALID_ARG;
+    }
+
+    /* If mamaSubscription_setRecap hasn't been called, default to mTimeout. */
+    if (MAMA_SUBSCRIPTION_DEFAULT_RECAP_TIMEOUT == self->mRecapTimeout)
+    {
+        self->mRecapTimeout = self->mTimeout;
+    }
+
+    *val = self->mRecapTimeout;
     return MAMA_STATUS_OK;
 }
 

--- a/mama/c_cpp/src/c/subscriptionimpl.h
+++ b/mama/c_cpp/src/c/subscriptionimpl.h
@@ -43,6 +43,11 @@ extern "C" {
 /* The default timeout when requesting initial and recap images. */
 #define MAMA_SUBSCRIPTION_DEFAULT_TIMEOUT 10.0
 
+/* The default timeout when requesting recap images.
+ * Defaults to special value used to indicate that subscription
+ * timeout should be used instead. */
+#define MAMA_SUBSCRIPTION_DEFAULT_RECAP_TIMEOUT -1
+
 /* *************************************************** */
 /* Enumerations. */
 /* *************************************************** */

--- a/mama/c_cpp/src/cpp/MamaSubscription.cpp
+++ b/mama/c_cpp/src/cpp/MamaSubscription.cpp
@@ -826,6 +826,23 @@ namespace Wombat
         return timeout;
     }
 
+    void MamaSubscription::setRecapTimeout (double timeout)
+    {
+        if (NULL != mSubscription)
+        {
+            mamaTry (mamaSubscription_setRecapTimeout (mSubscription,
+                                                       timeout));
+        }
+    }
+
+    double MamaSubscription::getRecapTimeout (void)
+    {
+        double timeout = 0.0;
+        mamaTry (mamaSubscription_getRecapTimeout (mSubscription,
+                                              &timeout));
+        return timeout;
+    }
+
     void MamaSubscription::setRecoverGaps (bool recover)
     {
         mamaTry (mamaSubscription_setRecoverGaps (mSubscription, 

--- a/mama/c_cpp/src/cpp/mama/MamaSubscription.h
+++ b/mama/c_cpp/src/cpp/mama/MamaSubscription.h
@@ -294,7 +294,7 @@ namespace Wombat
 
         /**
          * Set the timeout for this subscription. The timeout is used for
-         * requesting initial values, and recaps.
+         * requesting initial values.
          *
          * @param timeout The timeout in seconds.
          */
@@ -304,6 +304,20 @@ namespace Wombat
          * Return the timeout.
          */
         virtual double getTimeout (void);
+
+        /**
+         * Set the timeout for this subscription. The timeout is used for
+         * requesting recaps.
+         *
+         * @param timeout The timeout in seconds.
+         */
+        virtual void setRecapTimeout (double timeout);
+
+        /**
+        /**
+         * Return the recap timeout.
+         */
+        virtual double getRecapTimeout (void);
 
         /**
          * Attempt to recover from sequence number gaps by requesting a

--- a/mamda/c_cpp/src/cpp/MamdaSubscription.cpp
+++ b/mamda/c_cpp/src/cpp/MamdaSubscription.cpp
@@ -78,6 +78,7 @@ namespace Wombat
         void*                          mClosure;
         bool                           mRequireInitial;
         double                         mTimeout;
+        double                         mRecapTimeout;
         int                            mRetries;
         vector<MamdaMsgListener*>      mMsgListeners;
         vector<MamdaErrorListener*>    mErrorListeners;
@@ -114,6 +115,7 @@ namespace Wombat
         result->setServiceLevel   (getServiceLevel(), getServiceLevelOpt());
         result->setRequireInitial (getRequireInitial());
         result->setTimeout        (getTimeout());
+        result->setRecapTimeout   (getRecapTimeout());
         result->setRetries        (getRetries());
 
         return result;
@@ -227,6 +229,11 @@ namespace Wombat
         mImpl.mTimeout = timeout;
     }
 
+    void MamdaSubscription::setRecapTimeout (double  timeout)
+    {
+        mImpl.mRecapTimeout = timeout;
+    }
+
     void MamdaSubscription::setRetries (int retries)
     {
         mImpl.mRetries = retries;
@@ -301,6 +308,7 @@ namespace Wombat
         mImpl.mMamaSubscription->setRequiresInitial  (mImpl.mRequireInitial);
         mImpl.mMamaSubscription->setRetries          (mImpl.mRetries);
         mImpl.mMamaSubscription->setTimeout          (mImpl.mTimeout);
+        mImpl.mMamaSubscription->setRecapTimeout     (mImpl.mRecapTimeout);
 
         mImpl.mMamaSubscription->create (mImpl.mQueue,
                                          &mImpl,
@@ -395,6 +403,16 @@ namespace Wombat
         return mImpl.mTimeout;
     }
 
+    double MamdaSubscription::getRecapTimeout() const
+    {
+        if (-1 == mImpl.mRecapTimeout)
+        {
+            // If this hasn't been explicitly set, set it to mTimeout
+            mImpl.mRecapTimeout = mImpl.mTimeout;
+        }
+        return mImpl.mRecapTimeout;
+    }
+
     int MamdaSubscription::getRetries() const
     {
         return mImpl.mRetries;
@@ -424,6 +442,7 @@ namespace Wombat
         , mClosure            (NULL)
         , mRequireInitial     (true)
         , mTimeout            (10.0)
+        , mRecapTimeout       (-1)  // Special value used to indicate that mTimeout should be used.
         , mRetries            (MAMA_DEFAULT_RETRIES)
         , mLatestMsg          (NULL)
         , mMamaSubscription   (NULL)

--- a/mamda/c_cpp/src/cpp/mamda/MamdaSubscription.h
+++ b/mamda/c_cpp/src/cpp/mamda/MamdaSubscription.h
@@ -134,10 +134,16 @@ namespace Wombat
         void setRequireInitial (bool  require);
 
         /**
-         * Set the subscription timeout (in seconds).  Do this before
+         * Set the subscription initial timeout (in seconds).  Do this before
          * calling activate().
          */
         void setTimeout (double  timeout);
+        
+        /**
+         * Set the subscription recap timeout (in seconds).  Do this before
+         * calling activate().
+         */
+        void setRecapTimeout (double  timeout);
         
         /**
          * Set the subscription retries.  Do this before
@@ -265,6 +271,11 @@ namespace Wombat
          * Return the timeout (seconds).
          */
         double getTimeout() const;
+
+        /**
+         * Return the recap timeout (seconds).
+         */
+        double getRecapTimeout() const;
 
         /**
          * Return the retries.


### PR DESCRIPTION
## Summary
Adding the ability to use a separate timeout for subscription recaps from the initial request.
## Areas Affected
*Place an 'x' within the braces to check the box*
- [x] MAMAC
- [x] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [x] MAMDA
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
Added the following implementations for mama/mamda:
```
mamaSubscription_setRecapTimeout()
mamaSubscription_getRecapTimeout()
MamaSubscription::setRecapTimeout()
MamaSubscription::getRecapTimeout()
MamdaSubscription::setRecapTimeout()
MamdaSubscription::getRecapTimeout()
```
This new timeout is entirely optional. On the first call of `mamaSubscription_getRecapTimeout`, if the recap timeout has not been expliticaly been set it well be set at that time *to the value set currently for the initial timeout*. This way, existing code that just calls `mamaSubscription_setTimeout()` will behave in the same manner as before.

## Testing
Tested by simulating dropped messages using a custom publisher. Our mama clients see a gap and request a recap, logging the timeout used for the request.

Signed-off-by: Matt Mulhern <matt@openmama.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmama/openmama/191)
<!-- Reviewable:end -->
