### PR TITLE
Feature mama date time

### DIFF
--- a/mama/c_cpp/src/c/datetimeimpl.h
+++ b/mama/c_cpp/src/c/datetimeimpl.h
@@ -26,70 +26,82 @@
 extern "C" {
 #endif
 
-typedef uint64_t mama_time_t;
+typedef struct mama_time_t_
+{
+    mama_i64_t              mSeconds;
+    long                    mNanoseconds;
+    mamaDateTimePrecision   mPrecision;
+    mamaDateTimeHints       mHints;
+} mama_time_t;
 
 
-#define MAMA_TIME_IMPL_NULL               ((uint64_t)0x0ULL)
-#define MAMA_TIME_IMPL_MASK_SECONDS       ((uint64_t)0xffffffff00000000ULL)
-#define MAMA_TIME_IMPL_MASK_MICROSECONDS  ((uint64_t)0x00000000000fffffULL)
-#define MAMA_TIME_IMPL_MASK_PRECISION     ((uint64_t)0x00000000f0000000ULL)
-#define MAMA_TIME_IMPL_MASK_HINT          ((uint64_t)0x000000000f000000ULL)
-#define MAMA_TIME_IMPL_BIT_HAS_DATE       ((uint64_t)0x0000000001000000ULL)
-#define MAMA_TIME_IMPL_BIT_HAS_TIME       ((uint64_t)0x0000000002000000ULL)
-#define MAMA_TIME_IMPL_BIT_NO_TIMEZONE    ((uint64_t)0x0000000004000000ULL)
-#define MAMA_TIME_IMPL_MASK_TIME_ONLY     ((uint64_t)0xffffffff000fffffULL)
+#define mamaDateTimeImpl_clear(t) \
+    ((t)->mSeconds = 0, (t)->mNanoseconds = 0, (t)->mPrecision = MAMA_DATE_TIME_PREC_UNKNOWN, (t)->mHints = 0)
 
-#define mamaDateTimeImpl_clear(t)             ((t) =  MAMA_TIME_IMPL_NULL)
-#define mamaDateTimeImpl_copy(d,s)            ((d) =  (s))
-#define mamaDateTimeImpl_empty(t)             ((t) == MAMA_TIME_IMPL_NULL)
-#define mamaDateTimeImpl_equal(l,r)           ((l) == (r))
+#define mamaDateTimeImpl_copy(d,s) \
+    ((d)->mSeconds = (s)->mSeconds, (d)->mNanoseconds = (s)->mNanoseconds, (d)->mPrecision = (s)->mPrecision, (d)->mHints = (s)->mHints)
+
+#define mamaDateTimeImpl_empty(t) \
+    ((t)->mSeconds == 0, (t)->mNanoseconds == 0, (t)->mPrecision == MAMA_DATE_TIME_PREC_UNKNOWN, (t)->mHints == 0)
+
+#define mamaDateTimeImpl_equal(l,r) \
+    ((l)->mSeconds == (r)->mSeconds && (l)->mNanoseconds == (r)->mNanoseconds)
+
 
 #define mamaDateTimeImpl_clearSeconds(t) \
-      ((t) &= ~MAMA_TIME_IMPL_MASK_SECONDS)
+    ((t)->mSeconds = 0)
 #define mamaDateTimeImpl_clearMicroSeconds(t) \
-      ((t) &= ~MAMA_TIME_IMPL_MASK_MICROSECONDS)
+    ((t)->mNanoseconds = 0)
 #define mamaDateTimeImpl_clearPrecision(t) \
-      ((t) &= ~MAMA_TIME_IMPL_MASK_PRECISION)
+    ((t)->mPrecision = MAMA_DATE_TIME_PREC_UNKNOWN)
 #define mamaDateTimeImpl_clearHint(t) \
-      ((t) &= ~MAMA_TIME_IMPL_MASK_HINT)
-#define mamaDateTimeImpl_clearHasDate(t) \
-      ((t) &= ~MAMA_TIME_IMPL_BIT_HAS_DATE)
-#define mamaDateTimeImpl_clearHasTime(t) \
-      ((t) &= ~MAMA_TIME_IMPL_BIT_HAS_TIME)
-#define mamaDateTimeImpl_clearNoTimezone(t) \
-      ((t) &= ~MAMA_TIME_IMPL_NO_TIMEZONE)
+    ((t)->mHints = 0)
 
-#define mamaDateTimeImpl_getSeconds(t) \
-      (uint32_t) (((t) & MAMA_TIME_IMPL_MASK_SECONDS)   >> 32)
-#define mamaDateTimeImpl_getMicroSeconds(t) \
-      (uint32_t) ((t) & MAMA_TIME_IMPL_MASK_MICROSECONDS)
-#define mamaDateTimeImpl_getPrecision(t) \
-      (uint32_t) (((t) & MAMA_TIME_IMPL_MASK_PRECISION) >> 28)
-#define mamaDateTimeImpl_getHint(t) \
-      (uint32_t) (((t) & MAMA_TIME_IMPL_MASK_HINT)      >> 24)
+#define mamaDateTimeImpl_clearHasDate(t) \
+    ((t)->mHints &= ~MAMA_DATE_TIME_HAS_DATE)
+#define mamaDateTimeImpl_clearHasTime(t) \
+    ((t)->mHints &= ~MAMA_DATE_TIME_HAS_TIME)
+#define mamaDateTimeImpl_clearNoTimezone(t) \
+    ((t)->mHints &= ~MAMA_DATE_TIME_NO_TIMEZONE)
+
+
+#define mamaDateTimeImpl_getSeconds(t)      ((t)->mSeconds)
+
+#define mamaDateTimeImpl_getMicroSeconds(t) ((t)->mNanoseconds / 1000)
+
+#define mamaDateTimeImpl_getNanoSeconds(t)  ((t)->mNanoseconds)
+
+#define mamaDateTimeImpl_getPrecision(t)    ((t)->mPrecision)
+
+#define mamaDateTimeImpl_getHint(t)         ((t)->mHints)
+
 #define mamaDateTimeImpl_getHasDate(t) \
-      (uint8_t) (((t) & MAMA_TIME_IMPL_BIT_HAS_DATE) >> 24)
+      (((t)->mHints & MAMA_DATE_TIME_HAS_DATE) == MAMA_DATE_TIME_HAS_DATE)
 #define mamaDateTimeImpl_getHasTime(t) \
-      (uint8_t) (((t) & MAMA_TIME_IMPL_BIT_HAS_TIME) >> 24)
+      (((t)->mHints & MAMA_DATE_TIME_HAS_TIME) == MAMA_DATE_TIME_HAS_TIME)
 #define mamaDateTimeImpl_getNoTimezone(t) \
-      (uint8_t) (((t) & MAMA_TIME_IMPL_NO_TIMEZONE) >> 24)
-#define mamaDateTimeImpl_getTimeOnly(t) \
-      ((t) & MAMA_TIME_IMPL_MASK_TIME_ONLY)
+      (((t)->mHints & MAMA_DATE_TIME_NO_TIMEZONE) == MAMA_DATE_TIME_NO_TIMEZONE)
+
 
 #define mamaDateTimeImpl_setSeconds(t,s) \
-      ((t) = ((t) & ~MAMA_TIME_IMPL_MASK_SECONDS)      | ((uint64_t)(s) << 32))
+      ((t)->mSeconds = (mama_i64_t)(s))
 #define mamaDateTimeImpl_setMicroSeconds(t,us) \
-      ((t) = ((t) & ~MAMA_TIME_IMPL_MASK_MICROSECONDS) | ((uint64_t)(us)))
+      ((t)->mNanoseconds = (long)(us) * 1000)
+#define mamaDateTimeImpl_setNanoSeconds(t,ns) \
+      ((t)->mNanoseconds = (long)(ns))
 #define mamaDateTimeImpl_setPrecision(t,p) \
-      ((t) = ((t) & ~MAMA_TIME_IMPL_MASK_PRECISION)    | ((uint64_t)(p) << 28))
+      ((t)->mPrecision = (p))
 #define mamaDateTimeImpl_setHint(t,p) \
-      ((t) = ((t) & ~MAMA_TIME_IMPL_MASK_HINT)         | ((uint64_t)(p) << 24))
+      ((t)->mHints = (p))
+
+
 #define mamaDateTimeImpl_setHasDate(t) \
-      ((t) |= MAMA_TIME_IMPL_BIT_HAS_DATE)
+      ((t)->mHints |= MAMA_DATE_TIME_HAS_DATE)
 #define mamaDateTimeImpl_setHasTime(t) \
-      ((t) |= MAMA_TIME_IMPL_BIT_HAS_TIME)
+      ((t)->mHints |= MAMA_DATE_TIME_HAS_TIME)
 #define mamaDateTimeImpl_setNoTimezone(t) \
-      ((t) |= MAMA_TIME_IMPL_NO_TIMEZONE)
+      ((t)->mHints |= MAMA_DATE_TIME_NO_TIMEZONE)
+
 
 #define MAMA_TIME_IMPL_SECONDS_IN_DAY  (24*60*60)
 

--- a/mama/c_cpp/src/c/mama/datetime.h
+++ b/mama/c_cpp/src/c/mama/datetime.h
@@ -661,6 +661,17 @@ mamaDateTime_getStructTimeValWithTz(const mamaDateTime dateTime,
                                     const mamaTimeZone tz);
     
 /**
+ * Set the date/time from a "struct timeval".
+ *
+ * @param dateTime      The dateTime to update.
+ * @param inputTimeVal  The timeval struct to be used to update the dateTime.
+ */
+MAMAExpDLL
+extern mama_status
+mamaDateTime_setFromStructTimeVal(const mamaDateTime dateTime,
+                                  struct timeval*    inputTimeVal);
+
+/**
  * Get the date/time as a "struct tm".
  *
  * @param dateTime The dateTime to set.

--- a/mama/c_cpp/src/c/mama/msg.h
+++ b/mama/c_cpp/src/c/mama/msg.h
@@ -1698,6 +1698,23 @@ mamaMsg_getDateTimeMSec(
     mama_u64_t*    milliseconds);
 
 /**
+ * Get the value of a MAMA date/time field in seconds as a double
+ *
+ * @param msg The message.
+ * @param name The name
+ * @param fid  The field identifier
+ * @param seconds (out) Pointer to the value in seconds as a double
+ */
+MAMAExpDLL
+extern
+mama_status
+mamaMsg_getDateTimeSeconds(
+    const mamaMsg  msg,
+    const char*    name,
+    mama_fid_t     fid,
+    mama_f64_t*    seconds);
+
+/**
  * Get a MAMA price field.
  *
  * @param msg The message.

--- a/mama/c_cpp/src/c/mama/types.h
+++ b/mama/c_cpp/src/c/mama/types.h
@@ -85,7 +85,7 @@ typedef void*       mamaPluginInfo;
 /**
  * Flexible date/time format
  */
-typedef   mama_u64_t*   mamaDateTime;
+typedef   void*         mamaDateTime;
 
 /**
  * Time zone utility type

--- a/mama/c_cpp/src/c/msg.c
+++ b/mama/c_cpp/src/c/msg.c
@@ -1885,6 +1885,26 @@ mamaMsg_getDateTimeMSec(
 }
 
 mama_status
+mamaMsg_getDateTimeSeconds(
+    const mamaMsg  msg,
+    const char*    name,
+    mama_fid_t     fid,
+    mama_f64_t*    seconds)
+{
+    mama_status status = MAMA_STATUS_OK;
+    mamaMsgImpl*     impl   = (mamaMsgImpl*)msg;
+
+    if (!impl->mCurrentDateTime)
+        mamaDateTime_create(&impl->mCurrentDateTime);
+
+    status = mamaMsg_getDateTime (msg, name, fid, impl->mCurrentDateTime);
+    if (status == MAMA_STATUS_OK)
+        status = mamaDateTime_getEpochTimeSeconds (impl->mCurrentDateTime, seconds);
+
+    return status;
+}
+
+mama_status
 mamaMsg_getDateTime(
     const mamaMsg  msg,
     const char*    name,

--- a/mama/c_cpp/src/cpp/datetime.cpp
+++ b/mama/c_cpp/src/cpp/datetime.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "wombat/port.h"
+#include "mamacppinternal.h"
 #include "mama/mamacpp.h"
 #include <math.h>
 
@@ -32,28 +33,29 @@ namespace Wombat
     MamaDateTime::MamaDateTime()
         : mStrRep (NULL)
     {
-        mamaDateTime_clear (&mDateTime);
+        mamaDateTime_create (&mDateTime);
     }
 
     MamaDateTime::MamaDateTime (const MamaDateTime& copy)
         : mStrRep (NULL)
     {
-        mamaDateTime_copy (&mDateTime,
-                           const_cast<const mamaDateTime>(&copy.mDateTime));
+        mamaDateTime_create (&mDateTime);
+        mamaDateTime_copy (mDateTime,
+                           const_cast<const mamaDateTime>(copy.mDateTime));
     }
 
     MamaDateTime::MamaDateTime (const char*          str,
                                 const MamaTimeZone*  tz)
         : mStrRep (NULL)
     {
-        mamaDateTime_clear (&mDateTime);
+        mamaDateTime_create (&mDateTime);
         if (tz)
         {
-            mamaDateTime_setFromStringWithTz (&mDateTime, str, tz->getCValue());
+            mamaDateTime_setFromStringWithTz (mDateTime, str, tz->getCValue());
         }
         else
         {
-            mamaDateTime_setFromString (&mDateTime, str);
+            mamaDateTime_setFromString (mDateTime, str);
         }
     }
 
@@ -63,14 +65,16 @@ namespace Wombat
         {
             delete[] (mStrRep);
         }
+
+        mamaDateTime_destroy (mDateTime);
     }
 
     MamaDateTime& MamaDateTime::operator= (const MamaDateTime& rhs)
     {
         if (this != &rhs)
         {
-            mamaDateTime_copy (&mDateTime,
-                               const_cast<const mamaDateTime>(&rhs.mDateTime));
+            mamaDateTime_copy (mDateTime,
+                               const_cast<const mamaDateTime>(rhs.mDateTime));
         }
         return *this;
     }
@@ -78,45 +82,45 @@ namespace Wombat
     int MamaDateTime::compare (const MamaDateTime&  rhs) const
     {
         return mamaDateTime_compare (
-            const_cast<const mamaDateTime>(&mDateTime),
-            const_cast<const mamaDateTime>(&rhs.mDateTime));
+            const_cast<const mamaDateTime>(mDateTime),
+            const_cast<const mamaDateTime>(rhs.mDateTime));
     }
 
     void MamaDateTime::clear ()
     {
-        mamaDateTime_clear (&mDateTime);
+        mamaDateTime_clear (mDateTime);
     }
 
     void MamaDateTime::clearDate ()
     {
-        mamaDateTime_clearDate (&mDateTime);
+        mamaDateTime_clearDate (mDateTime);
     }
 
     void MamaDateTime::clearTime ()
     {
-        mamaDateTime_clearTime (&mDateTime);
+        mamaDateTime_clearTime (mDateTime);
     }
 
     void MamaDateTime::setEpochTimeF64 (double  seconds)
     {
-        mamaDateTime_setEpochTimeF64 (&mDateTime, seconds);
+        mamaDateTime_setEpochTimeF64 (mDateTime, seconds);
     }
 
     void MamaDateTime::setEpochTimeMilliseconds (mama_u64_t  milliseconds)
     {
-        mamaDateTime_setEpochTimeMilliseconds (&mDateTime, milliseconds);
+        mamaDateTime_setEpochTimeMilliseconds (mDateTime, milliseconds);
     }
 
     void MamaDateTime::setEpochTimeMicroseconds (mama_u64_t  microseconds)
     {
-        mamaDateTime_setEpochTimeMicroseconds (&mDateTime, microseconds);
+        mamaDateTime_setEpochTimeMicroseconds (mDateTime, microseconds);
     }
 
     void MamaDateTime::setEpochTime (mama_u32_t             seconds,
                                      mama_u32_t             microseconds,
                                      mamaDateTimePrecision  precision)
     {
-        mamaDateTime_setEpochTime (&mDateTime, seconds, microseconds, precision);
+        mamaDateTime_setEpochTime (mDateTime, seconds, microseconds, precision);
     }
 
     void MamaDateTime::setWithHints (mama_u32_t             seconds,
@@ -124,13 +128,13 @@ namespace Wombat
                                      mamaDateTimePrecision  precision,
                                      mamaDateTimeHints      hints)
     {
-        mamaDateTime_setWithHints (&mDateTime, seconds, microseconds, precision,
+        mamaDateTime_setWithHints (mDateTime, seconds, microseconds, precision,
                                    hints);
     }
 
     void MamaDateTime::setPrecision (mamaDateTimePrecision  precision)
     {
-        mamaDateTime_setPrecision (&mDateTime, precision);
+        mamaDateTime_setPrecision (mDateTime, precision);
     }
 
     void MamaDateTime::setFromString (const char*           str,
@@ -138,11 +142,11 @@ namespace Wombat
     {
         if (tz)
         {
-            mamaDateTime_setFromStringWithTz (&mDateTime, str, tz->getCValue());
+            mamaDateTime_setFromStringWithTz (mDateTime, str, tz->getCValue());
         }
         else
         {
-            mamaDateTime_setFromString (&mDateTime, str);
+            mamaDateTime_setFromString (mDateTime, str);
         }
     }
 
@@ -152,24 +156,30 @@ namespace Wombat
     {
         if (tz)
         {
-            mamaDateTime_setFromStringBufferWithTz (&mDateTime, str, strLen,
+            mamaDateTime_setFromStringBufferWithTz (mDateTime, str, strLen,
                                                     tz->getCValue());
         }
         else
         {
-            mamaDateTime_setFromStringBuffer (&mDateTime, str, strLen);
+            mamaDateTime_setFromStringBuffer (mDateTime, str, strLen);
         }
     }
 
     void MamaDateTime::setToNow ()
     {
-        mamaDateTime_setToNow (&mDateTime);
+        mamaDateTime_setToNow (mDateTime);
     }
 
     void MamaDateTime::setToMidnightToday (const MamaTimeZone*  tz)
     {
-        mamaDateTime_setToMidnightToday (&mDateTime, 
+        mamaDateTime_setToMidnightToday (mDateTime, 
                                          tz == NULL ? NULL : tz->getCValue());
+    }
+
+    void MamaDateTime::set (struct timeval  inputTimeVal)
+    {
+        mamaDateTime_setFromStructTimeVal (mDateTime,
+                                           &inputTimeVal);
     }
 
     void MamaDateTime::set (mama_u32_t             year,
@@ -185,13 +195,13 @@ namespace Wombat
         if (tz)
         {
             mamaDateTime_setWithPrecisionAndTz (
-                &mDateTime, year, month, day, hours, minutes, seconds,
+                mDateTime, year, month, day, hours, minutes, seconds,
                 microseconds, precision, tz->getCValue());
         }
         else
         {
             mamaDateTime_setWithPrecisionAndTz (
-                &mDateTime, year, month, day, hours, minutes, seconds,
+                mDateTime, year, month, day, hours, minutes, seconds,
                 microseconds, precision, NULL);
         }
     }
@@ -206,13 +216,13 @@ namespace Wombat
         if (tz)
         {
             mamaDateTime_setTimeWithPrecisionAndTz (
-                &mDateTime, hours, minutes, seconds, microseconds, precision,
+                mDateTime, hours, minutes, seconds, microseconds, precision,
                 tz->getCValue());
         }
         else
         {
             mamaDateTime_setTimeWithPrecisionAndTz (
-                &mDateTime, hours, minutes, seconds, microseconds, precision,
+                mDateTime, hours, minutes, seconds, microseconds, precision,
                 NULL);
         }
     }
@@ -221,41 +231,41 @@ namespace Wombat
                                 mama_u32_t   month,
                                 mama_u32_t   day)
     {
-        mamaDateTime_setDate (&mDateTime, year, month, day);
+        mamaDateTime_setDate (mDateTime, year, month, day);
     }
 
     void MamaDateTime::copyTime (const MamaDateTime&  copy)
     {
-        mamaDateTime_copyTime (&mDateTime,
-                               const_cast<const mamaDateTime>(&copy.mDateTime));
+        mamaDateTime_copyTime (mDateTime,
+                               const_cast<const mamaDateTime>(copy.mDateTime));
     }
 
     void MamaDateTime::copyDate (const MamaDateTime&  copy)
     {
-        mamaDateTime_copyDate (&mDateTime,
-                               const_cast<const mamaDateTime>(&copy.mDateTime));
+        mamaDateTime_copyDate (mDateTime,
+                               const_cast<const mamaDateTime>(copy.mDateTime));
     }
 
     void MamaDateTime::addSeconds (mama_f64_t  seconds)
     {
-        mamaDateTime_addSeconds (&mDateTime, seconds);
+        mamaDateTime_addSeconds (mDateTime, seconds);
     }
 
     void MamaDateTime::addSeconds (mama_i32_t  seconds)
     {
-        mamaDateTime_addWholeSeconds (&mDateTime, seconds);
+        mamaDateTime_addWholeSeconds (mDateTime, seconds);
     }
 
     void MamaDateTime::addMicroseconds (mama_i64_t  microseconds)
     {
-        mamaDateTime_addMicroseconds (&mDateTime, microseconds);
+        mamaDateTime_addMicroseconds (mDateTime, microseconds);
     }
 
     mama_u64_t MamaDateTime::getEpochTimeMicroseconds () const
     {
         mama_u64_t  result = 0;
         mamaDateTime_getEpochTimeMicroseconds (
-            const_cast<const mamaDateTime>(&mDateTime), &result);
+            const_cast<const mamaDateTime>(mDateTime), &result);
         return result;
     }
 
@@ -263,7 +273,7 @@ namespace Wombat
     {
         mama_u64_t  result = 0;
         mamaDateTime_getEpochTimeMicrosecondsWithTz (
-            const_cast<const mamaDateTime>(&mDateTime), &result, tz.getCValue());
+            const_cast<const mamaDateTime>(mDateTime), &result, tz.getCValue());
         return result;
     }
 
@@ -271,7 +281,7 @@ namespace Wombat
     {
         mama_u64_t  result = 0;
         mamaDateTime_getEpochTimeMilliseconds (
-            const_cast<const mamaDateTime>(&mDateTime), &result);
+            const_cast<const mamaDateTime>(mDateTime), &result);
         return result;
     }
 
@@ -279,7 +289,7 @@ namespace Wombat
     {
         mama_u64_t  result = 0;
         mamaDateTime_getEpochTimeMillisecondsWithTz (
-            const_cast<const mamaDateTime>(&mDateTime), &result, tz.getCValue());
+            const_cast<const mamaDateTime>(mDateTime), &result, tz.getCValue());
         return result;
     }
 
@@ -287,7 +297,7 @@ namespace Wombat
     {
         mama_f64_t  result = 0;
         mamaDateTime_getEpochTimeSeconds (
-            const_cast<const mamaDateTime>(&mDateTime), &result);
+            const_cast<const mamaDateTime>(mDateTime), &result);
         return result;
     }
 
@@ -295,7 +305,7 @@ namespace Wombat
     {
         mama_f64_t  result = 0;
         mamaDateTime_getEpochTimeSecondsWithTz (
-            const_cast<const mamaDateTime>(&mDateTime), &result, tz.getCValue());
+            const_cast<const mamaDateTime>(mDateTime), &result, tz.getCValue());
         return result;
     }
 
@@ -303,54 +313,54 @@ namespace Wombat
     {
         mama_f64_t  result = 0;
         mamaDateTime_getEpochTimeSecondsWithCheck (
-            const_cast<const mamaDateTime>(&mDateTime), &result);
+            const_cast<const mamaDateTime>(mDateTime), &result);
         return result;
     }
 
     void MamaDateTime::getAsStructTimeVal (struct timeval&  result) const
     {
-        mamaDateTime_getStructTimeVal (const_cast<const mamaDateTime>(&mDateTime),
+        mamaDateTime_getStructTimeVal (const_cast<const mamaDateTime>(mDateTime),
                                        &result);
     }
 
     void MamaDateTime::getAsStructTimeVal (struct timeval&      result,
                                            const MamaTimeZone&  tz) const
     {
-        mamaDateTime_getStructTimeValWithTz (const_cast<const mamaDateTime>(&mDateTime),
+        mamaDateTime_getStructTimeValWithTz (const_cast<const mamaDateTime>(mDateTime),
                                              &result, tz.getCValue());
     }
 
     void MamaDateTime::getAsStructTm (struct tm&  result) const
     {
-        mamaDateTime_getStructTm (const_cast<const mamaDateTime>(&mDateTime),
+        mamaDateTime_getStructTm (const_cast<const mamaDateTime>(mDateTime),
                                   &result);
     }
 
     void MamaDateTime::getAsStructTm (struct tm&            result,
                                       const MamaTimeZone&  tz) const
     {
-        mamaDateTime_getStructTmWithTz (const_cast<const mamaDateTime>(&mDateTime),
+        mamaDateTime_getStructTmWithTz (const_cast<const mamaDateTime>(mDateTime),
                                         &result, tz.getCValue());
     }
 
     void MamaDateTime::getAsString (char*        result,
                                     mama_size_t  maxLen) const
     {
-        mamaDateTime_getAsString (const_cast<const mamaDateTime>(&mDateTime),
+        mamaDateTime_getAsString (const_cast<const mamaDateTime>(mDateTime),
                                   result, maxLen);
     }
 
     void MamaDateTime::getTimeAsString (char*        result,
                                         mama_size_t  maxLen) const
     {
-        mamaDateTime_getTimeAsString (const_cast<const mamaDateTime>(&mDateTime),
+        mamaDateTime_getTimeAsString (const_cast<const mamaDateTime>(mDateTime),
                                       result, maxLen);
     }
 
     void MamaDateTime::getDateAsString (char*        result,
                                         mama_size_t  maxLen) const
     {
-        mamaDateTime_getDateAsString (const_cast<const mamaDateTime>(&mDateTime),
+        mamaDateTime_getDateAsString (const_cast<const mamaDateTime>(mDateTime),
                                       result, maxLen);
     }
 
@@ -389,7 +399,7 @@ namespace Wombat
                                              const char*  format) const
     {
         mamaDateTime_getAsFormattedString (
-            const_cast<const mamaDateTime>(&mDateTime), result, maxLen, format);
+            const_cast<const mamaDateTime>(mDateTime), result, maxLen, format);
     }
 
     void MamaDateTime::getAsFormattedString (char*                result,
@@ -398,42 +408,42 @@ namespace Wombat
                                              const MamaTimeZone&  tz) const
     {
         mamaDateTime_getAsFormattedStringWithTz (
-            const_cast<const mamaDateTime>(&mDateTime),
+            const_cast<const mamaDateTime>(mDateTime),
             result, maxLen, format, tz.getCValue());
     }
 
     mama_u32_t MamaDateTime::getYear() const
     {
         mama_u32_t  result = 0;
-        mamaDateTime_getYear (const_cast<const mamaDateTime>(&mDateTime),&result);
+        mamaDateTime_getYear (const_cast<const mamaDateTime>(mDateTime),&result);
         return result;
     }
 
     mama_u32_t MamaDateTime::getMonth() const
     {
         mama_u32_t  result = 0;
-        mamaDateTime_getMonth(const_cast<const mamaDateTime>(&mDateTime), &result);
+        mamaDateTime_getMonth(const_cast<const mamaDateTime>(mDateTime), &result);
         return result;
     }
 
     mama_u32_t MamaDateTime::getDay() const
     {
         mama_u32_t  result = 0;
-        mamaDateTime_getDay (const_cast<const mamaDateTime>(&mDateTime), &result);
+        mamaDateTime_getDay (const_cast<const mamaDateTime>(mDateTime), &result);
         return result;
     }
 
     mama_u32_t MamaDateTime::getHour() const
     {
         mama_u32_t  result = 0;
-        mamaDateTime_getHour (const_cast<const mamaDateTime>(&mDateTime), &result);
+        mamaDateTime_getHour (const_cast<const mamaDateTime>(mDateTime), &result);
         return result;
     }
 
     mama_u32_t MamaDateTime::getMinute() const
     {
         mama_u32_t  result = 0;
-        mamaDateTime_getMinute (const_cast<const mamaDateTime>(&mDateTime),
+        mamaDateTime_getMinute (const_cast<const mamaDateTime>(mDateTime),
                                 &result);
         return result;
     }
@@ -441,23 +451,26 @@ namespace Wombat
     mama_u32_t MamaDateTime::getSecond() const
     {
         mama_u32_t  result = 0;
-        mamaDateTime_getSecond (const_cast<const mamaDateTime>(&mDateTime),
+        mamaDateTime_getSecond (const_cast<const mamaDateTime>(mDateTime),
                                 &result);
         return result;
     }
 
     mama_u32_t MamaDateTime::getMicrosecond() const
     {
+        mama_status status = MAMA_STATUS_OK;
         mama_u32_t  result = 0;
-        mamaDateTime_getMicrosecond (const_cast<const mamaDateTime>(&mDateTime),
-                                     &result);
+
+        mamaTry (mamaDateTime_getMicrosecond (const_cast<const mamaDateTime>(mDateTime),
+                                              &result));
+
         return result;
     }
 
     mamaDayOfWeek MamaDateTime::getDayOfWeek() const
     {
         mamaDayOfWeek  result = Sunday;
-        mamaDateTime_getDayOfWeek (const_cast<const mamaDateTime>(&mDateTime),
+        mamaDateTime_getDayOfWeek (const_cast<const mamaDateTime>(mDateTime),
                                    &result);
         return result;
     }
@@ -465,33 +478,33 @@ namespace Wombat
     bool MamaDateTime::operator== (const MamaDateTime& rhs) const
     {
         return (this == &rhs) ||
-            mamaDateTime_equal (const_cast<const mamaDateTime>(&mDateTime),
-                                const_cast<const mamaDateTime>(&rhs.mDateTime));
+            mamaDateTime_equal (const_cast<const mamaDateTime>(mDateTime),
+                                const_cast<const mamaDateTime>(rhs.mDateTime));
     }
 
     bool MamaDateTime::operator> (const MamaDateTime& rhs) const
     {
         return mamaDateTime_compare (
-            const_cast<const mamaDateTime>(&mDateTime),
-            const_cast<const mamaDateTime>(&rhs.mDateTime)) > 0;
+            const_cast<const mamaDateTime>(mDateTime),
+            const_cast<const mamaDateTime>(rhs.mDateTime)) > 0;
     }
 
     bool MamaDateTime::operator< (const MamaDateTime& rhs) const
     {
         return mamaDateTime_compare (
-            const_cast<const mamaDateTime>(&mDateTime),
-            const_cast<const mamaDateTime>(&rhs.mDateTime)) < 0;
+            const_cast<const mamaDateTime>(mDateTime),
+            const_cast<const mamaDateTime>(rhs.mDateTime)) < 0;
     }
 
     bool MamaDateTime::empty() const
     {
-        return mamaDateTime_empty (const_cast<const mamaDateTime>(&mDateTime));
+        return mamaDateTime_empty (const_cast<const mamaDateTime>(mDateTime));
     }
 
     bool MamaDateTime::hasTime() const
     {
         mama_bool_t  result = 0;
-        mamaDateTime_hasTime (const_cast<const mamaDateTime>(&mDateTime),
+        mamaDateTime_hasTime (const_cast<const mamaDateTime>(mDateTime),
                               &result);
         return (result);
     }
@@ -499,19 +512,19 @@ namespace Wombat
     bool MamaDateTime::hasDate() const
     {
         mama_bool_t  result = 0;
-        mamaDateTime_hasDate (const_cast<const mamaDateTime>(&mDateTime),
+        mamaDateTime_hasDate (const_cast<const mamaDateTime>(mDateTime),
                               &result);
         return (result);
     }
 
     mamaDateTime MamaDateTime::getCValue()
     {
-        return &mDateTime;
+        return mDateTime;
     }
 
     const mamaDateTime MamaDateTime::getCValue() const
     {
-        return const_cast<const mamaDateTime>(&mDateTime);
+        return const_cast<const mamaDateTime>(mDateTime);
     }
 
 } /* namespace  Wombat */

--- a/mama/c_cpp/src/cpp/mama/MamaDateTime.h
+++ b/mama/c_cpp/src/cpp/mama/MamaDateTime.h
@@ -112,6 +112,12 @@ public:
     void          setToMidnightToday (const MamaTimeZone*    tz = NULL);
 
     /**
+     * Set the underlying C mamaDateTime from a TimeVal Struct.
+     *  This will allow for extended date ranges.
+     */
+    void          set             (struct timeval      inputTimeVal);
+
+    /**
      * Set the entire date and time for the MamaDateTime.  The year,
      * month and day parameters must all be integers greater than
      * zero.
@@ -298,7 +304,7 @@ public:
     const mamaDateTime  getCValue() const;
 
 private:
-    mama_u64_t      mDateTime;
+    mamaDateTime    mDateTime;
     mutable char*   mStrRep;
 };
 

--- a/mama/c_cpp/src/gunittest/c/mamadatetime/datetimetest.cpp
+++ b/mama/c_cpp/src/gunittest/c/mamadatetime/datetimetest.cpp
@@ -64,7 +64,7 @@ MamaDateTimeTestC::TearDown(void)
     mama_close();
 }
 
-// Test Create function will valid and NULL parameters
+// Test Create function with valid and NULL parameters
 TEST_F (MamaDateTimeTestC, TestCreate)
 {
     mamaDateTime t = NULL;
@@ -73,7 +73,7 @@ TEST_F (MamaDateTimeTestC, TestCreate)
     EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_destroy(t) );
 }
 
-// Test Destroy function will valid and NULL parameters
+// Test Destroy function with valid and NULL parameters
 TEST_F (MamaDateTimeTestC, TestDestroy)
 {
     mamaDateTime t, nullTime = NULL; 
@@ -83,7 +83,7 @@ TEST_F (MamaDateTimeTestC, TestDestroy)
     EXPECT_EQ ( MAMA_STATUS_INVALID_ARG, mamaDateTime_destroy(nullTime) );
 }
 
-// Test Clear function will valid and NULL parameters
+// Test Clear function with valid and NULL parameters
 TEST_F (MamaDateTimeTestC, TestClear)
 {
     mamaDateTime t, nullTime = NULL; 
@@ -96,7 +96,7 @@ TEST_F (MamaDateTimeTestC, TestClear)
     EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_destroy(t) );
 }
 
-// Test ClearDate function will valid and NULL parameters
+// Test ClearDate function with valid and NULL parameters
 TEST_F (MamaDateTimeTestC, TestClearDate)
 {
     mamaDateTime t, nullTime = NULL; 
@@ -109,7 +109,7 @@ TEST_F (MamaDateTimeTestC, TestClearDate)
     EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_destroy(t) );
 }
 
-// Test ClearTime function will valid and NULL parameters
+// Test ClearTime function with valid and NULL parameters
 TEST_F (MamaDateTimeTestC, TestClearTime)
 {
     mamaDateTime t, nullTime = NULL; 
@@ -122,7 +122,7 @@ TEST_F (MamaDateTimeTestC, TestClearTime)
     EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_destroy(t) );
 }
 
-// Test Copy function will valid and NULL parameters
+// Test Copy function with valid and NULL parameters
 TEST_F (MamaDateTimeTestC, TestCopy)
 {
     mamaDateTime t,u, nullTime = NULL; 
@@ -144,7 +144,7 @@ TEST_F (MamaDateTimeTestC, TestCopy)
 }
 
 
-// Test Empty function will valid and NULL parameters
+// Test Empty function with valid and NULL parameters
 TEST_F (MamaDateTimeTestC, TestEmpty)
 {
     mamaDateTime t, nullTime = NULL; 
@@ -159,7 +159,7 @@ TEST_F (MamaDateTimeTestC, TestEmpty)
     EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_destroy(t) );
 }
 
-// Test Equal function will valid and NULL parameters
+// Test Equal function with valid and NULL parameters
 TEST_F (MamaDateTimeTestC, TestEqual)
 {
     mamaDateTime t, u, nullTime = NULL; 
@@ -228,8 +228,9 @@ TEST_F (MamaDateTimeTestC, TestCompare)
     // t is less than u
 
     EXPECT_EQ ( -1, mamaDateTime_compare(t,u) );
-    ASSERT_NE ( 1, mamaDateTime_compare(t,u) );
+    EXPECT_EQ ( 1, mamaDateTime_compare(u,t) );
     EXPECT_EQ ( 0, mamaDateTime_compare(t, t) );
+    EXPECT_EQ ( 0, mamaDateTime_compare(u, u) );
 
     EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_destroy(t) );
     EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_destroy(u) );
@@ -491,7 +492,7 @@ TEST_F (MamaDateTimeTestC, TestCopyTime)
     
     EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_setTime(t2, hour, minute, second, microsecond) );
     EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_copyTime(t1,t2) );
-    EXPECT_EQ ( 0, mamaDateTime_equal(t1,t2) );
+    EXPECT_EQ ( 1, mamaDateTime_equal(t1,t2) );
 
     EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_destroy(t1) );
     EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_destroy(t2) ); 
@@ -1394,6 +1395,31 @@ TEST_F (MamaDateTimeTestC, TestDiffMicroseconds)
     EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_destroy(t2) );
 }
 
+TEST_F (MamaDateTimeTestC, TestDiffMicrosecondsMixedValues)
+{
+    mamaDateTime t1, t2, nullTime = NULL;
+
+    std::string szTime1 = "2013-07-04 10:03:21.123",
+                szTime2 = "2012-07-04 10:03:21.123";
+
+    mama_i64_t mics = 1000000, dd = UINT_MAX, hh = -24, mm = 60, ss = 60;
+    mama_i64_t act, expected =  dd * hh * mm * ss * mics;
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_create(&t1) );
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_create(&t2) );
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_setFromString(t1, szTime1.c_str()) );
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_setFromString(t2, szTime2.c_str()) );
+
+    EXPECT_EQ ( MAMA_STATUS_INVALID_ARG, mamaDateTime_diffMicroseconds(nullTime, nullTime, NULL) );
+    EXPECT_EQ ( MAMA_STATUS_INVALID_ARG, mamaDateTime_diffMicroseconds(t1, nullTime, NULL) );
+    EXPECT_EQ ( MAMA_STATUS_INVALID_ARG, mamaDateTime_diffMicroseconds(t1, t2, NULL) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_diffMicroseconds(t1, t2, &act) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_destroy(t1) );
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_destroy(t2) );
+}
+
 /*  Description:     Get the current time since epoch by passing: 
  *                       1) NULL date-time & valid seconds
  *                       2) Valid date-time & NULL seconds
@@ -1409,28 +1435,28 @@ TEST_F (MamaDateTimeTestC, NullArguments)
     mamaDateTime    m_DateTime = NULL;
     
     /* Call with a NULL date time */
-    ASSERT_EQ (MAMA_STATUS_NULL_ARG, 
+    EXPECT_EQ (MAMA_STATUS_NULL_ARG, 
                mamaDateTime_getEpochTimeSecondsWithCheck (NULL, &seconds));
 
     /* NULL seconds */
-    mamaDateTime_create (&m_DateTime);
-    ASSERT_EQ (MAMA_STATUS_NULL_ARG, 
+    EXPECT_EQ (MAMA_STATUS_OK, mamaDateTime_create (&m_DateTime));
+    EXPECT_EQ (MAMA_STATUS_NULL_ARG, 
                mamaDateTime_getEpochTimeSecondsWithCheck (m_DateTime, NULL));
 
     /* NULL for both */
-    ASSERT_EQ (MAMA_STATUS_NULL_ARG, 
+    EXPECT_EQ (MAMA_STATUS_NULL_ARG, 
                mamaDateTime_getEpochTimeSecondsWithCheck (NULL, NULL));
 
-    mamaDateTime_destroy (m_DateTime);
+    EXPECT_EQ (MAMA_STATUS_OK, mamaDateTime_destroy (m_DateTime));
 }
 
 /*  Description:     Get the number of seconds since epoch from:
  *                       1) A string representation of a time
- *                       2) A string representation of a time and the current 
+ *                       2) A string representation of a time and the current
  *                          date
  *                   Compare these strings.
  *
- *  Expected Result: completeDateSeconds = timeSeconds 
+ *  Expected Result: completeDateSeconds = timeSeconds
  */
 TEST_F (MamaDateTimeTestC, CompareDates)
 {
@@ -1443,41 +1469,467 @@ TEST_F (MamaDateTimeTestC, CompareDates)
     mama_f64_t   timeSeconds           = 0;
     
     /* Get todays date in a date time */
-    ASSERT_EQ (MAMA_STATUS_OK, 
+    EXPECT_EQ (MAMA_STATUS_OK, 
                mamaDateTime_create (&today));
 
-    ASSERT_EQ (MAMA_STATUS_OK, 
+    EXPECT_EQ (MAMA_STATUS_OK, 
                mamaDateTime_setToNow (today));
 
     /* Get the string representation of the data */
-    ASSERT_EQ (MAMA_STATUS_OK, 
+    EXPECT_EQ (MAMA_STATUS_OK, 
                mamaDateTime_getAsFormattedString (today, stringDate, 100, "%Y-%m-%d"));
 
     /* Destroy the date */
-    ASSERT_EQ (MAMA_STATUS_OK, 
+    EXPECT_EQ (MAMA_STATUS_OK, 
                mamaDateTime_destroy (today));
 
     /* Format a string using today's date and a time, 
      * this should be as "2010-07-04 10:00:00.000" */
-    mamaDateTime_create (&m_cDateTime);
+    EXPECT_EQ (MAMA_STATUS_OK, mamaDateTime_create (&m_cDateTime));
     sprintf (completeDateTime, "%s %s", stringDate, time);
 
     /* Set the date from this string */
-    ASSERT_EQ (MAMA_STATUS_OK,
+    EXPECT_EQ (MAMA_STATUS_OK,
                mamaDateTime_setFromString (m_cDateTime, completeDateTime));
 
     /* Get the number of seconds */
-    ASSERT_EQ (MAMA_STATUS_OK, 
+    EXPECT_EQ (MAMA_STATUS_OK, 
                mamaDateTime_getEpochTimeSecondsWithCheck (m_cDateTime, &completeDateSeconds));
 
     /* Set the date using just the time string */
-    ASSERT_EQ (MAMA_STATUS_OK, mamaDateTime_clear (m_cDateTime));
-    ASSERT_EQ (MAMA_STATUS_OK, mamaDateTime_setFromString (m_cDateTime, time));
+    EXPECT_EQ (MAMA_STATUS_OK, mamaDateTime_clear (m_cDateTime));
+    EXPECT_EQ (MAMA_STATUS_OK, mamaDateTime_setFromString (m_cDateTime, time));
 
     /* Get the number of seconds from this */
-    ASSERT_EQ (MAMA_STATUS_OK, mamaDateTime_getEpochTimeSecondsWithCheck (m_cDateTime, &timeSeconds));
+    EXPECT_EQ (MAMA_STATUS_OK, mamaDateTime_getEpochTimeSecondsWithCheck (m_cDateTime, &timeSeconds));
     
     /* These must be the same */
-    ASSERT_EQ (completeDateSeconds, timeSeconds);
-    ASSERT_EQ (MAMA_STATUS_OK, mamaDateTime_destroy (m_cDateTime));
+    EXPECT_EQ (completeDateSeconds, timeSeconds);
+    EXPECT_EQ (MAMA_STATUS_OK, mamaDateTime_destroy (m_cDateTime));
 }
+
+/*  Description:     Set the number of seconds since epoch from a timeval.
+ *                   Compare these strings.
+ *
+ *  Expected Result: timeStr = stringBuffer
+ */
+TEST_F (MamaDateTimeTestC, TestSetStructTimeVal)
+{
+    struct timeval          tVal;
+    mamaDateTime            t, nullTime = NULL;
+    const char*             timeStr     = "2017-01-17 17:31:47.123000";
+    char                    stringBuffer[50];
+    mama_u32_t              secs        = 0;
+    mama_u32_t              uSecs       = 0;
+    mamaDateTimePrecision   precision;
+
+    /* The following timeval represents the time - "2017-01-17 17:31:47.123" */
+    tVal.tv_sec = 1484674307;
+    tVal.tv_usec = 123000;
+
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_create(&t) );
+
+    EXPECT_EQ ( MAMA_STATUS_INVALID_ARG, mamaDateTime_setFromStructTimeVal(nullTime, NULL) );
+    EXPECT_EQ ( MAMA_STATUS_INVALID_ARG, mamaDateTime_setFromStructTimeVal(nullTime, &tVal) );
+    EXPECT_EQ ( MAMA_STATUS_INVALID_ARG, mamaDateTime_setFromStructTimeVal(t, NULL) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_setFromStructTimeVal(t, &tVal) );
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_getAsString (t, stringBuffer, 50) );
+    EXPECT_STREQ (timeStr, stringBuffer);
+
+    /* Precision was set to 6 dp so should be MAMA_DATE_TIME_PREC_MICROSECONDS */
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_getEpochTime(t, &secs, &uSecs, &precision) );
+    EXPECT_EQ ( precision, MAMA_DATE_TIME_PREC_MICROSECONDS );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_destroy(t) );
+}
+
+TEST_F (MamaDateTimeTestC, TestGetEpochTimeExtended)
+{
+    struct timeval          tVal1, tVal2;
+    mamaDateTime            t           = NULL;
+    mama_u32_t              secs        = 0;
+    mama_u32_t              uSecs       = 0;
+    mamaDateTimePrecision   precision;
+
+    /* The following timeval represents the time - "2106-02-07 06:28:16.123000"
+        1 second more than a uint32_t can hold */
+    tVal1.tv_sec = 4294967296;
+    tVal1.tv_usec = 123000;
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_create(&t) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_setFromStructTimeVal(t, &tVal1) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_getStructTimeVal(t, &tVal2) );
+    EXPECT_EQ ( tVal1.tv_sec, tVal2.tv_sec );
+    EXPECT_EQ ( tVal1.tv_usec, tVal2.tv_usec );
+
+    EXPECT_EQ ( MAMA_STATUS_INVALID_ARG, mamaDateTime_getEpochTime(t, &secs, &uSecs, &precision) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_destroy(t) );
+}
+
+TEST_F (MamaDateTimeTestC, TestGetEpochTimeExtendedNegativeValues)
+{
+    struct timeval          tVal1, tVal2;
+    mamaDateTime            t           = NULL;
+    mama_u32_t              secs        = 0;
+    mama_u32_t              uSecs       = 0;
+    mamaDateTimePrecision   precision;
+    char                    stringBuffer[50];
+    const char*             expectedDate = "1969-12-31 23:59:55";
+
+    /* The following timeval represents the time - "1969-12-31 23:59:55" */
+    tVal1.tv_sec = -5;
+    tVal1.tv_usec = -1;
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_create(&t) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_setFromStructTimeVal(t, &tVal1) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_getStructTimeVal(t, &tVal2) );
+    EXPECT_EQ ( tVal1.tv_sec, tVal2.tv_sec );
+    EXPECT_EQ ( tVal1.tv_usec, tVal2.tv_usec );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_getEpochTime(t, &secs, &uSecs, &precision) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_getAsString (t, stringBuffer, 50) );
+    EXPECT_STREQ (expectedDate, stringBuffer);
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_destroy(t) );
+}
+
+TEST_F (MamaDateTimeTestC, TestGetStructTimeValExtended)
+{
+    struct timeval          tVal1, tVal2;
+    mamaDateTime            t           = NULL;
+    mama_u32_t              secs        = 0;
+    mama_u32_t              uSecs       = 0;
+    mamaDateTimePrecision   precision;
+
+    /* The following timeval represents the time - "4375-02-26 15:38:40.123000" */
+    tVal1.tv_sec = 75899345920;
+    tVal1.tv_usec = 123000;
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_create(&t) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_setFromStructTimeVal(t, &tVal1) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_getStructTimeVal(t, &tVal2) );
+    EXPECT_EQ ( tVal1.tv_sec, tVal2.tv_sec );
+    EXPECT_EQ ( tVal1.tv_usec, tVal2.tv_usec );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_destroy(t) );
+}
+
+TEST_F (MamaDateTimeTestC, TestGetStructTimeValExtendedNegativeValues)
+{
+    struct timeval          tVal1, tVal2;
+    mamaDateTime            t           = NULL;
+    mama_u32_t              secs        = 0;
+    mama_u32_t              uSecs       = 0;
+    mamaDateTimePrecision   precision;
+    char                    stringBuffer[50];
+    const char*             expectedDate = "1969-12-31 23:59:55";
+
+    /* The following timeval represents the time - "1969-12-31 23:59:55" */
+    tVal1.tv_sec = -5;
+    tVal1.tv_usec = -1;
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_create(&t) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_setFromStructTimeVal(t, &tVal1) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_getStructTimeVal(t, &tVal2) );
+    EXPECT_EQ ( tVal1.tv_sec, tVal2.tv_sec );
+    EXPECT_EQ ( tVal1.tv_usec, tVal2.tv_usec );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_getAsString (t, stringBuffer, 50) );
+    EXPECT_STREQ (expectedDate, stringBuffer);
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_destroy(t) );
+}
+
+TEST_F (MamaDateTimeTestC, TestGetEpochTimeWithTzExtended)
+{
+    struct timeval          tVal1, tVal2;
+    mamaDateTime            t           = NULL;
+    mama_u32_t              secs        = 0;
+    mama_u32_t              uSecs       = 0;
+    mamaDateTimePrecision   precision;
+    mamaTimeZone            tz          = mamaTimeZone_utc();
+
+    /* The following timeval represents the time - "2106-02-07 06:28:16.123000"
+        1 second more than a uint32_t can hold */
+    tVal1.tv_sec = 4294967296;
+    tVal1.tv_usec = 123000;
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_create(&t) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_setFromStructTimeVal(t, &tVal1) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_getStructTimeVal(t, &tVal2) );
+    EXPECT_EQ ( tVal1.tv_sec, tVal2.tv_sec );
+    EXPECT_EQ ( tVal1.tv_usec, tVal2.tv_usec );
+
+    EXPECT_EQ ( MAMA_STATUS_INVALID_ARG, mamaDateTime_getEpochTimeWithTz(t, &secs, &uSecs, &precision, tz) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_destroy(t) );
+}
+
+TEST_F (MamaDateTimeTestC, TestGetEpochTimeMicrosecondsExtended)
+{
+    struct timeval  tVal1, tVal2;
+    mamaDateTime    t       = NULL;
+    mama_u64_t      uSecs   = 0;
+
+    /* The following timeval represents the time - "4375-02-26 15:38:40.123000" */
+    tVal1.tv_sec = 75899345920;
+    tVal1.tv_usec = 123000;
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_create(&t) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_setFromStructTimeVal(t, &tVal1) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_getStructTimeVal(t, &tVal2) );
+    EXPECT_EQ ( tVal1.tv_sec, tVal2.tv_sec );
+    EXPECT_EQ ( tVal1.tv_usec, tVal2.tv_usec );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_getEpochTimeMicroseconds(t, &uSecs) );
+
+    EXPECT_EQ ( uSecs, (tVal1.tv_sec * 1000000) + tVal1.tv_usec );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_destroy(t) );
+}
+
+TEST_F (MamaDateTimeTestC, TestGetWithHintsExtended)
+{
+    struct timeval          tVal1, tVal2;
+    mamaDateTime            t           = NULL;
+    mama_u32_t              secs        = 0;
+    mama_u32_t              uSecs       = 0;
+    mamaDateTimePrecision   precision;
+    mamaDateTimeHints       hints;
+
+    /* The following timeval represents the time - "2106-02-07 06:28:16.123000"
+        1 second more than a uint32_t can hold */
+    tVal1.tv_sec = 4294967296;
+    tVal1.tv_usec = 123000;
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_create(&t) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_setFromStructTimeVal(t, &tVal1) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_getStructTimeVal(t, &tVal2) );
+    EXPECT_EQ ( tVal1.tv_sec, tVal2.tv_sec );
+    EXPECT_EQ ( tVal1.tv_usec, tVal2.tv_usec );
+
+    EXPECT_EQ ( MAMA_STATUS_INVALID_ARG, mamaDateTime_getWithHints(t, &secs, &uSecs, &precision, &hints) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_destroy(t) );
+}
+
+TEST_F (MamaDateTimeTestC, TestGetMicrosecondExtended)
+{
+    struct timeval  tVal1, tVal2;
+    mamaDateTime    t       = NULL;
+    mama_u32_t      uSec    = 0;
+
+    /* The following timeval represents the time - "2106-02-07 06:28:16"
+        But the microseconds will be 1 microsecond more than a uint32_t can hold */
+    tVal1.tv_sec = 4294967295;
+    tVal1.tv_usec = 4294967296;
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_create(&t) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_setFromStructTimeVal(t, &tVal1) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_getStructTimeVal(t, &tVal2) );
+    EXPECT_EQ ( tVal1.tv_sec, tVal2.tv_sec );
+    EXPECT_EQ ( tVal1.tv_usec, tVal2.tv_usec );
+
+    EXPECT_EQ ( MAMA_STATUS_INVALID_ARG, mamaDateTime_getMicrosecond(t, &uSec) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_destroy(t) );
+}
+
+TEST_F (MamaDateTimeTestC, TestSetTimeExTest)
+{
+    mamaDateTime    t1   = NULL;
+    mama_u32_t      hour = 9, minute = 21, second = 12, microsecond = 500;
+    mama_u32_t      year = 2500, month = 12, day = 15;
+    char            dateTimeString[56];
+
+    const char*     expectedResult = "2500-12-15 09:21:12.000";
+
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_create(&t1) );
+
+    // Add a date beyond the current limit, 2106
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_setTime(t1, hour, minute, second, microsecond));
+
+    // Add a date beyond the current limit, 2106
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_setDate(t1, year, month, day));
+
+    // Get the date as a string for comparing
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_getAsString (t1, dateTimeString, 56));
+
+    EXPECT_STREQ ( dateTimeString, expectedResult );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_destroy(t1) );
+}
+
+TEST_F (MamaDateTimeTestC, GetAsFormattedStringWithTzTest)
+{
+    mamaDateTime t1                    = NULL;
+    char         stringDate[100]       = "";
+    const char*  time                  = "2013-07-04 10:03:21.123000";
+    char         completeDateTime[100] = "";
+    mamaDateTime m_cDateTime           = NULL;
+    mama_f64_t   completeDateSeconds   = 0;
+    mama_f64_t   timeSeconds           = 0;
+
+    /* Get todays date in a date time */
+    EXPECT_EQ (MAMA_STATUS_OK, mamaDateTime_create (&t1));
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_setFromString(t1, time) );
+
+    /* Get the string representation of the data */
+    EXPECT_EQ (MAMA_STATUS_OK,
+               mamaDateTime_getAsFormattedString (t1, stringDate, 100, "%Y-%m-%d %H:%M:%S"));
+
+    /* Get the string representation of the data */
+    EXPECT_EQ (MAMA_STATUS_OK,
+               mamaDateTime_getAsFormattedStringWithTz (t1, completeDateTime, 100, "%Y-%m-%d %H:%M:%S", mamaTimeZone_utc()));
+
+    EXPECT_STREQ ( stringDate, completeDateTime );
+
+    /* Test some of the seconds / sub-seconds options */
+    EXPECT_EQ (MAMA_STATUS_OK,
+               mamaDateTime_getAsFormattedStringWithTz (t1, completeDateTime, 100, "%Y-%m-%d %H:%M:%S.%.", mamaTimeZone_utc()));
+
+    EXPECT_STREQ ( time, completeDateTime );
+
+    // %, should add the "." before the sub seconds
+    EXPECT_EQ (MAMA_STATUS_OK,
+               mamaDateTime_getAsFormattedStringWithTz (t1, completeDateTime, 100, "%Y-%m-%d %H:%M:%S%,", mamaTimeZone_utc()));
+
+    EXPECT_STREQ ( time, completeDateTime );
+
+    /* Destroy the date */
+    EXPECT_EQ (MAMA_STATUS_OK,
+               mamaDateTime_destroy (t1));
+}
+
+TEST_F (MamaDateTimeTestC, TestGetEpochTimeMicrosecondsExtendedNegativeValues)
+{
+    struct timeval  tVal1, tVal2;
+    mamaDateTime    t       = NULL;
+    mama_u64_t      uSecs   = 0;
+    char            stringBuffer[50];
+    const char*     expectedDate = "1969-12-31 23:59:55";
+
+    /* The following timeval represents the time - "1969-12-31 23:59:55" */
+    tVal1.tv_sec = -5;
+    tVal1.tv_usec = -1;
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_create(&t) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_setFromStructTimeVal(t, &tVal1) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_getStructTimeVal(t, &tVal2) );
+    EXPECT_EQ ( tVal1.tv_sec, tVal2.tv_sec );
+    EXPECT_EQ ( tVal1.tv_usec, tVal2.tv_usec );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_getEpochTimeMicroseconds(t, &uSecs) );
+
+    EXPECT_EQ ( uSecs, (tVal1.tv_sec * 1000000) + tVal1.tv_usec );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_getAsString (t, stringBuffer, 50) );
+    EXPECT_STREQ (expectedDate, stringBuffer);
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_destroy(t) );
+}
+
+TEST_F (MamaDateTimeTestC, TestGetWithHintsExtendedNegativeValues)
+{
+    struct timeval          tVal1, tVal2;
+    mamaDateTime            t           = NULL;
+    mama_u32_t              secs        = 0;
+    mama_u32_t              uSecs       = 0;
+    mamaDateTimePrecision   precision;
+    mamaDateTimeHints       hints;
+    char                    stringBuffer[50];
+    const char*             expectedDate = "1969-12-31 23:59:55";
+
+    /* The following timeval represents the time - "1969-12-31 23:59:55" */
+    tVal1.tv_sec = -5;
+    tVal1.tv_usec = -1;
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_create(&t) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_setFromStructTimeVal(t, &tVal1) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_getStructTimeVal(t, &tVal2) );
+    EXPECT_EQ ( tVal1.tv_sec, tVal2.tv_sec );
+    EXPECT_EQ ( tVal1.tv_usec, tVal2.tv_usec );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_getWithHints(t, &secs, &uSecs, &precision, &hints) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_getAsString (t, stringBuffer, 50) );
+    EXPECT_STREQ (expectedDate, stringBuffer);
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_destroy(t) );
+}
+
+TEST_F (MamaDateTimeTestC, TestGetMicrosecondExtendedNegativeValues)
+{
+    struct timeval  tVal1, tVal2;
+    mamaDateTime    t       = NULL;
+    mama_u32_t      uSec    = 0;
+    char            stringBuffer[50];
+    const char*     expectedDate = "1969-12-31 23:59:55";
+
+    /* The following timeval represents the time - "1969-12-31 23:59:55" */
+    tVal1.tv_sec = -5;
+    tVal1.tv_usec = -1;
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_create(&t) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_setFromStructTimeVal(t, &tVal1) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_getStructTimeVal(t, &tVal2) );
+    EXPECT_EQ ( tVal1.tv_sec, tVal2.tv_sec );
+    EXPECT_EQ ( tVal1.tv_usec, tVal2.tv_usec );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_getMicrosecond(t, &uSec) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_getAsString (t, stringBuffer, 50) );
+    EXPECT_STREQ (expectedDate, stringBuffer);
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_destroy(t) );
+}
+
+TEST_F (MamaDateTimeTestC, TestVeryLargeValues)
+{
+    struct timeval          tVal1, tVal2;
+    mamaDateTime            t           = NULL;
+
+    /* The following timeval represents the largest possible valule for an int64" */
+    mama_i64_t int64_max = 9223372036854775807;
+    tVal1.tv_sec = int64_max;
+    tVal1.tv_usec = 0;
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_create(&t) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_setFromStructTimeVal(t, &tVal1) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_getStructTimeVal(t, &tVal2) );
+    EXPECT_EQ ( tVal1.tv_sec, tVal2.tv_sec );
+    EXPECT_EQ ( tVal1.tv_usec, tVal2.tv_usec );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_destroy(t) );
+}
+

