### PR TITLE
PLAT-737: Core within mamaSubscription_processWildCardMsg()

### DIFF
--- a/mama/c_cpp/src/c/subscription.c
+++ b/mama/c_cpp/src/c/subscription.c
@@ -2165,8 +2165,9 @@ mamaSubscription_processWildCardMsg( mamaSubscription subscription,
                                      const char* topic,
                                      void* topicClosure)
 {
-    mamaBridgeImpl* bridge  = NULL;
-    int             allowed = 0;
+    mamaBridgeImpl*         bridge      = NULL;
+    mamaEntitlementBridge   entBridge   = NULL;
+    int                     allowed     = 0;
 
     if ( (gMamaLogLevel >= MAMA_LOG_LEVEL_FINEST) ||
             (mamaSubscription_checkDebugLevel (subscription,
@@ -2174,7 +2175,7 @@ mamaSubscription_processWildCardMsg( mamaSubscription subscription,
     {
         const char* text = mamaMsg_toString(msg);
         mama_forceLog (MAMA_LOG_LEVEL_FINEST, 
-                "mamaSubscription_processMsg(): %s%s msg = %s subsc (%p)",
+                "mamaSubscription_processWildCardMsg(): %s%s msg = %s subsc (%p)",
                 userSymbolFormatted, 
                 text, 
                 subscription);
@@ -2184,16 +2185,21 @@ mamaSubscription_processWildCardMsg( mamaSubscription subscription,
 
     if (!mamaBridgeImpl_areEntitlementsDeferred(bridge))
     {
-        allowed = self->mSubjectContext.mEntitlementBridge->isAllowed(self->mSubjectContext.mEntitlementSubscription, 
-                                                            self->mSubjectContext.mSymbol);
-        if (!allowed)
+        entBridge = self->mSubjectContext.mEntitlementBridge;
+
+        if (NULL != entBridge)
         {
-            self->mWcCallbacks.onError (self,
-                    MAMA_STATUS_NOT_ENTITLED,
-                    NULL,
-                    self->mUserSymbol,
-                    self->mClosure);
-            return MAMA_STATUS_NOT_ENTITLED;
+            allowed = entBridge->isAllowed(self->mSubjectContext.mEntitlementSubscription, 
+                                                                self->mSubjectContext.mSymbol);
+            if (!allowed)
+            {
+                self->mWcCallbacks.onError (self,
+                        MAMA_STATUS_NOT_ENTITLED,
+                        NULL,
+                        self->mUserSymbol,
+                        self->mClosure);
+                return MAMA_STATUS_NOT_ENTITLED;
+            }
         }
     }
 
@@ -2204,7 +2210,7 @@ mamaSubscription_processWildCardMsg( mamaSubscription subscription,
            self->mClosure, 
            topicClosure);
 
-    /*Do not access subscription here as it mey have been deleted/destroyed*/
+    /* Do not access subscription here as it may have been deleted/destroyed */
     return MAMA_STATUS_OK;
 }
     


### PR DESCRIPTION
# Core within mamaSubscription_processWildCardMsg() checking entitlements
## Summary
A core was observed while running the example app "mamasubscriberc -w" within the function mamaSubscription_processWildCardMsg().  The issue is that currently we do not create an entitlement subscription for basic subscriptions.

## Areas Affected
- [x] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
Added additional entitlements check into mamaSubscription_processWildCardMsg() to check that we have an entitlement subscription before trying to verify if we are entitled to continue

## Testing
With the patch applied we get the expected results from running "mamasubscriberc -w" and no core.

Signed-off-by: Gary Molloy <gmolloy@velatt.com>