### PR TITLE
[PLAT-421] - Changes added to C and C++ versions of getPublisher

### DIFF
--- a/mama/c_cpp/src/c/dqpublishermanager.c
+++ b/mama/c_cpp/src/c/dqpublishermanager.c
@@ -564,7 +564,10 @@ mama_status mamaDQPublisherManager_getPublisher (
         mamaDQPublisher* pub)
 {
     mamaDQPublisherManagerImpl* impl  = (mamaDQPublisherManagerImpl*) manager;
-    mamaPublishTopic* topic           = NULL;
+    mamaPublishTopic*           topic = NULL;
+
+    if (!impl || !pub)
+         return MAMA_STATUS_INVALID_ARG;
 
     topic = (mamaPublishTopic*) wtable_lookup (impl->mPublisherMap, (char*)symbol);
 

--- a/mama/c_cpp/src/c/dqpublishermanager.c
+++ b/mama/c_cpp/src/c/dqpublishermanager.c
@@ -557,3 +557,20 @@ mama_status mamaDQPublisherManager_sendNoSubscribers (
 
     return MAMA_STATUS_OK;
 }
+
+mama_status mamaDQPublisherManager_getPublisher (
+        mamaDQPublisherManager manager,
+        const char *symbol,
+        mamaDQPublisher* pub)
+{
+    mamaDQPublisherManagerImpl* impl  = (mamaDQPublisherManagerImpl*) manager;
+    mamaPublishTopic* topic           = NULL;
+
+    topic = (mamaPublishTopic*) wtable_lookup (impl->mPublisherMap, (char*)symbol);
+
+    if (!topic)
+         return MAMA_STATUS_NOT_FOUND;
+
+    *pub = topic->pub;
+    return MAMA_STATUS_OK;
+}

--- a/mama/c_cpp/src/c/mama/dqpublishermanager.h
+++ b/mama/c_cpp/src/c/mama/dqpublishermanager.h
@@ -190,6 +190,13 @@ mamaDQPublisherManager_sendNoSubscribers (
         const char *symbol);
 
 MAMAExpDLL
+extern mama_status
+mamaDQPublisherManager_getPublisher (
+        mamaDQPublisherManager manager,
+        const char *symbol,
+        mamaDQPublisher* pub);
+
+MAMAExpDLL
 extern void 
 mamaDQPublisherManager_enableSendTime (
         mamaDQPublisherManager manager, 

--- a/mama/c_cpp/src/cpp/MamaDQPublisherManager.cpp
+++ b/mama/c_cpp/src/cpp/MamaDQPublisherManager.cpp
@@ -191,7 +191,7 @@ struct MamaDQPublisherManagerImpl
     MamaDQPublisher* createPublisher (const char *symbol, void * cache);
     void destroyPublisher (const char *symbol);
 
-    MamaDQPublisher* getPublisher (const char* symbol);
+    const MamaDQPublisher* getPublisher (const char* symbol) const;
 
     void setInfo(mamaPublishTopic* info){mReuseableInfo.set(info);}
 
@@ -317,7 +317,7 @@ void MamaDQPublisherManager::destroyPublisher (const char *symbol)
 	mImpl->destroyPublisher (symbol);
 }
 
-MamaDQPublisher* MamaDQPublisherManager::getPublisher (const char* symbol)
+const MamaDQPublisher* MamaDQPublisherManager::getPublisher (const char* symbol) const
 {
     return mImpl->getPublisher (symbol);
 }
@@ -386,13 +386,13 @@ void MamaDQPublisherManagerImpl::destroyPublisher (const char *symbol)
 	aDQPublisher->destroy();
 }
 
