### PR TITLE
SCONS: Updated scons script to build noop on windows

### DIFF
--- a/mama/c_cpp/SConscript.win
+++ b/mama/c_cpp/SConscript.win
@@ -110,6 +110,7 @@ env.SConscript('src/c/SConscript.win','env')
 env.SConscript('src/cpp/SConscript.win','env')
 env.SConscript('src/c/payload/SConscript.win','env')
 env.SConscript('src/c/bridge/SConscript.win','env')
+env.SConscript('src/c/entitlement/SConscript','env')
 env.SConscript('src/examples/SConscript.win','env')
 
 if env['with_unittest'] == True and 'dynamic' in env['build']:

--- a/mama/c_cpp/src/c/entitlement/SConscript
+++ b/mama/c_cpp/src/c/entitlement/SConscript
@@ -9,5 +9,4 @@ if len(env['entitlements']) > 0:
         modules.append(lib)
 
 for m in modules:
-    if os.path.isfile( os.path.join(m,'SConscript') ):
-        env.SConscript( os.path.join(m,'SConscript'), 'env' )
+    env.SConscript( os.path.join(m,'SConscript'), 'env' )

--- a/mama/c_cpp/src/c/entitlement/noop/SConscript
+++ b/mama/c_cpp/src/c/entitlement/noop/SConscript
@@ -19,6 +19,8 @@ if env['PLATFORM'] == "win32":
     env.Append(LIBS=libs, CPPPATH=[includePath])
     env.InstallLibrary(sources, target)
 else:
+    lib = []
+    lib.append(env.SharedLibrary(target, sources))
     env.Append(LIBS=['mama', ], CPPPATH=[includePath])
     env['CCFLAGS'] = [x for x in env['CCFLAGS'] if x != '-pedantic-errors']
     env.Append(CFLAGS=['-Werror'])

--- a/mama/c_cpp/src/c/entitlement/noop/SConscript
+++ b/mama/c_cpp/src/c/entitlement/noop/SConscript
@@ -10,17 +10,16 @@ includePath = []
 includePath.append('#mama/c_cpp/src/c')
 includePath.append('.')
 
-
-env['CCFLAGS'] = [x for x in env['CCFLAGS'] if x != '-pedantic-errors']
-
-env.Append(LIBS=['mama', ], 
-           CPPPATH=[includePath])
-
-env.Append(CFLAGS=['-Werror'])
-
 sources = Glob('*.c')
 
-lib = []
-lib.append(env.SharedLibrary(target, sources))
-
-Alias('install', env.Install('$libdir', lib))
+if env['PLATFORM'] == "win32":
+    libs = []
+    libs.append('libwombatcommon%s.lib' % ( env['suffix'] ))
+    libs.append('libmamac%s.lib' % ( env['suffix'] ))
+    env.Append(LIBS=libs, CPPPATH=[includePath])
+    env.InstallLibrary(sources, target)
+else:
+    env.Append(LIBS=['mama', ], CPPPATH=[includePath])
+    env['CCFLAGS'] = [x for x in env['CCFLAGS'] if x != '-pedantic-errors']
+    env.Append(CFLAGS=['-Werror'])
+    Alias('install', env.Install('$libdir', lib))


### PR DESCRIPTION
## Summary
Updated scons script to build noop on windows

## Areas Affected
*Place an 'x' within the braces to check the box*
- [ ] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [x] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
Fix applied as per issue #192. Scons builds won't include the noop
entitlement bridge without this change.

## Testing
Build was tested on both linux and windows.