### PR TITLE
MAMA: Fixed issue where destroying partial transport crashes

### DIFF
--- a/mama/c_cpp/src/c/transport.c
+++ b/mama/c_cpp/src/c/transport.c
@@ -638,6 +638,8 @@ mamaTransport_create (mamaTransport transport,
     if (!transport) return MAMA_STATUS_NULL_ARG;
     if (!bridgeImpl) return MAMA_STATUS_NO_BRIDGE_IMPL;
 
+    self->mListeners = NULL;
+
     mama_log(MAMA_LOG_LEVEL_FINER, "Entering mamaTransport_create for transport (%p) with name %s", transport, name);
 
     self->mBridgeImpl = (mamaBridgeImpl*)bridgeImpl;
@@ -2755,7 +2757,12 @@ void mamaTransportImpl_clearTransportWithListeners (transportImpl *impl)
     /* Otherwise iterate the local list of subscriptions. */
     else
     {
-        list_for_each (impl->mListeners, mamaTransportImpl_clearTransportCallback, NULL);
+        if (impl->mListeners != NULL)
+        {
+            list_for_each (impl->mListeners,
+                           mamaTransportImpl_clearTransportCallback,
+                           NULL);
+        }
     }
 }
 


### PR DESCRIPTION
This change adds the fix suggested in #18 for the listeners list
in MAMA's transport.c to protect against instances where a
partially created transport (i.e. a transport whose creation
failed part of the way through) could cause a crash during
mamaTransport_destroy.

Signed-off-by: Frank Quinn <fquinn.ni@gmail.com>