--- a/mama/c_cpp/src/gunittest/cpp/MamaDateTimeTest.cpp
+++ b/mama/c_cpp/src/gunittest/cpp/MamaDateTimeTest.cpp
@@ -153,3 +153,65 @@ TEST_F(MamaDateTimeTest, SetDateTimezoneCheck)
     ASSERT_EQ(dt1.getEpochTimeMicroseconds(), dt2.getEpochTimeMicroseconds());
 }
 
+TEST_F(MamaDateTimeTest, GetFromStructTimeVal)
+{
+    struct timeval          tVal;
+    MamaDateTime            dt1;
+    mamaDateTimePrecision   precision   = MAMA_DATE_TIME_PREC_MICROSECONDS;
+    mamaDateTimeHints       hints       =  MAMA_DATE_TIME_HAS_DATE;
+
+    mama_u32_t secs      = 43219, mSecs = 123, uSecs = (mSecs * 1000) + 456;
+
+    dt1.setWithHints(secs, uSecs, precision, hints);
+
+    dt1.getAsStructTimeVal(tVal);
+
+    ASSERT_EQ ( tVal.tv_sec, secs );
+    ASSERT_EQ ( tVal.tv_usec, uSecs );
+}
+
+TEST_F(MamaDateTimeTest, SetFromStructTimeVal)
+{
+    struct timeval  tVal;
+    MamaDateTime    dt1;
+    const char*     timeStr     = "2017-01-17 17:31:47.123000";
+    char            stringBuffer[50];
+
+    /* The following timeval represents the time - "2017-01-17 17:31:47.123000" */
+    tVal.tv_sec = 1484674307;
+    tVal.tv_usec = 123000;
+
+    dt1.set(tVal);
+    dt1.getAsString(stringBuffer, 50);
+
+    ASSERT_STREQ (timeStr, stringBuffer);
+}
+
+TEST_F(MamaDateTimeTest, GetMicrosecondExtended)
+{
+    struct timeval      tVal;
+    MamaDateTime        dt1;
+    mama_u32_t          uSecs   = 0;
+    const MamaStatus&   status  = MAMA_STATUS_OK;
+
+    /* The following timeval represents the time - "2106-02-07 06:28:16"
+        But the microseconds will be 1 microsecond more than a uint32_t can hold */
+    tVal.tv_sec = 1484674307;
+    tVal.tv_usec = 4294967296;
+
+    dt1.set(tVal);
+
+    try
+    {
+        uSecs = dt1.getMicrosecond();
+    }
+    catch (MamaStatus mamaStatus)
+    {
+        EXPECT_EQ ( mamaStatus.getStatus(), MAMA_STATUS_INVALID_ARG );
+        return;
+    }
+
+    // If we get here there is a problem as this scenario should throw an exception
+    ASSERT_TRUE(0);
+}
+

