### PR TITLE
COMMON: Added new method for finding a file in a PATH

### DIFF
--- a/OpenMama.sln
+++ b/OpenMama.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "c", "c", "{F02CD330-5AFF-424D-B58C-5E875224AADB}"
 EndProject
@@ -66,6 +66,9 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "dotnet", "dotnet", "{34321A46-A7F4-42C5-A743-B1EBE3FA69EE}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "mamac", "mama\c_cpp\src\c\mamac.vcxproj", "{7F64D11F-C002-4271-BDEC-A82C614403EF}"
+	ProjectSection(ProjectDependencies) = postProject
+		{1231A373-C9B9-4914-BE64-F5760F0E2D27} = {1231A373-C9B9-4914-BE64-F5760F0E2D27}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "mamacpp", "mama\c_cpp\src\cpp\mamacpp.vcxproj", "{66CB8ABC-8EA3-4FF6-B715-D878B37CCCB3}"
 EndProject

--- a/common/c_cpp/src/c/SConscript.win
+++ b/common/c_cpp/src/c/SConscript.win
@@ -22,6 +22,7 @@ fileparser.c
 mempool.c
 memnode.c
 thread.c
+fileutils.c
 windows/strpcasecmp.c
 windows/strptime.c
 windows/platform.c

--- a/common/c_cpp/src/c/commonc.vcxproj
+++ b/common/c_cpp/src/c/commonc.vcxproj
@@ -216,6 +216,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="destroyHandle.c" />
+    <ClCompile Include="fileutils.c" />
     <ClCompile Include="windows\environment.c" />
     <ClCompile Include="lex.yy.c" />
     <ClCompile Include="libyywrap.c" />
@@ -247,6 +248,8 @@
   <ItemGroup>
     <ClInclude Include="windows\wombat\port.h" />
     <ClInclude Include="property.h" />
+    <ClInclude Include="wombat\environment.h" />
+    <ClInclude Include="wombat\fileutils.h" />
     <ClInclude Include="wombat\wtable.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/common/c_cpp/src/c/fileutils.c
+++ b/common/c_cpp/src/c/fileutils.c
@@ -22,6 +22,7 @@
 #include <wombat/fileutils.h>
 #include <wombat/environment.h>
 #include <stdio.h>
+#include <string.h>
 
 int
 fileUtils_findFileInPathList (char*         buffer,

--- a/common/c_cpp/src/c/fileutils.c
+++ b/common/c_cpp/src/c/fileutils.c
@@ -1,0 +1,71 @@
+/*
+ *
+ * OpenMAMA: The open middleware agnostic messaging API
+ * Copyright (C) 2011 NYSE Technologies, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+#include <wombat/fileutils.h>
+#include <wombat/environment.h>
+#include <stdio.h>
+
+int
+fileUtils_findFileInPathList (char*         buffer,
+                              size_t        bufferSize,
+                              const char*   filename,
+                              const char*   pathlist,
+                              const char*   delim)
+{
+    char *token = NULL;
+    char delimiters[16];
+
+    if (NULL == pathlist)
+    {
+        return 0;
+    }
+
+    if (NULL == delim)
+    {
+        snprintf(delimiters, sizeof(delimiters), "%c", PATH_DELIM);
+    }
+    else
+    {
+        strncpy (delimiters, delim, sizeof(delimiters));
+    }
+
+    token = strtok ((char*) pathlist, delimiters);
+    while (token != NULL) {
+        /* Only consider non-zero-length strings */
+        if (strlen(token) > 0)
+        {
+            FILE * file;
+            /* Build absolute path */
+            snprintf (buffer, bufferSize, "%s%s%s", token, PATHSEP, filename);
+            file = fopen(buffer, "r");
+            if (file) {
+                /* Close this handle and let the caller open if it wants to */
+                fclose(file);
+                return 1;
+            }
+        }
+
+        /* Move onto next element in path list */
+        token = strtok (NULL, delimiters);
+    }
+    strncpy(buffer, "", bufferSize);
+    return 0;
+}

--- a/common/c_cpp/src/c/wombat/environment.h
+++ b/common/c_cpp/src/c/wombat/environment.h
@@ -24,6 +24,10 @@
 
 #include "wombat/wConfig.h"
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 /**
  * This function will delete an environment varible.
  *
@@ -58,5 +62,9 @@ extern int
 environment_setVariable(
     const char *name,
     const char *value);
+
+#if defined (__cplusplus)
+}
+#endif
 
 #endif /* _WOMBAT_ENVIRONMENT_H */

--- a/common/c_cpp/src/c/wombat/fileutils.h
+++ b/common/c_cpp/src/c/wombat/fileutils.h
@@ -1,0 +1,69 @@
+/* $Id$
+ *
+ * OpenMAMA: The open middleware agnostic messaging API
+ * Copyright (C) 2011 NYSE Technologies, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+#ifndef WOMBAT_FILEUTILS_H__
+#define WOMBAT_FILEUTILS_H__
+
+
+/*************************************************************************
+ * Includes
+**************************************************************************/
+
+#include <wombat/port.h>
+
+#if defined (__cplusplus)
+extern "C"
+{
+#endif
+
+
+/*************************************************************************
+ * Typedefs, structs, enums and globals
+**************************************************************************/
+
+/**
+* This method searches through a string of delimited file paths searching
+* for a file in any one of those paths. Common usages would be searching
+* through LD_LIBRARY_PATH or PATH to look for values.
+*
+* @param buffer     The string buffer to populate with the results
+* @param bufferSize The number of bytes in buffer
+* @param filename   This will refer to the filename which we are looking for.
+* @param pathlist   This is a delimited string representing each path which
+*                   is to be considered whils searching for filename.
+* @param delim      This is a delimiter to use when tokenizing the pathlist.
+*                   If NULL is provided, it will be detected.
+*
+* @return 1 if match found otherwise returns 0.
+*/
+COMMONExpDLL
+int
+fileUtils_findFileInPathList (char*         buffer,
+                              size_t        bufferSize,
+                              const char*   filename,
+                              const char*   pathlist,
+                              const char*   delim);
+
+#if defined (__cplusplus)
+}
+#endif
+
+#endif /* WOMBAT_FILEUTILS_H__ */

