### PR TITLE
COMMON: Support atomic operations on additional CPUs

### DIFF
--- a/common/c_cpp/src/c/linux/wInterlocked.h
+++ b/common/c_cpp/src/c/linux/wInterlocked.h
@@ -33,6 +33,8 @@
 /* Linux implementation. */
 /* *************************************************** */
 
+#if defined(__i386__) || defined(__x86_64__)
+
 /* 32-bit atomic exchange. Returns previous value. */
 static __inline__ uint32_t
 axchg32 (uint32_t* ptr, uint32_t newVal)
@@ -61,6 +63,43 @@ adec32 (uint32_t* ptr)
                       : "=m" (*ptr)
                       : "m" (*ptr));
 }
+
+#else
+
+#ifdef __GNUC__
+
+/* 32-bit atomic exchange. Returns previous value. */
+static __inline__ uint32_t
+axchg32 (uint32_t* ptr, uint32_t newVal)
+{
+    /* Warning: behavior not guaranteed to be consistent
+       on all platforms.  Unit tests may be required to validate
+       on each build.
+       http://gcc.gnu.org/onlinedocs/gcc-4.3.5/gcc/Atomic-Builtins.html
+    */
+    return __sync_lock_test_and_set(ptr, newVal);
+}
+
+/* 32-bit atomic increment. */
+static __inline__ void
+ainc32 (uint32_t* ptr)
+{
+    __sync_fetch_and_add(ptr, 1);
+}
+
+/* 32-bit atomic decrement. */
+static __inline__ void
+adec32 (uint32_t* ptr)
+{
+   __sync_fetch_and_sub(ptr, 1);
+}
+
+#else
+#error "Unsupported CPU / compiler combination, please implement atomic functions"
+#endif
+
+
+#endif
 
 /* *************************************************** */
 /* Type Defines. */


### PR DESCRIPTION
Decided to go with Daniel's patch in http://anonscm.debian.org/gitweb/?p=collab-maint/openmama.git;a=blob;f=debian/patches/0010-Support-atomic-operations-on-additional-CPUs.patch;hb=HEAD

It's nice because it leaves functionality as-is for x86, and only resorts to builtin atomics if it needs to.

Signed-off-by: Daniel Pocock <daniel@pocock.com.au>