### PR TITLE
UT: Fixed unit test for modifyable payloads

### DIFF
--- a/mama/c_cpp/src/gunittest/cpp/MamaMsgTest.cpp
+++ b/mama/c_cpp/src/gunittest/cpp/MamaMsgTest.cpp
@@ -121,6 +121,13 @@ TEST_F (MamaMsgTestCPP, TempCopyNotOwnerTest)
     // getTempCopy: when the message cannot be modified, getTempCopy returns
     // a copy of the message and always the same copy.
 
+    // If no bridges have marked messages as immutable, this test is irrelevant
+    if (mamaInternal_getAllowMsgModify())
+    {
+        SUCCEED();
+        return;
+    }
+
     const void*       buffer          = NULL;
     size_t            bufferLength    = 0;
     MamaMsg*          msg             = new MamaMsg;
@@ -129,12 +136,6 @@ TEST_F (MamaMsgTestCPP, TempCopyNotOwnerTest)
     MamaMsg* copy2 = NULL;
     const char* testString      = "test";
     short owner;
-
-    // If no bridges have marked messages as immutable, this test is irrelevant
-    if (mamaInternal_getAllowMsgModify())
-    {
-        SUCCEED();
-    }
 
     msg->create();
     msg->addString (NULL, 101, testString);

--- a/mama/c_cpp/src/gunittest/cpp/MamaMsgTest.cpp
+++ b/mama/c_cpp/src/gunittest/cpp/MamaMsgTest.cpp
@@ -130,6 +130,12 @@ TEST_F (MamaMsgTestCPP, TempCopyNotOwnerTest)
     const char* testString      = "test";
     short owner;
 
+    // If no bridges have marked messages as immutable, this test is irrelevant
+    if (mamaInternal_getAllowMsgModify())
+    {
+        SUCCEED();
+    }
+
     msg->create();
     msg->addString (NULL, 101, testString);
     msg->getByteBuffer (buffer, bufferLength);


### PR DESCRIPTION
Fixed issue with MamaMsgTestCPP.TempCopyNotOwnerTest where the unit test
would fail because it assumed that the underlying payload was immutable.
With the recent changes submitted by Marti, this is no longer the default
case, so this test started to fail. This modification checks to see if any
bridges have marked the payloads as immutable before continuing with this
test.

Signed-off-by: Frank Quinn <fquinn.ni@gmail.com>