### PR TITLE
PLAT-839: Default value of mama.msg.allowmodify changed from "false" to "true"

### DIFF
--- a/mama/c_cpp/src/c/mama.c
+++ b/mama/c_cpp/src/c/mama.c
@@ -105,7 +105,7 @@ mamaStat                gPublisherSend;
 mamaStat                gPublisherInboxSend;
 mamaStat                gPublisherReplySend;
 
-mama_bool_t gAllowMsgModify = 0;
+mama_bool_t gAllowMsgModify = 1;
 
 mama_status mama_statsInit (void);
 mama_status mama_setupStatsGenerator (void);
@@ -926,10 +926,10 @@ mama_openWithPropertiesCount (const char* path,
     }
 
     prop = properties_Get (gProperties, "mama.message.allowmodify");
-    if (prop && strtobool (prop))
+    if (prop && (!strtobool (prop)))
     {
-        gAllowMsgModify = 1;
-        mama_log (MAMA_LOG_LEVEL_FINE, "mama.message.allowmodify: true");
+        gAllowMsgModify = 0;
+        mama_log (MAMA_LOG_LEVEL_FINE, "mama.message.allowmodify: false");
     }
 
     if (strlen( (char*) gEntitlementBridges))


### PR DESCRIPTION
# PR_TITLE
## Summary
Default value of mama.msg.allowmodify changed from "false" to "true".

## Areas Affected
*Place an 'x' within the braces to check the box*
- [x] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
mama.message.allowmodify controls whether or not MAMA is allowed to 
internally modify messages it has received.  Specifically it is checked inside 
mamaDqPublisher_send() when updating the sequence number and senderId 
of the outgoing message.  If mama.message.allowmodify is false, a copy of 
the message is taken at this point.  If it is true, the original message is 
updated.

In most cases it is in fact safe to modify the message.  The only case 
where it is not safe is when republishing messages from a Data Fabric 
Shared Memory transport.  Testing has discovered that copying the 
message adds around 2 microseconds to the time it takes to execute 
mamaDqPublisher_send().  Since in most cases there is no actual benefit 
for this extra latency, the default value of the parameter has been changed 
to avoid performing the extra copy unless it is explicitly required.

## Testing
Logging has changed slightly.
Previously there would be no logging unless you changed the value from false (default) to true, in which case you would see:
mama_log (MAMA_LOG_LEVEL_FINE, "mama.message.allowmodify: true");

This has now been reversed - i.e. you will see no logging unless you changed the value from true (default) to false, in which case you will see:
mama_log (MAMA_LOG_LEVEL_FINE, "mama.message.allowmodify: false");