### PR TITLE
PLAT-687: Make OEA Socket Timeouts Configurable in MAMA

### DIFF
--- a/mama/c_cpp/src/c/entitlement/oea/oea.c
+++ b/mama/c_cpp/src/c/entitlement/oea/oea.c
@@ -85,6 +85,7 @@ oeaEntitlementBridge_init(entitlementBridge* bridge)
 {
     const char*     portLowStr                  = NULL;
     const char*     portHighStr                 = NULL;
+    const char*     socketTimeoutStr            = NULL;
     int             portLow                     = 8000;
     int             portHigh                    = 8001;
     int             size                        = 0;
@@ -145,7 +146,27 @@ oeaEntitlementBridge_init(entitlementBridge* bridge)
     entitlementCallbacks.onEntitlementsUpdated        = entitlementUpdatedCallback;
     entitlementCallbacks.onSwitchEntitlementsChecking = entitlementCheckingSwitchCallback;
 
-    
+#if (OEA_MAJVERSION == 3 && OEA_MINVERSION >= 8)
+    /* Socket related tcp timeouts - only available in 3.8+ */
+    socketTimeoutStr = mama_getProperty (OEA_WRITE_TIMEOUT);
+    if (socketTimeoutStr != NULL)
+    {
+        oea_setSocketWriteTimeout (strtoul(socketTimeoutStr, NULL, 10));
+    }
+
+    socketTimeoutStr = mama_getProperty (OEA_READ_TIMEOUT);
+    if (socketTimeoutStr != NULL)
+    {
+        oea_setSocketReadTimeout (strtoul(socketTimeoutStr, NULL, 10));
+    }
+
+    socketTimeoutStr = mama_getProperty (OEA_CONNECTION_TIMEOUT);
+    if (socketTimeoutStr != NULL)
+    {
+        oea_setSocketConnectionTimeout (strtoul(socketTimeoutStr, NULL, 10));
+    }
+#endif
+
     oClient = oeaClient_create(&entitlementStatus,
                                 site,
                                 portLow,

--- a/mama/c_cpp/src/c/entitlement/oea/oea.h
+++ b/mama/c_cpp/src/c/entitlement/oea/oea.h
@@ -38,6 +38,10 @@ extern "C" {
 #define OEA_SITE_PROPERTY       "mama.entitlement.site"
 #define OEA_IP_ADDR_PROPERTY    "mama.entitlement.effective_ip_address"
 
+#define OEA_WRITE_TIMEOUT       "mama.entitlement.oea.write_timeout"
+#define OEA_READ_TIMEOUT        "mama.entitlement.oea.read_timeout"
+#define OEA_CONNECTION_TIMEOUT  "mama.entitlement.oea.connection_timeout"
+
 #define OEA_MAX_ENTITLEMENT_SERVERS 32
 
 


### PR DESCRIPTION
# Make OEA Socket Timeouts Configurable in MAMA
## Summary
Three new OEA properties added to MAMA

## Areas Affected
*Place an 'x' within the braces to check the box*
- [x] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
The following properties have been added to MAMA that will allow you to set OEA socket related tcp timeouts:

- mama.entitlement.oea.write_timeout
- mama.entitlement.oea.read_timeout
- mama.entitlement.oea.connection_timeout

## Testing
These changes have been made in advance of OEA v3.8 so currently there is no way of testing this.


Signed-off-by: Gary Molloy <gmolloy@velatt.com>