### PR TITLE
MAMA: Removed mixed declaration in ent-noop

### DIFF
--- a/mama/c_cpp/src/c/entitlement/noop/noop.c
+++ b/mama/c_cpp/src/c/entitlement/noop/noop.c
@@ -66,10 +66,11 @@ noopEntitlementBridge_createSubscription(mamaEntitlementBridge mamaEntBridge, Su
     /* Although this is a no-op bridge, some mama functionality assumes that an entitlementSubscription
      * exists as long as an entitlementBridge has been loaded
      */
-    mama_log(MAMA_LOG_LEVEL_FINEST, "noopEntitlementBridge_createSubscription():");
 
     mama_status                         status;
     mamaEntitlementSubscription         mamaEntSub    = NULL;
+
+    mama_log(MAMA_LOG_LEVEL_FINEST, "noopEntitlementBridge_createSubscription():");
 
     /* Allocate mama_level entitlement subscription object and set implementation struct pointer. */
     status = mamaEntitlementBridge_createSubscription(&mamaEntSub);
@@ -99,7 +100,7 @@ mama_status
 noopEntitlementBridge_setIsSnapshot(entitlementSubscriptionHandle handle, int isSnapshot)
 {
     mama_log(MAMA_LOG_LEVEL_FINEST, "noopEntitlementBridge_setIsSnapShot():");
-	return MAMA_STATUS_OK;
+    return MAMA_STATUS_OK;
 }
 
 int


### PR DESCRIPTION
Causes build error on visual studio versions prior to 2015.

Signed-off-by: Frank Quinn <fquinn.ni@gmail.com>