### PR TITLE
Corrected prototype for bridgeMamaPublisherSendReplyToInbox (#38)

### DIFF
--- a/mama/c_cpp/src/c/bridge.h
+++ b/mama/c_cpp/src/c/bridge.h
@@ -389,7 +389,7 @@ typedef mama_status
 
 typedef mama_status
 (*bridgeMamaPublisher_sendReplyToInbox)(publisherBridge publisher,
-                                        void *         request,
+                                        mamaMsg         request,
                                         mamaMsg         reply);
 
 typedef mama_status

--- a/mama/c_cpp/src/c/bridge/qpid/publisher.c
+++ b/mama/c_cpp/src/c/bridge/qpid/publisher.c
@@ -363,17 +363,16 @@ qpidBridgeMamaPublisher_send (publisherBridge publisher, mamaMsg msg)
 /* Send reply to inbox. */
 mama_status
 qpidBridgeMamaPublisher_sendReplyToInbox (publisherBridge   publisher,
-                                          void*             request,
+                                          mamaMsg           request,
                                           mamaMsg           reply)
 {
     qpidPublisherBridge*    impl            = (qpidPublisherBridge*) publisher;
-    mamaMsg                 requestMsg      = (mamaMsg) request;
     const char*             inboxSubject    = NULL;
     const char*             replyTo         = NULL;
     msgBridge               bridgeMsg       = NULL;
     mama_status             status          = MAMA_STATUS_OK;
 
-    if (NULL == publisher || NULL == request || NULL == reply)
+    if (NULL == publisher || NULL == request|| NULL == reply)
     {
         return MAMA_STATUS_NULL_ARG;
     }
@@ -387,7 +386,7 @@ qpidBridgeMamaPublisher_sendReplyToInbox (publisherBridge   publisher,
                                             impl->mSubject);
 
     /* Get the incoming bridge message from the mamaMsg */
-    status = mamaMsgImpl_getBridgeMsg (requestMsg, &bridgeMsg);
+    status = mamaMsgImpl_getBridgeMsg (request, &bridgeMsg);
     if (MAMA_STATUS_OK != status)
     {
         mama_log (MAMA_LOG_LEVEL_ERROR,

--- a/mama/c_cpp/src/c/bridge/qpid/qpidbridgefunctions.h
+++ b/mama/c_cpp/src/c/bridge/qpid/qpidbridgefunctions.h
@@ -1089,7 +1089,7 @@ qpidBridgeMamaPublisher_send (publisherBridge publisher, mamaMsg msg);
 MAMAExpDLL
 extern mama_status
 qpidBridgeMamaPublisher_sendReplyToInbox (publisherBridge publisher,
-                                          void*           request,
+                                          mamaMsg         request,
                                           mamaMsg         reply);
 
 /**


### PR DESCRIPTION
Updated the prototype for the bridge function to be a mamaMsg
rather than a mamaMsg cast as a void* only to be cast back to
a mamaMsg in the bridge function itself.

Signed-off-by: Frank Quinn <fquinn.ni@gmail.com>