--- a/mama/dotnet/src/cs/MamaMsg.cs
+++ b/mama/dotnet/src/cs/MamaMsg.cs
@@ -625,21 +625,22 @@ namespace Wombat
             
             return result;
         }
+
 		private ulong convertToMamaDateTime (DateTime val)
 		{
-			ulong dateTimeMsec = (ulong)((val.Ticks - 621355968000000000) / TimeSpan.TicksPerMillisecond);
+			double dateTimeSec = (((double)val.Ticks - 621355968000000000.0) / TimeSpan.TicksPerSecond);
 			ulong dateTime = 0;
-			int code = NativeMethods.mamaDateTime_setEpochTimeMilliseconds (ref dateTime, dateTimeMsec);
+			int code = NativeMethods.mamaDateTime_setEpochTimeF64 (ref dateTime, dateTimeSec);
 			CheckResultCode(code);
 			return dateTime;
 		}
 
 		private long convertFromMamaDateTime (ulong val)
 		{
-			ulong dateTimeMsec = 0;
-			int code = NativeMethods.mamaDateTime_getEpochTimeMilliseconds (ref val, ref dateTimeMsec);
+			double dateTimeSec = 0;
+			int code = NativeMethods.mamaDateTime_getEpochTimeSeconds (ref val, ref dateTimeSec);
 			CheckResultCode(code);
-			return ((long)dateTimeMsec * TimeSpan.TicksPerMillisecond) + 621355968000000000;
+			return (long)((dateTimeSec * (double)TimeSpan.TicksPerSecond) + 621355968000000000.0);
 		}
 
 		/// <summary>
