### PR TITLE
[PLAT-753] - Creation of the exceptionHandlers in a try/catch

### DIFF
--- a/mama/c_cpp/src/examples/cpp/mamaiocpp.cpp
+++ b/mama/c_cpp/src/examples/cpp/mamaiocpp.cpp
@@ -223,12 +223,20 @@ static void createIOHandlers (void)
                                gFD,
                                MAMA_IO_WRITE);
 
-        /* Handles exceptional events like out of band data */
-        gExceptHandler = new MamaIo;
-        gExceptHandler->create (gDefaultQueue,
-                                new IOCallback (),
-                                gFD,
-                                MAMA_IO_EXCEPT);
+        /* Not all middlewares can support MAMA_IO_EXCEPT */
+        try
+        {
+            /* Handles exceptional events like out of band data */
+            gExceptHandler = new MamaIo;
+            gExceptHandler->create (gDefaultQueue,
+                                    new IOCallback (),
+                                    gFD,
+                                    MAMA_IO_EXCEPT);
+        }
+        catch (MamaStatus &status)
+        {
+            cerr << "Warning: Cannot create IO Handler for MAMA_IO_EXCEPT: not supported on current middleware " << endl;
+        }
     }
     catch (MamaStatus &status)
     {

--- a/mama/dotnet/src/examples/MamaIo/MamaIoCS.cs
+++ b/mama/dotnet/src/examples/MamaIo/MamaIoCS.cs
@@ -142,8 +142,15 @@ namespace Wombat
 				readHandler.create(defaultQueue, new ReadIoCallback(this), descriptor, mamaIoType.MAMA_IO_READ);
 				writeHandler = new MamaIo();
 				writeHandler.create(defaultQueue, new WriteIoCallback(this), descriptor, mamaIoType.MAMA_IO_WRITE);
-				exceptHandler = new MamaIo();
-				exceptHandler.create(defaultQueue, new ExceptIoCallback(this), descriptor, mamaIoType.MAMA_IO_EXCEPT);
+                try
+                {
+				    exceptHandler = new MamaIo();
+				    exceptHandler.create(defaultQueue, new ExceptIoCallback(this), descriptor, mamaIoType.MAMA_IO_EXCEPT);
+                }
+                catch (MamaException e)
+                {
+                    Console.WriteLine("Warning: Cannot create IO Handler for MAMA_IO_EXCEPT: not supported on current middleware");
+                }
 			}
 			catch (MamaException e)
 			{


### PR DESCRIPTION
# Creation of the exceptionHandlers in a try/catch (C++ and C#) inside MamaIoCS code logic as some middlewares do not support MAMA_IO_EXCEPT.
## Summary
Windows *and* WMW only. Fixed bug where MAMA_STATUS_UNSUPPORTED_IO_TYPE was seeing whenever I/O type was not found.

## Areas Affected
*Place an 'x' within the braces to check the box*
- [x] MAMAC
- [ ] MAMACPP
- [x] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [x] Examples

## Details
New unknown I/O type handler implementation to fix the issue. Now, in case of 
failing this message will be logged: "Warning: Cannot create IO Handler for 
MAMA_IO_EXCEPT: not supported on current middleware".

## Testing
Replication steps:
1. Start MamaIoCS.exe [Windows box]
`MamaIoCS.exe -m wmw -p 7777`
2. start netcat [linux box]
3. MamaIoCS.exe accepts a connection and produces error
`Accepting connection from 10.119.18.62:35485
Error creation IO Handler: Wombat.MamaException: mamaStatus: (MAMA_STATUS_UNSUPPORTED_IO_TYPE)
   at Wombat.MamaWrapper.CheckResultCode(Int32 code)
   at Wombat.MamaIo.create(MamaQueue queue, MamaIoCallback action, UInt32 descriptor, mamaIoType ioType, Object closure)
   at Wombat.MamaIo.create(MamaQueue queue, MamaIoCallback action, UInt32 descriptor, mamaIoType ioType)
   at Wombat.MamaIoCS.CreateIoHandlers()`

With the new patch this error should go away. Instead, we will get this warning log message.