### PR TITLE
PLAT-529: Fixed a bug where mamapublishercpp was adding an extra . to…

### DIFF
--- a/mama/c_cpp/src/examples/cpp/mamapublishercpp.cpp
+++ b/mama/c_cpp/src/examples/cpp/mamapublishercpp.cpp
@@ -51,7 +51,6 @@ using std::cout;
 using std::endl;
 
 static int           gCount         = 0;
-static const char *  gSource        = "";
 static const char *  gOutBoundTopic = "MAMA_TOPIC";
 static const char *  gInBoundTopic  = "MAMA_INBOUND_TOPIC";
 static const char *  gTransportName = "pub";
@@ -185,7 +184,7 @@ void MamaPublisherSample::run()
                                              this,
                                              NULL,
                                              gOutBoundTopic,
-                                             gSource,
+                                             NULL,
                                              NULL);
         }
         else
@@ -348,11 +347,6 @@ void parseCommandLine (int argc, const char **argv)
         if (strcmp ("-s", argv[i]) == 0)
         {
             gOutBoundTopic = argv[i+1];
-            i += 2;
-        }
-        else if (strcmp ("-S", argv[i]) == 0)
-        {
-            gSource = argv[i+1];
             i += 2;
         }
         else if (strcmp ("-l", argv[i]) == 0)


### PR DESCRIPTION
# PR_TITLE
Fixed a bug where mamapublishercpp was adding an extra . to start of topics

## Areas Affected
- [ ] MAMAC
- [X] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
Fixed a bug where mamapublishercpp was adding an extra . to start of topics due to passing an empty string as the source to MamaPublisher::createWithCallbacks (instead of NULL).