@@ -4870,8 +4871,8 @@ namespace Wombat
 			bool throwOnError)
 		{
 			EnsurePeerCreated();
-			ulong dateTimeMsec = 0;
-			int code = NativeMethods.mamaMsg_getDateTimeMSec(nativeHandle, name, fid, ref dateTimeMsec);
+			double dateTimeSec = 0;
+			int code = NativeMethods.mamaMsg_getDateTimeSeconds(nativeHandle, name, fid, ref dateTimeSec);
 			if ((MamaStatus.mamaStatus)code != MamaStatus.mamaStatus.MAMA_STATUS_OK)
 			{
 				if (throwOnError)
@@ -4883,8 +4884,8 @@ namespace Wombat
 					return false;
 				}
 			}
-            
-            long ret = ((long)dateTimeMsec * TimeSpan.TicksPerMillisecond) + 621355968000000000;
+
+			long ret = (long)((dateTimeSec * (double)TimeSpan.TicksPerSecond) + 621355968000000000.0);
 			result = new DateTime(ret);
 			return true;
 		}
@@ -5617,6 +5618,11 @@ namespace Wombat
 				ushort fid,
 				ref ulong result);
             [DllImport(Mama.DllName, CallingConvention = CallingConvention.Cdecl)]
+			public static extern int mamaMsg_getDateTimeSeconds(IntPtr mamaMsg,
+				string name,
+				ushort fid,
+				ref double result);
+            [DllImport(Mama.DllName, CallingConvention = CallingConvention.Cdecl)]
 			public static extern int mamaMsg_getPrice(IntPtr mamaMsg,
 				string name,
 				ushort fid,
@@ -5759,8 +5765,14 @@ namespace Wombat
 			public static extern int mamaDateTime_setEpochTimeMilliseconds(ref ulong dateTime,
 				ulong milliseconds);
             [DllImport(Mama.DllName, CallingConvention = CallingConvention.Cdecl)]
+			public static extern int mamaDateTime_setEpochTimeF64(ref ulong dateTime,
+				double seconds);
+            [DllImport(Mama.DllName, CallingConvention = CallingConvention.Cdecl)]
 			public static extern int mamaDateTime_getEpochTimeMilliseconds(ref ulong dateTime,
 				ref ulong milliseconds);
+            [DllImport(Mama.DllName, CallingConvention = CallingConvention.Cdecl)]
+			public static extern int mamaDateTime_getEpochTimeSeconds(ref ulong dateTime,
+				ref double seconds);
             [DllImport(Mama.DllName, CallingConvention = CallingConvention.Cdecl)]
 			public static extern int mamaPrice_create(ref IntPtr nativeHandle);
             [DllImport(Mama.DllName, CallingConvention = CallingConvention.Cdecl)]

--- a/mama/jni/src/c/mamadatetimejni.c
+++ b/mama/jni/src/c/mamadatetimejni.c
@@ -1248,37 +1248,6 @@ JNIEXPORT void JNICALL Java_com_wombat_mama_MamaDateTime_copy
 
 /*
  * Class:     com_wombat_mama_MamaDateTime
- * Method:    _setEpochTime
- * Signature: (JJS)V
- */
-JNIEXPORT void JNICALL Java_com_wombat_mama_MamaDateTime__1setEpochTime
-  (JNIEnv* env, jobject this, jlong seconds, jlong microseconds, jshort precision)
-{
-    jlong       pDateTime   = 0;
-    mama_status status      = MAMA_STATUS_OK;
-    char        errorString [UTILS_MAX_ERROR_STRING_LENGTH]; 
-    
-    pDateTime = (*env)->GetLongField(env,this,dateTimePointerFieldId_g);
-    MAMA_THROW_NULL_PARAMETER_RETURN_VOID(pDateTime,  
-		"Null parameter, MamaDateTime may have already been destroyed.") ;
-    
-    if(MAMA_STATUS_OK!=(status=mamaDateTime_setEpochTime(
-                            CAST_JLONG_TO_POINTER (mamaDateTime,pDateTime), 
-                            (mama_u32_t) seconds, 
-                            (mama_u32_t) microseconds, 
-                            (mamaDateTimePrecision) precision)))
-    {
-         utils_buildErrorStringForStatus(
-                errorString,
-                UTILS_MAX_ERROR_STRING_LENGTH,
-                "Error calling MamaDateTime.setEpochTime().",
-                status);
-        utils_throwExceptionForMamaStatus(env,status,errorString);
-    }
-}
-
-/*
- * Class:     com_wombat_mama_MamaDateTime
  * Method:    _setPrecision
  * Signature: (S)V
  */
@@ -1444,6 +1413,54 @@ JNIEXPORT void JNICALL Java_com_wombat_mama_MamaDateTime__1setTime (JNIEnv* env,
         utils_throwExceptionForMamaStatus(env,status,errorString);
     }
 }  
