### PR TITLE
MAMA: Fixed ability to use custom properties file

### DIFF
--- a/common/c_cpp/src/c/commonc.vcxproj
+++ b/common/c_cpp/src/c/commonc.vcxproj
@@ -243,6 +243,10 @@
     <ClCompile Include="wtable.c" />
     <ClCompile Include="windows\wUuid.c" />
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="property.h" />
+    <ClInclude Include="wombat\wtable.h" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/common/c_cpp/src/c/property.c
+++ b/common/c_cpp/src/c/property.c
@@ -579,3 +579,10 @@ propertiesImpl_AddProperty( propertiesImpl properties,
 
     return 1;
 }
+
+uint32_t properties_Count (wproperty_t handle)
+{
+    /* Get the impl */
+    propertiesImpl_ *this = (propertiesImpl_ *)handle;
+    return wtable_get_count (this->mTable);
+}

--- a/common/c_cpp/src/c/property.h
+++ b/common/c_cpp/src/c/property.h
@@ -22,7 +22,8 @@
 #ifndef PROPERTY_H__
 #define PROPERTY_H__
  
-#include "wombat/wConfig.h"
+#include <wombat/wConfig.h>
+#include <wombat/port.h>
 
 #if defined(__cplusplus)
 extern "C" {
@@ -125,6 +126,12 @@ COMMONExpDLL
 char* 
 properties_AddEscapes (const char* src, const char chars[], int num);
 
+/**
+* Returns the number of properties that have been processed so far
+*/
+COMMONExpDLL
+uint32_t
+properties_Count (wproperty_t handle);
 
 #if defined(__cplusplus)
 }

--- a/common/c_cpp/src/c/wombat/wtable.h
+++ b/common/c_cpp/src/c/wombat/wtable.h
@@ -28,6 +28,7 @@ extern "C" {
 
 #include "wincompat.h"
 #include <sys/types.h>
+#include <wombat/port.h>
 
 typedef void* wtable_t;
 
@@ -118,7 +119,14 @@ void wtable_clear_for_each (wtable_t table, wTableCallback cb, void* closure);
 /**
  * Dump a table for debugging purposes.
  */
+COMMONExpDLL
 void dumptable (wtable_t table);
+
+/**
+* Return number of elements in the table
+*/
+COMMONExpDLL
+uint32_t wtable_get_count (wtable_t table);
 
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
Without this change, there is no way to specify a non-default properties
file which will be honoured by parts of the MAMA loading process including
the bridge loading stage without reporting an error.

Added new function for counting the number of properties which have been
specified and for counting the number of elements in a wtable. This is to
enable effective checking of whether or not property loading has been
successful so it can report an error only when necessary.

It will now only report an error if:

 - A specific properties file was requested
 - Default properties are being loaded and no existing properties are loaded

To use custom properties, use mama_setPropertiesFromFile or mama_setProperty
before mama_loadBridge is called.

Signed-off-by: Frank Quinn <fquinn.ni@gmail.com>