### PR TITLE
SCONS: Fixed build issue with multiple build types on windows

### DIFF
--- a/common/c_cpp/SConscript.win
+++ b/common/c_cpp/SConscript.win
@@ -45,5 +45,5 @@ env.SConscript('src/c/SConscript.win','env')
 if env.get('with_enterprise',None) == True:
     env.SConscript('src/enterprise/SConscript.win', 'env')
 
-if env['with_unittest'] == True:
-    env.SConscript('src/gunittest/SConscript.win', 'env')
+if env['with_unittest'] == True and 'dynamic' in env['build']:
+    env.SConscript('src/gunittest/SConscript', 'env')

--- a/common/c_cpp/src/gunittest/SConscript
+++ b/common/c_cpp/src/gunittest/SConscript
@@ -1,15 +1,25 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 Import('env')
+import os
 env = env.Clone()
 
 incpath = []
 incpath.append('$gtest_home/include')
 
 libpath = []
-libpath.append('$gtest_home/lib')
+libs = []
 
-env.Append(LIBPATH=libpath, CPPPATH=incpath, LIBS=['gtest', 'gtest_main'
-           ])
+if env['PLATFORM'] == "win32":
+    libpath.append(os.path.join(env['gtest_home'], 'msvc', env['win_arch_path'], env['win_type_path']))
+    if 'debug' in env['build']:
+        libs = ['gtestd', 'gtest_maind']
+    else:
+        libs = ['gtest', 'gtest_main']
+else:
+    libpath.append('$gtest_home/lib')
+    libs = ['gtest', 'gtest_main']
+
+env.Append(LIBPATH=libpath, CPPPATH=incpath, LIBS=libs)
 
 env.SConscript('c/SConscript', 'env')

--- a/common/c_cpp/src/gunittest/c/SConscript
+++ b/common/c_cpp/src/gunittest/c/SConscript
@@ -16,11 +16,15 @@ incpath.append('#mama/c_cpp/src/c')
 
 libpath = []
 libpath.append('$libdir')
+libs = []
+if env['PLATFORM'] == "win32":
+    libs.append('libmamac%s' % ( env['suffix'] ))
+    libs.append('libwombatcommon%s' % ( env['suffix'] ))
+else:
+    libs = ['dl', 'wombatcommon', 'mama', 'pthread']
+    env['CCFLAGS'] = [x for x in env['CCFLAGS'] if x != '-pedantic-errors']
 