+
+/*
+ * Class:     com_wombat_mama_MamaDateTime
+ * Method:    _setFromStructTimeVal
+ * Signature: (JJS)V
+ */
+JNIEXPORT void JNICALL Java_com_wombat_mama_MamaDateTime__1setFromStructTimeVal (JNIEnv* env, jobject this,
+                                                    jlong second, jlong microsecond, jshort precision)
+{
+    jlong               pDateTime   = 0;
+    jlong               pTimeZone   = 0;
+    mama_status         status      = MAMA_STATUS_OK;
+    char                errorString [UTILS_MAX_ERROR_STRING_LENGTH];
+    struct timeval      aTimeVal;
+
+    pDateTime = (*env)->GetLongField (env,this,dateTimePointerFieldId_g);
+    MAMA_THROW_NULL_PARAMETER_RETURN_VOID(pDateTime,
+		"Null parameter, MamaDateTime may have already been destroyed.") ;
+
+    /* Build the timeval as its is not natively available in Java */
+    aTimeVal.tv_sec = (time_t)second;
+    aTimeVal.tv_usec = (long)microsecond;
+
+    if (MAMA_STATUS_OK!=(status=mamaDateTime_setFromStructTimeVal(
+                            CAST_JLONG_TO_POINTER (mamaDateTime,pDateTime),
+                            &aTimeVal)))
+    {
+         utils_buildErrorStringForStatus(
+                errorString,
+                UTILS_MAX_ERROR_STRING_LENGTH,
+                "Error calling mamaDateTime_setFromStructTimeVal().",
+                status);
+        utils_throwExceptionForMamaStatus(env,status,errorString);
+    }
+
+    /* Now set the percision */
+    if(MAMA_STATUS_OK!=(status=mamaDateTime_setPrecision(
+                            CAST_JLONG_TO_POINTER (mamaDateTime,pDateTime),
+                            (mamaDateTimePrecision) precision)))
+    {
+         utils_buildErrorStringForStatus(
+                errorString,
+                UTILS_MAX_ERROR_STRING_LENGTH,
+                "Error calling mamaDateTime_setPrecision().",
+                status);
+        utils_throwExceptionForMamaStatus(env,status,errorString);
+    }
+}
 
 /*
  * Class:     com_wombat_mama_MamaDateTime

--- a/mama/jni/src/com/wombat/mama/MamaDateTime.java
+++ b/mama/jni/src/com/wombat/mama/MamaDateTime.java
@@ -140,13 +140,13 @@ public class MamaDateTime implements Comparable
                               long                  microseconds,
                               MamaDateTimePrecision precision)
     {
-        _setEpochTime (secondsSinceEpoch, microseconds, precision.getShortValue());                                  
+        _setFromStructTimeVal (secondsSinceEpoch, microseconds, precision.getShortValue());
     }
 
     public void setEpochTime (long secondsSinceEpoch,
                               long microseconds)
     {
-        _setEpochTime (secondsSinceEpoch, microseconds, MamaDateTimePrecision.PREC_UNKNOWN.getShortValue());
+        _setFromStructTimeVal (secondsSinceEpoch, microseconds, MamaDateTimePrecision.PREC_UNKNOWN.getShortValue());
     }
 
 
@@ -164,7 +164,7 @@ public class MamaDateTime implements Comparable
         /**
          * This is not actually implemented in C/C++. The hints field is ignored.
          */
