### PR TITLE
MAMAJNI: Updated JNI thread to use AttachThreadAsDaemon

### DIFF
--- a/mama/jni/src/c/mamajniutils.c
+++ b/mama/jni/src/c/mamajniutils.c
@@ -75,7 +75,7 @@ JNIEnv* utils_getENV(JavaVM* jvm)
     /*env will still be NULL if the current thread was not attached to the JVM*/
     if(!env)
     {
-        if (0!= (*jvm)->AttachCurrentThread(jvm,(void**)&env,NULL))
+        if (0!= (*jvm)->AttachCurrentThreadAsDaemon(jvm,(void**)&env,NULL))
         {
             /*We can't throw an exception as we need a JNIEnv**/
             mama_log (MAMA_LOG_LEVEL_NORMAL, "Could not attach current thread.");


### PR DESCRIPTION
As per issue #181, without this change if using non-default MAMA
queues in JNI, application will hang on shutdown as it cannot
terminate the native threads.

Signed-off-as: Frank Quinn <fquinn.ni@gmail.com>