### PR TITLE
PLAT-747: Mamalistenc cores on start up when entitlement servers are not defined

### DIFF
--- a/mama/c_cpp/src/c/entitlement/oea/oea.c
+++ b/mama/c_cpp/src/c/entitlement/oea/oea.c
@@ -109,8 +109,8 @@ oeaEntitlementBridge_init(entitlementBridge* bridge)
 
     if (NULL == (entitlementServers = oeaEntitlmentBridge_parseServersProperty()))
     {
-        goto initFreeClientAndBridge;
         status = MAMA_ENTITLE_NO_SERVERS_SPECIFIED;
+        goto initFreeBridge;
     }
 
     while (entitlementServers[size] != NULL)


### PR DESCRIPTION
# Entitlements core when no entitlement servers are defined
## Summary
MAMA would core when running an entitled build but then fail to define any entitlement servers in the mama.properties.

## Areas Affected
- [x] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
Fixed the return code and error handling in the even that we fail to find any entitlement.servers in the mama.properties

## Testing
With this change in place we now get the correct behaviour when no entitlement servers are defined:

```
$ mamalistenc -S UTP -tport tcp_sub -m wmw -s FR0000031122.EUR.XPAR
2016-08-31 14:45:51:
********************************************************************************
Warning: This is a developer release and has only undergone basic sanity checks.
It is for testing only and should not be used in a production environment
**********************************************************************************
2016-08-31 14:45:51: Failed to open properties file or no entitlement.servers property.
2016-08-31 14:45:51: mama_loadEntitlementBridgeInternal (): Failed to initialise entitlement bridge [oea]. Cannot load.
2016-08-31 14:45:51: mama_openWithProperties(): Could not load oea entitlements library.
Failed to initialize MAMA STATUS: 9030 (ENTITLE_NO_SERVERS_SPECIFIED)
```

Signed-off-by: Gary Molloy <gmolloy@velatt.com>