-        _setEpochTime (secondsSinceEpoch, microseconds, precision.getShortValue());
+        _setFromStructTimeVal (secondsSinceEpoch, microseconds, precision.getShortValue());
     }
 
     void setPrecision (MamaDateTimePrecision precision) 
@@ -333,15 +333,11 @@ public class MamaDateTime implements Comparable
     }
 
     public native void destroy ();
-    
-    private native void _create ();  
-    
-    public native void copy (MamaDateTime copy); 
-    
-    private native void _setEpochTime (long secondsSinceEpoch, 
-                                       long microseconds, 
-                                       short precision);
-    
+
+    private native void _create ();
+
+    public native void copy (MamaDateTime copy);
+
     private native void _setPrecision (short precision);
     
     private native int  _getPrecision ();
@@ -357,8 +353,12 @@ public class MamaDateTime implements Comparable
                                   long microsecond,
                                   short precision,
                                   String tz);
-                                  
-  
+
+    private native void _setFromStructTimeVal (long second,
+                                               long microsecond,
+                                               short precision);
+
+
     private native short _getDayOfWeek();
     
     private native long _getEpochTimeMicroseconds (String tz);

--- a/mama/jni/src/junittests/MamaDateTimeSetTimeZone.java
+++ b/mama/jni/src/junittests/MamaDateTimeSetTimeZone.java
@@ -95,5 +95,144 @@ public class MamaDateTimeSetTimeZone extends TestCase
         String time = mDateTime.getTimeAsString();
         assertEquals(time, "03:16:42.000099");
     }