-env.Append(LIBPATH=libpath, LIBS=['dl', 'wombatcommon', 'mama', 'pthread'],
-           CPPPATH=incpath)
-
-env['CCFLAGS'] = [x for x in env['CCFLAGS'] if x != '-pedantic-errors']
+env.Append(LIBPATH=libpath, LIBS=libs, CPPPATH=incpath)
 
 sources = Split("""
 queuetest.cpp

--- a/mama/c_cpp/SConscript.win
+++ b/mama/c_cpp/SConscript.win
@@ -114,7 +114,7 @@ env.SConscript('src/c/entitlement/SConscript','env')
 env.SConscript('src/examples/SConscript.win','env')
 
 if env['with_unittest'] == True and 'dynamic' in env['build']:
-    env.SConscript( 'src/gunittest/SConscript.win','env' )
+    env.SConscript( 'src/gunittest/SConscript','env' )
 
 if env['with_testtools'] == True and 'dynamic' in env['build']:
     env.SConscript( 'src/testtools/SConscript.win','env' )

--- a/mama/c_cpp/src/c/bridge/qpid/SConscript
+++ b/mama/c_cpp/src/c/bridge/qpid/SConscript
@@ -10,9 +10,12 @@ libPath = []
 libPath.append('$libdir')
 libPath.append(os.path.join(env['qpid_home'], 'lib'))
 libPath.append(os.path.join(env['qpid_home'], 'lib64'))
+libPath.append(os.path.join(env['libevent_home'], 'lib'))
+libPath.append(os.path.join(env['libevent_home'], 'lib64'))
 
 incPath = []
 incPath.append('$qpid_home/include')
+incPath.append('$libevent_home/include')
 incPath.append('#mama/c_cpp/src/c')
 
 env['CCFLAGS'] = [x for x in env['CCFLAGS'] if x != '-pedantic-errors']

--- a/mama/c_cpp/src/c/bridge/qpid/SConscript.win
+++ b/mama/c_cpp/src/c/bridge/qpid/SConscript.win
@@ -14,7 +14,7 @@ libPath.append('$libdir')
 incPath = []
 incPath.append('$libevent_home/WIN32-Code')
 incPath.append('$libevent_home')
-incPath.append('$qpid_home/include')
+incPath.append('$qpid_home/proton-c/include')
 incPath.append('#common/c_cpp/src/c/windows')
 incPath.append('#common/c_cpp/src/c')
 incPath.append('#mama/c_cpp/src/c')
@@ -37,7 +37,7 @@ else:
   libs.append('qpid-proton')
   buildType = "Release"
 
-libPath.append('%s/%s/%s' % (env['qpid_home'], archPath, buildType))
+libPath.append('%s/proton-c/%s/%s' % (env['qpid_home'], archPath, buildType))
 libPath.append('%s/WIN32-Prj/%s/%s' % (env['libevent_home'], archPath, buildType))
 
 env['CCFLAGS'].append(['/TP', '/WX-'])

--- a/mama/c_cpp/src/c/fieldcache/fieldcachefieldimpl.h
+++ b/mama/c_cpp/src/c/fieldcache/fieldcachefieldimpl.h
@@ -96,6 +96,7 @@ typedef struct mamaFieldCacheFieldImpl_
 /* Copy size byte starting at pointer data to field to the internal field data.
  * New memory is allocated with malloc and old one is freed with free (if needed).
  */
+MAMAExpDLL
 mama_status
 mamaFieldCacheField_setDataValue(
     mamaFieldCacheField field,
@@ -106,6 +107,7 @@ mamaFieldCacheField_setDataValue(
  * Returns a pointer to the old data pointer so that old data can be destroyed
  * and freed.
  */
+MAMAExpDLL
 mama_status
 mamaFieldCacheField_setDataPointer(mamaFieldCacheField field,
                                    void* data,
@@ -113,11 +115,13 @@ mamaFieldCacheField_setDataPointer(mamaFieldCacheField field,
 
 /* Price vector type requires a special function to be destroyed and freed.
  */
+MAMAExpDLL
 mama_status
 mamaFieldCacheField_destroyPriceVector(mamaFieldCacheVector priceVector);
 
 /* DateTime vector type requires a special function to be destroyed and freed.
  */
+MAMAExpDLL
 mama_status
 mamaFieldCacheField_destroyDateTimeVector(mamaFieldCacheVector dateTimeVector);
 

--- a/mama/c_cpp/src/c/fieldcache/fieldcachelist.h
+++ b/mama/c_cpp/src/c/fieldcache/fieldcachelist.h
@@ -49,6 +49,7 @@ typedef mamaFieldCacheListImpl* mamaFieldCacheList;
  * @param list (out) The list to create.
  * @return Result of the operation.
  */
+MAMAExpDLL
 mama_status
 mamaFieldCacheList_create(mamaFieldCacheList* list);
 
@@ -62,6 +63,7 @@ mamaFieldCacheList_create(mamaFieldCacheList* list);
  * @param list (in) The list to destroy.
  * @return Result of the operation.
  */
+MAMAExpDLL
 mama_status
 mamaFieldCacheList_destroy(mamaFieldCacheList list);
 
@@ -73,6 +75,7 @@ mamaFieldCacheList_destroy(mamaFieldCacheList list);
  * @param list (in) The list to free.
  * @return Result of the operation.
  */
+MAMAExpDLL
 mama_status
 mamaFieldCacheList_free(mamaFieldCacheList list);
 
@@ -83,6 +86,7 @@ mamaFieldCacheList_free(mamaFieldCacheList list);
  * @param list (in) The list to clear.
  * @return Result of the operation.
  */
+MAMAExpDLL
 mama_status
 mamaFieldCacheList_clear(mamaFieldCacheList list);
 
@@ -93,6 +97,7 @@ mamaFieldCacheList_clear(mamaFieldCacheList list);
  * @param item (in) The item to add.
  * @return Result of the operation.
  */
+MAMAExpDLL
 mama_status
 mamaFieldCacheList_add(mamaFieldCacheList list, void* item);
 
@@ -104,6 +109,7 @@ mamaFieldCacheList_add(mamaFieldCacheList list, void* item);
  * @param item (in) The item to set.
  * @return Result of the operation.
  */
+MAMAExpDLL
 mama_status
 mamaFieldCacheList_set(mamaFieldCacheList list, mama_size_t index, void* item);
 
@@ -115,6 +121,7 @@ mamaFieldCacheList_set(mamaFieldCacheList list, mama_size_t index, void* item);
  * @param item (out) The item in the list.
  * @return Result of the operation.
  */
+MAMAExpDLL
 mama_status
 mamaFieldCacheList_get(mamaFieldCacheList list, mama_size_t index, void** item);
 
@@ -125,6 +132,7 @@ mamaFieldCacheList_get(mamaFieldCacheList list, mama_size_t index, void** item);
  * @param size (out) The size of the list.
  * @return Result of the operation.
  */
+MAMAExpDLL
 mama_status
 mamaFieldCacheList_getSize(mamaFieldCacheList list, mama_size_t* size);
 

--- a/mama/c_cpp/src/c/fieldcache/fieldcachemap.h
+++ b/mama/c_cpp/src/c/fieldcache/fieldcachemap.h
@@ -84,16 +84,20 @@ typedef enum
 
 extern const mamaFieldCacheMapType gMamaFieldCacheMapType;
 
+MAMAExpDLL
 mama_status
 mamaFieldCacheMap_create(mamaFieldCacheMap* map);
 
+MAMAExpDLL
 mama_status
 mamaFieldCacheMap_destroy(mamaFieldCacheMap map);
 
+MAMAExpDLL
 mama_status
 mamaFieldCacheMap_add(mamaFieldCacheMap map,
                       mamaFieldCacheField field);
 
+MAMAExpDLL
 mama_status
 mamaFieldCacheMap_find(mamaFieldCacheMap map,
                        mama_fid_t fid,
@@ -101,6 +105,7 @@ mamaFieldCacheMap_find(mamaFieldCacheMap map,
                        const char* name,
                        mamaFieldCacheField* field);
 
+MAMAExpDLL
 mama_status
 mamaFieldCacheMap_clear(mamaFieldCacheMap map);
 

--- a/mama/c_cpp/src/c/fieldcache/fieldcachemaparray.h
+++ b/mama/c_cpp/src/c/fieldcache/fieldcachemaparray.h
@@ -55,32 +55,42 @@ typedef mamaFieldCacheMapIteratorArrayImpl* mamaFieldCacheMapIteratorArray;
 
 
 /* Map */
+MAMAExpDLL
 mama_status mamaFieldCacheMapArray_create(mamaFieldCacheMap* map);
 
+MAMAExpDLL
 mama_status mamaFieldCacheMapArray_destroy(mamaFieldCacheMap map);
 
+MAMAExpDLL
 mama_status mamaFieldCacheMapArray_add(mamaFieldCacheMap map,
                                        mamaFieldCacheField field);
 
+MAMAExpDLL
 mama_status mamaFieldCacheMapArray_find(mamaFieldCacheMap map,
                                         mama_fid_t fid,
                                         mamaFieldType type,
                                         const char* name,
                                         mamaFieldCacheField* field);
 
+MAMAExpDLL
 mama_status mamaFieldCacheMapArray_clear(mamaFieldCacheMap map);
 
 
 /* Iterator */
+MAMAExpDLL
 mama_status mamaFieldCacheMapIteratorArray_create(mamaFieldCacheIterator* iterator,
                                                   mamaFieldCacheMap map);
 
+MAMAExpDLL
 mama_status mamaFieldCacheMapIteratorArray_destroy(mamaFieldCacheIterator iterator);
 
+MAMAExpDLL
 mamaFieldCacheField mamaFieldCacheMapIteratorArray_next(mamaFieldCacheIterator iterator);
 
+MAMAExpDLL
 mama_bool_t mamaFieldCacheMapIteratorArray_hasNext(mamaFieldCacheIterator iterator);
 
+MAMAExpDLL
 mamaFieldCacheField mamaFieldCacheMapIteratorArray_begin(mamaFieldCacheIterator iterator);
 
 #if defined( __cplusplus )

--- a/mama/c_cpp/src/c/fieldcache/fieldcachevector.h
+++ b/mama/c_cpp/src/c/fieldcache/fieldcachevector.h
@@ -48,6 +48,7 @@ typedef mamaFieldCacheVectorImpl* mamaFieldCacheVector;
  * @param vector (out) The vector to create.
  * @return Result of the operation.
  */
+MAMAExpDLL
 mama_status
 mamaFieldCacheVector_create(mamaFieldCacheVector* vector);
 
@@ -61,6 +62,7 @@ mamaFieldCacheVector_create(mamaFieldCacheVector* vector);
  * @param vector (in) The vector to destroy.
  * @return Result of the operation.
  */
+MAMAExpDLL
 mama_status
 mamaFieldCacheVector_destroy(mamaFieldCacheVector vector);
 
@@ -72,6 +74,7 @@ mamaFieldCacheVector_destroy(mamaFieldCacheVector vector);
  * @param vector (in) The vector to free.
  * @return Result of the operation.
  */
+MAMAExpDLL
 mama_status
 mamaFieldCacheVector_free(mamaFieldCacheVector vector);
 
@@ -82,6 +85,7 @@ mamaFieldCacheVector_free(mamaFieldCacheVector vector);
  * @param vector (in) The vector to clear.
  * @return Result of the operation.
  */
+MAMAExpDLL
 mama_status
 mamaFieldCacheVector_clear(mamaFieldCacheVector vector);
 
@@ -93,6 +97,7 @@ mamaFieldCacheVector_clear(mamaFieldCacheVector vector);
  * @param item (in) The item to set.
  * @return Result of the operation.
  */
+MAMAExpDLL
 mama_status
 mamaFieldCacheVector_set(mamaFieldCacheVector vector, mama_size_t index, void* item);
 
@@ -104,6 +109,7 @@ mamaFieldCacheVector_set(mamaFieldCacheVector vector, mama_size_t index, void* i
  * @param item (out) The item in the vector.
  * @return Result of the operation.
  */
+MAMAExpDLL
 mama_status
 mamaFieldCacheVector_get(mamaFieldCacheVector vector, mama_size_t index, void** item);
 
@@ -114,6 +120,7 @@ mamaFieldCacheVector_get(mamaFieldCacheVector vector, mama_size_t index, void** 
  * @param size (out) The size of the vector.
  * @return Result of the operation.
  */
+MAMAExpDLL
 mama_status
 mamaFieldCacheVector_getSize(mamaFieldCacheVector vector, mama_size_t* size);
 
@@ -124,6 +131,7 @@ mamaFieldCacheVector_getSize(mamaFieldCacheVector vector, mama_size_t* size);
  * @param newAllocSize (in) The new size.
  * @return Result of the operation.
  */
+MAMAExpDLL
 mama_status
 mamaFieldCacheVector_grow(mamaFieldCacheVector vector, mama_size_t newAllocSize);
 

--- a/mama/c_cpp/src/c/mamainternal.h
+++ b/mama/c_cpp/src/c/mamainternal.h
@@ -96,7 +96,7 @@ typedef struct mamaPayloadLib_
 /*
  * @brief Structure for storing combined mamaEntitlementBridge and LIB_HANDLE data.
  */
- typedef struct mamaEntitlementLib_
+typedef struct mamaEntitlementLib_
 {
     mamaEntitlementBridge bridge;
     LIB_HANDLE            library;
@@ -127,6 +127,7 @@ mamaInternal_registerBridge (mamaBridge     bridge,
 /**
  * getVersion for use when mama is wrapped
  */
+MAMAExpDLL
 const char*
 mama_wrapperGetVersion(mamaBridge     bridge);
 
@@ -150,9 +151,11 @@ MAMAExpDLL
 mamaPayloadBridge
 mamaInternal_findPayload (char id);
 
+MAMAExpDLL
 mamaPayloadBridge
 mamaInternal_getDefaultPayload (void);
 
+MAMAExpDLL
 mama_bool_t
 mamaInternal_getAllowMsgModify (void);
 
@@ -166,6 +169,7 @@ mamaInternal_getAllowMsgModify (void);
  *
  * @return mama_status indicating the success or failure of the initialisation.
  */
+MAMAExpDLL
 mama_status
 mamaInternal_initialiseTable (wtable_t*   table,
                               const char* name,
@@ -182,6 +186,7 @@ mamaInternal_initialiseTable (wtable_t*   table,
  * @return A mama_status indicating the success or failure of the initialisation.
  *
  */
+MAMAExpDLL
 mama_status
 mamaInternal_init (void);
 
@@ -213,6 +218,7 @@ mamaInternal_getPayloadId (const char*       payloadName,
  * @brief Return count of entitlementBridges loaded.
  * @return Integer number of loaded bridges.
  */
+MAMAExpDLL
 mama_i32_t
 mamaInternal_getEntitlementBridgeCount (void);
 
@@ -224,7 +230,8 @@ mamaInternal_getEntitlementBridgeCount (void);
  *
  * @return MAMA_STATUS_OK if successful.
  */
- mama_status
+MAMAExpDLL
+mama_status
 mamaInternal_getEntitlementBridgeByName(mamaEntitlementBridge* entBridge, const char* name);
 
 MAMAExpDLL

--- a/mama/c_cpp/src/c/msgutils.h
+++ b/mama/c_cpp/src/c/msgutils.h
@@ -34,21 +34,27 @@ extern "C" {
 #define DQ_DISCONNECT   12
 #define DQ_CONNECT      13
 
+MAMAExpDLL
 mama_status
 msgUtils_getIssueSymbol            (mamaMsg msg, const char** result);
 
+MAMAExpDLL
 mama_status
 msgUtils_setStatus                 (mamaMsg msg, short status);
 
+MAMAExpDLL
 mama_status
 msgUtils_msgTotal                  (mamaMsg msg, short* result);
 
+MAMAExpDLL
 mama_status 
 msgUtils_msgNum                    (mamaMsg msg, short* result);
 
+MAMAExpDLL
 mama_status
 msgUtils_msgSubscMsgType           (mamaMsg msg, short* result);
 
+MAMAExpDLL
 mama_status 
 msgUtils_createSubscriptionMessage (mamaSubscription  subscription,
                                     mamaSubscMsgType  subscMsgType,
@@ -61,6 +67,7 @@ msgUtils_createSubscriptionMessage (mamaSubscription  subscription,
  * @param subsc
  * @return the subscribe message.
  */
+MAMAExpDLL
 mama_status
 msgUtils_createSubscribeMsg        (mamaSubscription subsc, mamaMsg* result);
 
@@ -68,15 +75,19 @@ msgUtils_createSubscribeMsg        (mamaSubscription subsc, mamaMsg* result);
  * Create a RESUBSCRIBE message  in response to a sync request.
  * @return  the resubscribe message.
  */
+MAMAExpDLL
 mama_status
 msgUtils_createResubscribeMessage  (mamaMsg* result);
 
+MAMAExpDLL
 mama_status
 msgUtils_createRefreshMsg          (mamaSubscription subsc, mamaMsg* result);
 
+MAMAExpDLL
 mama_status
 msgUtils_createTimeoutMsg          (mamaMsg* msg);
 
+MAMAExpDLL
 mama_status
 msgUtils_createEndOfInitialsMsg    (mamaMsg* msg);
 
@@ -85,28 +96,35 @@ msgUtils_createEndOfInitialsMsg    (mamaMsg* msg);
  * of an item..
  * @return the recover request message.
  */
+MAMAExpDLL
 mama_status
 msgUtils_createRecoveryRequestMsg  (mamaSubscription subsc, 
                                     short            reason,
                                     mamaMsg*         result, 
                                     const char*      issueSymbol);
 
+MAMAExpDLL
 mama_status
 msgUtils_setSubscSubject           (mamaMsg msg, const char* sendSubject);
 
+MAMAExpDLL
 mama_status 
 msgUtils_createUnsubscribeMsg      (mamaSubscription subsc, mamaMsg* msg);
 
+MAMAExpDLL
 mama_status
 msgUtils_createDictionarySubscribe (mamaSubscription subscription, 
                                     mamaMsg*         msg);
 
+MAMAExpDLL
 mama_status
 msgUtils_createSnapshotSubscribe   (mamaSubscription subsc, mamaMsg* msg);
 
+MAMAExpDLL
 mama_status
 msgUtils_msgTotal                  (mamaMsg msg, short* result);
 
+MAMAExpDLL
 mama_status
 msgUtils_msgNum                    (mamaMsg msg, short* result);
 

--- a/mama/c_cpp/src/c/payload/qpidmsg/SConscript.win
+++ b/mama/c_cpp/src/c/payload/qpidmsg/SConscript.win
@@ -9,7 +9,7 @@ target = 'libmamaqpidmsgimpl'
 env.Append( CPPDEFINES 	= ['BRIDGE', 'MAMA_DLL', 'HAVE_QPID_PROTON_VERSION_H'] )
 
 includePath = []
-includePath.append('$qpid_home/include')
+includePath.append('$qpid_home/proton-c/include')
 includePath.append('#common/c_cpp/src/c')
 
 libPath = []
@@ -30,7 +30,7 @@ else:
   libs.append('qpid-proton')
   buildType = "Release"
 
-libPath.append('%s/%s/%s' % (env['qpid_home'], archPath, buildType))
+libPath.append('%s/proton-c/%s/%s' % (env['qpid_home'], archPath, buildType))
 
 env['CCFLAGS'].append(['/TP', '/WX-'])
 env.Append(LIBS=libs, LIBPATH=libPath, CPPPATH=[includePath])

--- a/mama/c_cpp/src/examples/c/SConscript.win
+++ b/mama/c_cpp/src/examples/c/SConscript.win
@@ -40,4 +40,5 @@ for b in binaries:
 	InstExamples.append( examplesrc )
 
 Alias( 'install', env.Install('$bindir',InstBin) )
-Alias( 'install', env.Install('$prefix/examples/mama/c', InstExamples) )
+if 'inc_example_src' in env and env['inc_example_src']:
+    Alias( 'install', env.Install('$prefix/examples/mama/c', InstExamples) )

--- a/mama/c_cpp/src/examples/cpp/SConscript.win
+++ b/mama/c_cpp/src/examples/cpp/SConscript.win
@@ -46,4 +46,5 @@ for b in binaries:
 		env.AddPostAction( example, 'mt.exe -nologo -manifest ${TARGET}.manifest -outputresource:$TARGET;1')
 
 Alias( 'install', env.Install('$bindir',InstBin) )
-Alias( 'install', env.Install('$prefix/examples/mama/cpp/', InstExamples) )
+if 'inc_example_src' in env and env['inc_example_src']:
+    Alias( 'install', env.Install('$prefix/examples/mama/cpp/', InstExamples) )

--- a/mama/c_cpp/src/gunittest/SConscript
+++ b/mama/c_cpp/src/gunittest/SConscript
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+import os
 Import('env')
 env = env.Clone()
 
@@ -9,8 +10,24 @@ incpath.append('$gtest_home/include')
 libpath = []
 libpath.append('$gtest_home/lib')
 
-env.Append(LIBPATH=libpath, CPPPATH=incpath, LIBS=['gtest', 'gtest_main'
-           ], CCFLAGS=['-Wno-sign-compare'])
+ccflags = []
+
+if env['PLATFORM'] == "win32":
+    libpath.append(os.path.join(env['gtest_home'], 'msvc', env['win_arch_path'], env['win_type_path']))
+    if 'debug' in env['build']:
+        libs = ['gtestd', 'gtest_maind']
+    else:
+        libs = ['gtest', 'gtest_main']
+    libs.append('libmamac%s' % ( env['suffix'] ))
+    libs.append('libwombatcommon%s' % ( env['suffix'] ))
+    ccflags.append('/DGTEST_USE_OWN_TR1_TUPLE=0')
+    ccflags.append('/D_VARIADIC_MAX=10')
+else:
+    ccflags.append('-Wno-sign-compare')
+    libpath.append('$gtest_home/lib')
+    libs = ['gtest', 'gtest_main', 'dl', 'wombatcommon', 'mama', 'pthread']
+
+env.Append(LIBPATH=libpath, CPPPATH=incpath, LIBS=libs, CCFLAGS=ccflags)
 
 env.SConscript('c/SConscript', 'env')
 env.SConscript('cpp/SConscript', 'env')

--- a/mama/c_cpp/src/gunittest/c/MainUnitTestC.h
+++ b/mama/c_cpp/src/gunittest/c/MainUnitTestC.h
@@ -24,6 +24,13 @@
 
 #define NOT_NULL ( (void*)1 )
 
+#ifdef max
+#undef max
+#endif
+
+#ifdef min
+#undef min
+#endif
 
 #define ALLOW_NON_IMPLEMENTED(strictness, status)                              \
  do {                                                                          \

--- a/mama/c_cpp/src/gunittest/c/SConscript
+++ b/mama/c_cpp/src/gunittest/c/SConscript
@@ -16,8 +16,7 @@ incpath.append('#mama/c_cpp/src/c')
 libpath = []
 libpath.append('$libdir')
 
-env.Append(LIBPATH=libpath, LIBS=['dl', 'wombatcommon', 'mama', 'pthread'],
-           CPPPATH=incpath)
+env.Append(LIBPATH=libpath, CPPPATH=incpath)
 
 env['CCFLAGS'] = [x for x in env['CCFLAGS'] if x != '-pedantic-errors']
 

--- a/mama/c_cpp/src/gunittest/c/mamamsg/msgvectortests.cpp
+++ b/mama/c_cpp/src/gunittest/c/mamamsg/msgvectortests.cpp
@@ -2991,15 +2991,15 @@ protected:
         for( uint32_t ii(0) ; ii < VECTOR_SIZE ; ++ii )
         {
             char buffer[20];
-            ::snprintf(buffer, 20, "InitialString%u", ii);
-            mIn[ii] = ::strndup( buffer, 20 );
+            snprintf(buffer, 20, "InitialString%u", ii);
+            mIn[ii] = strdup(buffer);
         }
 
         for( uint32_t ii(0) ; ii < VECTOR_UPDATE_SIZE ; ++ii )
         {
             char buffer[20];
-            ::snprintf(buffer, 20, "UpdateString%u", ii);
-            mUpdate[ii] = ::strndup( buffer, 20 );
+            snprintf(buffer, 20, "UpdateString%u", ii);
+            mUpdate[ii] = strdup(buffer);
         }
     }
 

--- a/mama/c_cpp/src/gunittest/c/payload/payloadvectortests.cpp
+++ b/mama/c_cpp/src/gunittest/c/payload/payloadvectortests.cpp
@@ -3190,15 +3190,15 @@ protected:
         for( uint32_t ii(0) ; ii < VECTOR_SIZE ; ++ii )
         {
             char buffer[20];
-            ::snprintf(buffer, 20, "InitialString%u", ii);
-            m_in[ii] = ::strndup( buffer, 20 );
+            snprintf(buffer, 20, "InitialString%u", ii);
+            m_in[ii] = strdup(buffer);
         }
 
         for( uint32_t ii(0) ; ii < VECTOR_UPDATE_SIZE ; ++ii )
         {
             char buffer[20];
-            ::snprintf(buffer, 20, "UpdateString%u", ii);
-            m_update[ii] = ::strndup( buffer, 20 );
+            snprintf(buffer, 20, "UpdateString%u", ii);
+            m_update[ii] = strdup(buffer);
         }
     }
 

--- a/mama/c_cpp/src/gunittest/cpp/SConscript
+++ b/mama/c_cpp/src/gunittest/cpp/SConscript
@@ -14,8 +14,12 @@ incpath.append('#mama/c_cpp/src/cpp')
 libpath = []
 libpath.append('$libdir')
 
-env.Append(LIBPATH=libpath, LIBS=['mama', 'mamacpp', 'wombatcommon',
-           'dl'], CPPPATH=incpath)
+if env['PLATFORM'] == "win32":
+    env.Append(LIBS=['libmamacpp%s' % env['suffix']])
+else:
+    env.Append(LIBS=['mamacpp'])
+
+env.Append(LIBPATH=libpath, CPPPATH=incpath)
 
 env['CCFLAGS'] = [x for x in env['CCFLAGS'] if x != '-pedantic-errors']
 

--- a/mama/dotnet/SConscript.win
+++ b/mama/dotnet/SConscript.win
@@ -219,7 +219,7 @@ if 'dynamic' in env['build']:
     elif env['TARGET_ARCH'] == 'x86_64':
         env.Append( CSCFLAGS = ['/platform:x64'])
 
-    lib, doc_xml = env.InstallDotNetLibrary(target, sources)
+    (lib, doc_xml) = env.InstallDotNetLibrary(target, sources)
     
     if env['with_examples'] == True:
         for key in examples:
@@ -227,13 +227,14 @@ if 'dynamic' in env['build']:
                                     ASSEMBLYREFS = [ AssemblyRefs, lib ],
                                     WINEXE = 0)
             Alias('install', env.Install('$bindir',exe ) )
-            Alias('install', env.Install('$prefix/examples/mama/cs/%s' % key, examples[key]['sources']))
-            Alias('install', env.Install('$prefix/examples/mama/cs/%s' % key, examples[key]['project']))
+            if 'inc_example_src' in env and env['inc_example_src']:
+                Alias('install', env.Install('$prefix/examples/mama/cs/%s' % key, examples[key]['sources']))
+                Alias('install', env.Install('$prefix/examples/mama/cs/%s' % key, examples[key]['project']))
 
     if env['with_testtools'] == True:
         env.Log("C# testtool MamdaBookSelfTest included in examples")
 
-# if env['with_docs'] == True:
-#    doc = env.BuildNDoc(lib, doc_xml, doc_dir)
+    # if env['with_docs'] == True:
+    #    doc = env.BuildNDoc(lib, doc_xml, doc_dir)
 
-Clean(lib, [ cs, ai,])
+    Clean(lib, [ cs, ai,])

--- a/mama/jni/SConscript.win
+++ b/mama/jni/SConscript.win
@@ -56,28 +56,27 @@ jar = env.Jar(target='mamajni.jar', source='classes', JARCHDIR = Dir('classes').
 
 Jars['mamajni.jar'] = jar
 
-Alias('install', env.InstallAs('$libdir/mamajni_%s.jar' % version, jar))
-Alias('install', env.InstallAs('$libdir/mamajni.jar', jar))
-Alias('install', env.Install('$prefix/examples/mamajni', jExamples))
-
-
 if 'dynamic' in env['build']:
+    Alias('install', env.InstallAs('$libdir/mamajni_%s.jar' % version, jar))
+    Alias('install', env.InstallAs('$libdir/mamajni.jar', jar))
+    if 'inc_example_src' in env and env['inc_example_src']:
+        Alias('install', env.Install('$prefix/examples/mamajni', jExamples))
     env.Append( CPPDEFINES = ['MAMA_DLL'] )
     env.Append( LINKFLAGS = ['/MAP'] )
     env.Append( LIBS = ['ws2_32.lib', 'advapi32.lib', 'kernel32.lib'] )
-if float(env['vsver']) == 7:
-    env.Append( LIBS = ['secur32.lib'])
+    if float(env['vsver']) == 7:
+        env.Append( LIBS = ['secur32.lib'])
 
-env.SConscript('src/c/SConscript.win', 'env')
+    env.SConscript('src/c/SConscript.win', 'env')
 
-if env['with_docs'] == True and not env.GetOption('clean'):
-    overview = posixpath.join( Dir('#mama/jni/doc').abspath, 'overview-jni.html' )
-    env.Append(
-        PROJECT_DOC_TITLE       = "MAMA (Middleware Agnostic Messaging API) JNI specification,  v%s" % (version),
-        PROJECT_OVERVIEW        = overview,
-        PROJECT_WINDOW_TITLE    = "MAMA JNI %s" % (version),
-        PROJECT_BOTTOM          = "Copyright 2011 NYSE Technologies",
-        PROJECT_HEADER          = "<img src='./resources/nyse_technologies.png' alt='NYSE Technologies' /><br/><b>MAMA JNI</b><br><font size='-1'>version %s</font>" % (version),
-    )
+    if env['with_docs'] == True and not env.GetOption('clean'):
+        overview = posixpath.join( Dir('#mama/jni/doc').abspath, 'overview-jni.html' )
+        env.Append(
+            PROJECT_DOC_TITLE       = "MAMA (Middleware Agnostic Messaging API) JNI specification,  v%s" % (version),
+            PROJECT_OVERVIEW        = overview,
+            PROJECT_WINDOW_TITLE    = "MAMA JNI %s" % (version),
+            PROJECT_BOTTOM          = "Copyright 2011 NYSE Technologies",
+            PROJECT_HEADER          = "<img src='./resources/nyse_technologies.png' alt='NYSE Technologies' /><br/><b>MAMA JNI</b><br><font size='-1'>version %s</font>" % (version),
+        )
 
-    env.JavaDocBuilder( '$prefix/doc/mama/jni/html','#mama/jni/src' )
+        env.JavaDocBuilder( '$prefix/doc/mama/jni/html','#mama/jni/src' )

--- a/mamda/c_cpp/SConscript.win
+++ b/mamda/c_cpp/SConscript.win
@@ -107,9 +107,6 @@ if env['with_examples'] == True and 'dynamic' in env['build']:
 if env['with_testtools'] == True and 'dynamic' in env['build']:
     env.SConscript('src/testtools/SConscript.win','env')
 
-if env['with_unittest'] == True:
-    env.SConscript('src/gunittest/SConscript.win','env')
-
 if ( env['with_docs'] == True and not Media.has_key('mamda/c_cpp/docs') and env['build'] == 'dynamic' and not env.GetOption('clean') ):
    cppdoc = env.Doxygen('doxyconfig-cpp.in')
 

--- a/mamda/dotnet/SConscript.win
+++ b/mamda/dotnet/SConscript.win
@@ -280,7 +280,7 @@ if 'dynamic-debug' == env['build']:
 elif 'dynamic' == env['build']:
     env.Append( CSCFLAGS = ['/optimize','/define:TRACE'] )
 elif 'static' in env['build']:
-    env.Log("MAMDA is not built statically")
+    env.Log("MAMDA.NET is not built statically")
 
 target = "MAMDA"
 
@@ -301,4 +301,4 @@ if 'dynamic' in env['build']:
     if env['with_testtools'] == True:
         env.Log("C# testtool MamdaBookSelfTest included in examples")
 
-Clean(lib, cs)
+    Clean(lib, cs)

--- a/mamda/java/SConscript.win
+++ b/mamda/java/SConscript.win
@@ -94,9 +94,10 @@ Alias('install', env.Install('$libdir', mamda_base))
 Alias('install', env.Install('$libdir', mamda_orderbook))
 Alias('install', env.Install('$libdir', mamda_options))
 
-Alias('install', env.Install('$prefix/examples/com/wombat/mamda/examples', baseExamples))
-Alias('install', env.Install('$prefix/examples/com/wombat/mamda/examples', orderbookExamples))
-Alias('install', env.Install('$prefix/examples/com/wombat/mamda/examples', optionsExamples))
+if 'inc_example_src' in env and env['inc_example_src']:
+    Alias('install', env.Install('$prefix/examples/com/wombat/mamda/examples', baseExamples))
+    Alias('install', env.Install('$prefix/examples/com/wombat/mamda/examples', orderbookExamples))
+    Alias('install', env.Install('$prefix/examples/com/wombat/mamda/examples', optionsExamples))
 
 
 Clean(lock_classes, symboliclinks)

--- a/site_scons/community/command_line.py
+++ b/site_scons/community/command_line.py
@@ -70,6 +70,8 @@ def get_command_line_opts( host, products, VERSIONS ):
             EnumVariable('product', 'Product to be built', 'mamda',
                          #mamda all is a windows only build
                          allowed_values=( [ x for x in products if x != "mamdaall" ] )),
+            PathVariable('libevent_home', 'Path to libevent Libraries',
+                          '/usr/', PathVariable.PathAccept),
             EnumVariable('target_arch', 'Specifies if the build should target 32 or 64 bit architectures.',
                           host['arch'], allowed_values=['i386', 'i586', 'i686', 'x86', 'x86_64']),
             EnumVariable( 'compiler', 'Compiler to use for building OpenMAMA',

--- a/site_scons/community/windows.py
+++ b/site_scons/community/windows.py
@@ -183,8 +183,20 @@ class Windows:
             if 'static-debug' in env['buildtype']:
                 builds.append( static_debug )
 
+        example_src_handled = False
         for env in builds:
             print 'Building: %s' % (env['build'])
+
+            if env['build'].startswith('dynamic') and not example_src_handled:
+                example_src_handled = True
+                env['inc_example_src'] = True
+
+            if 'debug' in env['build']:
+                env['win_type_path'] = 'Debug'
+            else:
+                env['win_type_path'] = 'Release'
+
+            env['lib_dep_prefix'] = os.path.join(env['win_arch_path'], env['win_type_path'])
 
             env['bindir'] = '$prefix/bin/$build'
             env['libdir'] = '$prefix/lib/$build'
@@ -222,9 +234,11 @@ class Windows:
         # Architecture specific setup
         if env['target_arch'] == 'x86_64':
             env['bit_suffix'] = '_x64'
+            env['win_arch_path'] = 'x64'
         else:
             env.Append( CPPDEFINES = ['_USE_32BIT_TIME_T'] )
             env['bit_suffix'] = ''
+            env['win_arch_path'] = ''
 
         if env['vsver'] > 7:
             env.Append( CCFLAGS = [ '/Z7','/MP' ])


### PR DESCRIPTION
Fix for #15

This fixes an issue where it was impossible to build multiple build types
using one command on windows. It also brings unit tests to the scons
windows builds.

Note that qpid_home on windows also points to the base proton directory
now rather than requiring the user to know to point to the 'proton-c'
subdirectory.

When building types beyond dynamic, this also flagged an issue where
several functions were not exported for DLL properly, particularly in
mamaFieldCache so this patch also resolves that issue by introducing the
correct function declarations.