### PR TITLE
COMMON: Windows type fix for Windows port of wthread_cond_wait

### DIFF
--- a/common/c_cpp/src/c/windows/port.c
+++ b/common/c_cpp/src/c/windows/port.c
@@ -128,7 +128,7 @@ void wthread_mutexattr_settype (int* attr, int param)
 {
 }
 
-DWORD wthread_cond_wait( HANDLE *event, LPCRITICAL_SECTION *cs )
+DWORD wthread_cond_wait( HANDLE *event, LPCRITICAL_SECTION cs )
 {
     DWORD rval;
 

--- a/common/c_cpp/src/c/windows/wombat/port.h
+++ b/common/c_cpp/src/c/windows/wombat/port.h
@@ -244,7 +244,7 @@ const char *index( const char *str, char c );
 #define wthread_cond_destroy( h )           (CloseHandle( *(h) ))
 
 COMMONExpDLL DWORD 
-wthread_cond_wait( HANDLE *event, LPCRITICAL_SECTION *cs );
+wthread_cond_wait( HANDLE *event, LPCRITICAL_SECTION cs );
 
 #define wthread_exit ExitThread
 


### PR DESCRIPTION
The Windows port of wthread_cond_wait passes a pointer to a
LPCRITICAL_SECTION to both the LeaveCriticalSection and
EnterCriticalSection functions. These should both be
LPCRITICAL_SECTIONs themselves.

Signed-off-by: Frank Quinn <fquinn.ni@gmail.com>