+
+    public void testSetEpochTimeLargePositive()
+    {
+        mDateTime.setEpochTime (4211753600L, 0, MamaDateTimePrecision.PREC_UNKNOWN);
+
+        double timeDouble = mDateTime.getEpochTimeSeconds();
+        assertEquals (4211753600.0, timeDouble);
+
+        long timeus = mDateTime.getEpochTimeMicroseconds();
+        assertEquals (4211753600000000L, timeus);
+        long timems = mDateTime.getEpochTimeMilliseconds();
+        assertEquals (4211753600000L, timems);
+    }
+
+
+    public void testSetEpochTimeLargePositiveWithMSec()
+    {
+        mDateTime.setEpochTime (4211753600L, 999999, MamaDateTimePrecision.PREC_UNKNOWN);
+
+        double timeDouble = mDateTime.getEpochTimeSeconds();
+        assertEquals (4211753600.999999, timeDouble);
+
+        long timeus = mDateTime.getEpochTimeMicroseconds();
+        assertEquals (4211753600999999L, timeus);
+        long timems = mDateTime.getEpochTimeMilliseconds();
+        assertEquals (4211753600999L, timems);
+    }
+
+    public void testSetEpochTimeLargeNegative()
+    {
+        mDateTime.setEpochTime (-4211753600L, 0, MamaDateTimePrecision.PREC_UNKNOWN);
+
+        double timeDouble = mDateTime.getEpochTimeSeconds();
+        assertEquals (-4211753600.0, timeDouble);
+
+        long timeus = mDateTime.getEpochTimeMicroseconds();
+        assertEquals (-4211753600000000L, timeus);
+        long timems = mDateTime.getEpochTimeMilliseconds();
+        assertEquals (-4211753600000L, timems);
+    }
+
+
+    public void testSetEpochTimeLargeNegativeWithMSec()
+    {
+        mDateTime.setEpochTime (-4211753600L, 999999, MamaDateTimePrecision.PREC_UNKNOWN);
+
+        double timeDouble = mDateTime.getEpochTimeSeconds();
+        assertEquals (-4211753599.000001, timeDouble);
+
+        long timeus = mDateTime.getEpochTimeMicroseconds();
+        assertEquals (-4211753599000001L, timeus);
+    }
+
+    public void testSetEpochTimeNegativeExtreme()
+    {
+        // This test will use the largest number that can be represented as microseconds
+        mDateTime.setEpochTime (-9223372036854L, 0, MamaDateTimePrecision.PREC_UNKNOWN);
+
+        double timeDouble = mDateTime.getEpochTimeSeconds();
+        assertEquals (-9223372036854.0, timeDouble);
+
+        long timeus = mDateTime.getEpochTimeMicroseconds();
+        assertEquals (-9223372036854000000L, timeus);
+        long timems = mDateTime.getEpochTimeMilliseconds();
+        assertEquals (-9223372036854000L, timems);
+    }
+
+
+    public void testSetEpochTimeNegativeExtremeWithMSec()
+    {
+        // This test will use the largest number that can be represented as microseconds
+        mDateTime.setEpochTime (-9223372036854L, 999999, MamaDateTimePrecision.PREC_UNKNOWN);
+
+        double timeDouble = mDateTime.getEpochTimeSeconds();
+        assertEquals (-9223372036853.000001, timeDouble);
+
+        long timeus = mDateTime.getEpochTimeMicroseconds();
+        assertEquals (-9223372036853000001L, timeus);
+        long timems = mDateTime.getEpochTimeMilliseconds();
+        assertEquals (-9223372036853001L, timems);
+    }
+
+    public void testSetEpochTime()
+    {
+        mDateTime.setEpochTime (123456, 12, MamaDateTimePrecision.PREC_UNKNOWN);
+
+        double timeDouble = mDateTime.getEpochTimeSeconds();
+        assertEquals (123456.000012, timeDouble);
+
+        long timeus = mDateTime.getEpochTimeMicroseconds();
+        assertEquals (123456000012L, timeus);
+    }
+
+
+    public void testSetEpochTimeBigMicroSecond()
+    {
+        mDateTime.setEpochTime (123456, 999999, MamaDateTimePrecision.PREC_UNKNOWN);
+
+        double timeDouble = mDateTime.getEpochTimeSeconds();
+        assertEquals (123456.999999, timeDouble);
+
+        long timeus = mDateTime.getEpochTimeMicroseconds();
+        assertEquals (123456999999L, timeus);
+    }
+
+    public void testSetEpochTimeNegativeMicroSecond()
+    {
+        mDateTime.setEpochTime (123456, -123456, MamaDateTimePrecision.PREC_UNKNOWN);
+
+        double timeDouble = mDateTime.getEpochTimeSeconds();
+        assertEquals (123455.876544, timeDouble);
+
+        long timeus = mDateTime.getEpochTimeMicroseconds();
+        assertEquals (123455876544L, timeus);
+    }
+
+    public void testSetWithHints()
+    {
+        // The hints are never used.
+        mDateTime.setWithHints (123456, 12, MamaDateTimePrecision.PREC_UNKNOWN, null);
+
+        double timeDouble = mDateTime.getEpochTimeSeconds();
+        assertEquals (123456.000012, timeDouble);
+
+        long timeus = mDateTime.getEpochTimeMicroseconds();
+        assertEquals (123456000012L, timeus);
+    }
+
+    public void testSetWithHintsWithMSec()
+    {
+        // The hints are never used.
+        mDateTime.setWithHints (123456, 999999, MamaDateTimePrecision.PREC_UNKNOWN, null);
+
+        double timeDouble = mDateTime.getEpochTimeSeconds();
+        assertEquals (123456.999999, timeDouble);
+
+        long timeus = mDateTime.getEpochTimeMicroseconds();
+        assertEquals (123456999999L, timeus);
+    }
 }
 