--- a/common/c_cpp/src/gunittest/c/SConscript
+++ b/common/c_cpp/src/gunittest/c/SConscript
@@ -30,6 +30,7 @@ sources = Split("""
 port.cpp
 queuetest.cpp
 timertest.cpp
+utiltest.cpp
 """)
 
 MainUnitTest = env.Object( '../MainUnitTestC.cpp' ) 

--- a/common/c_cpp/src/gunittest/c/UnitTestCommonC.vcxproj
+++ b/common/c_cpp/src/gunittest/c/UnitTestCommonC.vcxproj
@@ -180,6 +180,9 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
+    <PostBuildEvent>
+      <Command>copy "$(GTEST_HOME)\lib\gtest.dll" $(OutDir)</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\c\commonc.vcxproj">
@@ -190,6 +193,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\MainUnitTestC.cpp" />
+    <ClCompile Include="utiltest.cpp" />
     <ClInclude Include="..\MainUnitTestC.h" />
     <ClCompile Include="port.cpp" />
     <ClCompile Include="queuetest.cpp" />

--- a/common/c_cpp/src/gunittest/c/utiltest.cpp
+++ b/common/c_cpp/src/gunittest/c/utiltest.cpp
@@ -1,0 +1,86 @@
+/* $Id: queuetest.cpp,v 1.1.2.1 2012/11/21 10:03:55 matthewmulhern Exp $
+ *
+ * OpenMAMA: The open middleware agnostic messaging API
+ * Copyright (C) 2011 NYSE Technologies, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+
+#include <gtest/gtest.h>
+#include "MainUnitTestC.h"
+#include <wombat/fileutils.h>
+#include <wombat/environment.h>
+#include <stdio.h>
+
+
+class CommonUtilTestC : public ::testing::Test
+{	
+protected:
+    CommonUtilTestC();
+    virtual ~CommonUtilTestC();
+
+    virtual void SetUp();        
+    virtual void TearDown ();    
+public:
+};
+
+CommonUtilTestC::CommonUtilTestC()
+{
+}
+
+CommonUtilTestC::~CommonUtilTestC()
+{
+}
+
+void CommonUtilTestC::SetUp(void)
+{	
+}
+
+void CommonUtilTestC::TearDown(void)
+{
+}
+
+/* ************************************************************************* */
+/* Test Functions */
+/* ************************************************************************* */
+
+TEST_F (CommonUtilTestC, findFileInPath)
+{
+    char filePath[1024];
+
+    /* This should be successful in test environment */
+    EXPECT_EQ(1,
+        fileUtils_findFileInPathList (filePath,
+                                      sizeof(filePath),
+                                      "mama.properties",
+                                      environment_getVariable("WOMBAT_PATH"),
+                                      NULL));
+
+}
+
+TEST_F(CommonUtilTestC, findFileInPathNotExist)
+{
+    char filePath[1024];
+
+    /* This should be successful in test environment */
+    EXPECT_EQ(0,
+        fileUtils_findFileInPathList(filePath,
+            sizeof(filePath),
+            "mama.invisible_man",
+            environment_getVariable("WOMBAT_PATH"),
+            NULL));
+}

--- a/mama/c_cpp/src/gunittest/c/dictionarytest.cpp
+++ b/mama/c_cpp/src/gunittest/c/dictionarytest.cpp
@@ -21,6 +21,7 @@
 
 
 #include <gtest/gtest.h>
+#include <wombat/fileutils.h>
 #include "MainUnitTestC.h"
 #include "wombat/wConfig.h"
 #include "mama/mama.h"
@@ -77,14 +78,13 @@ TEST_F (MamaDictionaryTestC, LoadFromFileAndWriteToMsg)
     mamaDictionary dictionary;
     mamaMsg msg;
     char buf[1024];
-    const char* path = getenv("WOMBAT_PATH");
     size_t dictionarySize;
     size_t msgSize;
     
     ASSERT_EQ (MAMA_STATUS_OK, mamaDictionary_create(&dictionary));
 
-    ASSERT_NE (path, (const char*) NULL);
-    snprintf(buf, sizeof(buf), "%s/dictionary1.txt", path);
+    ASSERT_EQ (1, fileUtils_findFileInPathList(buf, sizeof(buf), "dictionary1.txt", getenv("WOMBAT_PATH"), NULL));
+
     ASSERT_EQ (MAMA_STATUS_OK, mamaDictionary_populateFromFile(dictionary, buf));
 
     ASSERT_EQ (MAMA_STATUS_OK, mamaDictionary_getDictionaryMessage(dictionary, &msg));


### PR DESCRIPTION
Added the fileUtils_findFileInPathList method for finding a file
within a delimited list of paths such as LD_LIBRARY_PATH or PATH,
and put it to work to fix an issue with the
MamaDictionaryTestC.LoadFromFileAndWriteToMsg unit test

Signed-off-by: Frank Quinn <fquinn.ni@gmail.com>