### PR TITLE
[PLAT-398] - MAMA JNI crash in MamaListen.java when using platformInfo.toString().

### DIFF
--- a/mama/jni/src/c/mamatransportjni.c
+++ b/mama/jni/src/c/mamatransportjni.c
@@ -1198,10 +1198,10 @@ jobject mamaTransportImpl_getConnectionObject(JNIEnv *env, const void *platformI
     if(NULL != platformInfo)
     {
         /* Cast the platform info to a C connection object. */
-        mamaConnection *cConnection = (mamaConnection *)platformInfo;
+        mamaConnection cConnection = (mamaConnection)platformInfo;
 
         /* Save the pointer to the C connection object inside the re-usable Java connection object. */
-        (*env)->SetLongField(env, transportClosure->mConnection, connectionPointerFieldId_g, CAST_POINTER_TO_JLONG(*cConnection));
+        (*env)->SetLongField(env, transportClosure->mConnection, connectionPointerFieldId_g, CAST_POINTER_TO_JLONG(cConnection));
 
         /* Return a reference to the re-usable object. */
         ret = transportClosure->mConnection;


### PR DESCRIPTION
# [PLAT-398] - MAMA JNI crash in MamaListen.java when using platformInfo.toString().
## Summary
Miss-cast to a pointer value of mamaConnection variable inside mamaTransportImpl_getConnectionObject is causing a crash.

## Areas Affected
- [ ] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [x] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
mamaConnection cConnection variable modified to not be a pointer anymore.
platformInfo was cast to a mamaConnection, but it was actually a mamaConnection.
Also the CAST_POINTER_TO_JLONG dereferences the ptr, which is at the incorrect level.

## Testing
Follow steps pointed out in #69 's description. It shouldn't crash anymore.