### PR DESCRIPTION
# Extended MAMA Date Time
## Summary
This change will allow you to extend a mamaDateTime to beyond the current limitation.

## Areas Affected
- [x] MAMAC
- [x] MAMACPP
- [x] MAMADOTNET
- [x] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [x] Unit Tests
- [ ] Examples

## Details
The mamaDateTime API was limited to representing data ranges between 1970
and 2106 due to its underlying data structure and several of its methods
which use an unsigned 32 bit integer to represent seconds since the epoch.

The structure of the mamaDateTime type has now been changed so that it can
store date ranges from -2^63 seconds before the epoch to 2^63-1 seconds
after the epoch, allowing it to represent dates far before and after the
current date ranges.

In addition, where necessary new functions have been added or the
implementation of existing functions modified in order to allow dates in
the extended ranges to be set and retrieved.

All other mamaDateTime functions will continue to work as they did
previously, but are not guaranteed to be able to represent dates beyond 2106.


C changes:

A new C function has been added that will allow you to store a date via a
struct timeval, mamaDateTime_setFromStructTimeVal(), and when used with the
existing function mamaDateTime_getStructTimeVal() will allow extended date
ranges to be set and retrieved.

Existing get functions that return a mama_u32_t will now return a
mama_status of MAMA_STATUS_INVALID_ARGS when attempting to return a date
outside of its current date range.

CPP changes:

A new overloaded set function has been added which takes a struct timeval
as an argument.  When used with the existing getAsStructTm() functions will
allow extended date ranges to be set and retrieved.

Java changes:

The functions MamaDateTime.setEpochTime(), and setWithHints() which accept
long values for seconds and microseconds now allow extended date ranges to
be set on the MamaDateTime.getEpochTimeSeconds() can be used to retrieve
extended date ranges.

C# changes:

Updates to the existing functions with MamaMsg to convertToMamaDateTime(),
convertFromMamaDateTime() and tryDateTimeImpl() so that we can use doubles for
getting and setting extended date ranges.


## Testing
Several new unitests have been added for c/cpp/dotnet that will cover the changes
