### PR TITLE
[PLAT-421] - New C, C++ and JAVA getPublisher implementation.

### DIFF
--- a/mama/c_cpp/src/c/dqpublishermanager.c
+++ b/mama/c_cpp/src/c/dqpublishermanager.c
@@ -557,3 +557,20 @@ mama_status mamaDQPublisherManager_sendNoSubscribers (
 
     return MAMA_STATUS_OK;
 }
+
+mama_status mamaDQPublisherManager_getPublisher (
+        mamaDQPublisherManager manager,
+        const char *symbol,
+        mamaDQPublisher* pub)
+{
+    mamaDQPublisherManagerImpl* impl  = (mamaDQPublisherManagerImpl*) manager;
+    mamaPublishTopic* topic           = NULL;
+
+    topic = (mamaPublishTopic*) wtable_lookup (impl->mPublisherMap, (char*)symbol);
+
+    if (!topic)
+         return MAMA_STATUS_NOT_FOUND;
+
+    *pub = topic->pub;
+    return MAMA_STATUS_OK;
+}

--- a/mama/c_cpp/src/c/mama/dqpublishermanager.h
+++ b/mama/c_cpp/src/c/mama/dqpublishermanager.h
@@ -190,6 +190,13 @@ mamaDQPublisherManager_sendNoSubscribers (
         const char *symbol);
 
 MAMAExpDLL
+extern mama_status
+mamaDQPublisherManager_getPublisher (
+        mamaDQPublisherManager manager,
+        const char *symbol,
+        mamaDQPublisher* pub);
+
+MAMAExpDLL
 extern void 
 mamaDQPublisherManager_enableSendTime (
         mamaDQPublisherManager manager, 

--- a/mama/c_cpp/src/cpp/MamaDQPublisherManager.cpp
+++ b/mama/c_cpp/src/cpp/MamaDQPublisherManager.cpp
@@ -190,8 +190,9 @@ struct MamaDQPublisherManagerImpl
     
     MamaDQPublisher* createPublisher (const char *symbol, void * cache);
     void destroyPublisher (const char *symbol);
-    
-      
+
+    MamaDQPublisher* getPublisher (const char* symbol);
+
     void setInfo(mamaPublishTopic* info){mReuseableInfo.set(info);}
 
     MamaMsg 				mReuseableMsg;
@@ -316,6 +317,11 @@ void MamaDQPublisherManager::destroyPublisher (const char *symbol)
 	mImpl->destroyPublisher (symbol);
 }
 
+MamaDQPublisher* MamaDQPublisherManager::getPublisher (const char* symbol)
+{
+    return mImpl->getPublisher (symbol);
+}
+
 void MamaDQPublisherManager::destroy (void)
 {
     mImpl->destroy ();
@@ -378,6 +384,15 @@ void MamaDQPublisherManagerImpl::destroyPublisher (const char *symbol)
 {	
 	MamaDQPublisher* aDQPublisher = removePublisher(symbol);
 	aDQPublisher->destroy();
+}
+
+MamaDQPublisher* MamaDQPublisherManagerImpl::getPublisher (const char* symbol)
+{
+        mamaDQPublisher aDQPublisher;
+        mamaDQPublisherManager_getPublisher(mDQPublisherManager, symbol, &aDQPublisher);
+        if (!aDQPublisher)
+            return (NULL);
+        return (MamaDQPublisher*)mamaDQPublisher_getClosure(aDQPublisher);
 }
 
 void MamaDQPublisherManagerImpl::create (MamaTransport *transport, 

--- a/mama/c_cpp/src/cpp/mama/MamaDQPublisherManager.h
+++ b/mama/c_cpp/src/cpp/mama/MamaDQPublisherManager.h
@@ -73,7 +73,9 @@ public:
       
     virtual MamaDQPublisher* createPublisher (const char *symbol, void * cache);
     virtual void destroyPublisher (const char *symbol);
-      
+
+    virtual MamaDQPublisher* getPublisher (const char* symbol);
+
     virtual void destroy (void);
 
     virtual void setStatus (mamaMsgStatus  status);

--- a/mama/jni/src/com/wombat/mama/MamaDQPublisherManager.java
+++ b/mama/jni/src/com/wombat/mama/MamaDQPublisherManager.java
@@ -317,4 +317,23 @@ public class MamaDQPublisherManager
         return null;
     }
 
+    /**
+     * Accessor for the internal ArrayList that contains all the current publishers
+     *
+     * @param symbol The symbol for the which you want to get the publisher
+     *
+     * @return The MamaDQPublisher associated with the given symbol
+     */
+    public static MamaDQPublisher getPublisher(String symbol)
+    {
+        Iterator it = myTopics.iterator();
+        while(it.hasNext())
+        {
+            MamaPublishTopic myTopic = (MamaPublishTopic) it.next();
+            if (myTopic.getSymbol().equals(symbol))
+                return myTopic.getPublisher();
+        }
+        return null;
+    }
+
 }


### PR DESCRIPTION
# [PLAT-421] - New C, C++ and JAVA getPublisher implementation.
## Summary
Method 'getPublisher' that is in Enterprise Mama for MamaDqPublisher is not in OpenMAMA. C/C++ and Java implementation of that method.

## Areas Affected
*Place an 'x' within the braces to check the box*
- [x] MAMAC
- [x] MAMACPP
- [ ] MAMADOTNET
- [x] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
See committed code. It is very simple and basic implementation for getPublisher. Based on its C function, the C++ version basically calls the underlying C function and returns mamaDQPublisher's closure. In terms of Java's implementation, it uses the already created myTopics mapped variable to do all the required logic of getPublisher.

## Testing
Check that MamaDqPublisherManager class provides a method to access the MamaDqPublisher and cache. Check that the C/C++-API provides a function to get a mamaDqPublisher. Check that values match those provided when the MamaDQPublisher was created. No OS or transport dependencies.