-MamaDQPublisher* MamaDQPublisherManagerImpl::getPublisher (const char* symbol)
+const MamaDQPublisher* MamaDQPublisherManagerImpl::getPublisher (const char* symbol) const
 {
         mamaDQPublisher aDQPublisher;
         mamaDQPublisherManager_getPublisher(mDQPublisherManager, symbol, &aDQPublisher);
         if (!aDQPublisher)
             return (NULL);
-        return (MamaDQPublisher*)mamaDQPublisher_getClosure(aDQPublisher);
+        return static_cast<MamaDQPublisher*>(mamaDQPublisher_getClosure(aDQPublisher));
 }
 
 void MamaDQPublisherManagerImpl::create (MamaTransport *transport, 

--- a/mama/c_cpp/src/cpp/MamaDQPublisherManager.cpp
+++ b/mama/c_cpp/src/cpp/MamaDQPublisherManager.cpp
@@ -190,8 +190,9 @@ struct MamaDQPublisherManagerImpl
     
     MamaDQPublisher* createPublisher (const char *symbol, void * cache);
     void destroyPublisher (const char *symbol);
-    
-      
+
+    MamaDQPublisher* getPublisher (const char* symbol);
+
     void setInfo(mamaPublishTopic* info){mReuseableInfo.set(info);}
 
     MamaMsg 				mReuseableMsg;
@@ -316,6 +317,11 @@ void MamaDQPublisherManager::destroyPublisher (const char *symbol)
 	mImpl->destroyPublisher (symbol);
 }
 
+MamaDQPublisher* MamaDQPublisherManager::getPublisher (const char* symbol)
+{
+    return mImpl->getPublisher (symbol);
+}
+
 void MamaDQPublisherManager::destroy (void)
 {
     mImpl->destroy ();
@@ -378,6 +384,15 @@ void MamaDQPublisherManagerImpl::destroyPublisher (const char *symbol)
 {	
 	MamaDQPublisher* aDQPublisher = removePublisher(symbol);
 	aDQPublisher->destroy();
+}
+
+MamaDQPublisher* MamaDQPublisherManagerImpl::getPublisher (const char* symbol)
+{
+        mamaDQPublisher aDQPublisher;
+        mamaDQPublisherManager_getPublisher(mDQPublisherManager, symbol, &aDQPublisher);
+        if (!aDQPublisher)
+            return (NULL);
+        return (MamaDQPublisher*)mamaDQPublisher_getClosure(aDQPublisher);
 }
 
 void MamaDQPublisherManagerImpl::create (MamaTransport *transport, 

--- a/mama/c_cpp/src/cpp/mama/MamaDQPublisherManager.h
+++ b/mama/c_cpp/src/cpp/mama/MamaDQPublisherManager.h
@@ -74,7 +74,7 @@ public:
     virtual MamaDQPublisher* createPublisher (const char *symbol, void * cache);
     virtual void destroyPublisher (const char *symbol);
 
-    virtual MamaDQPublisher* getPublisher (const char* symbol);
+    virtual const MamaDQPublisher* getPublisher (const char* symbol) const;
 
     virtual void destroy (void);
 

--- a/mama/c_cpp/src/cpp/mama/MamaDQPublisherManager.h
+++ b/mama/c_cpp/src/cpp/mama/MamaDQPublisherManager.h
@@ -73,7 +73,9 @@ public:
       
     virtual MamaDQPublisher* createPublisher (const char *symbol, void * cache);
     virtual void destroyPublisher (const char *symbol);
-      
+
+    virtual MamaDQPublisher* getPublisher (const char* symbol);
+
     virtual void destroy (void);
 
     virtual void setStatus (mamaMsgStatus  status);

--- a/mama/jni/src/com/wombat/mama/MamaDQPublisherManager.java
+++ b/mama/jni/src/com/wombat/mama/MamaDQPublisherManager.java
@@ -317,4 +317,23 @@ public class MamaDQPublisherManager
         return null;
     }
 
+    /**
+     * Accessor for the internal ArrayList that contains all the current publishers
+     *
+     * @param symbol The symbol for the which you want to get the publisher
+     *
+     * @return The MamaDQPublisher associated with the given symbol
+     */
+    public static MamaDQPublisher getPublisher(String symbol)
+    {
+        Iterator it = myTopics.iterator();
+        while(it.hasNext())
+        {
+            MamaPublishTopic myTopic = (MamaPublishTopic) it.next();
+            if (myTopic.getSymbol().equals(symbol))
+                return myTopic.getPublisher();
+        }
+        return null;
+    }
+
 }


### PR DESCRIPTION
# [PLAT-421] - Changes added to C and C++ versions of getPublisher
## Summary
#199 code changes suggested by Dimitri have been implemented

## Areas Affected
*Place an 'x' within the braces to check the box*
- [x] MAMAC
- [x] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
Precisely, it has been added:
1. NULL checks inside C and C++ getPublisher()
2. static_cast inside C++ function
3. 'const' statement added before and after getPublisher's C++ function

## Testing
N/A.