### PR TITLE
COMMON: Made version string parsing more robust

### DIFF
--- a/common/c_cpp/src/c/strutils.c
+++ b/common/c_cpp/src/c/strutils.c
@@ -566,11 +566,19 @@ int strToVersionInfo(const char* s, versionInfo* version)
     int         j         = 0;
     int         retVal    = 0;
     char        copy[VERSION_INFO_STR_MAX];
+    char*       verStart  = NULL;
+    size_t      verStrLen = 0;
+
+    if (NULL == version)
+    {
+        return retVal;
+    }
 
     /* Zero set version so all versions are guaranteed NULL */
     memset (version, 0, sizeof(versionInfo));
 
-    if (strlenEx(s) == 0 || strlenEx(s) > VERSION_INFO_STR_MAX)
+    verStrLen = strlenEx(s);
+    if (verStrLen == 0 || verStrLen > VERSION_INFO_STR_MAX)
     {
         return retVal;
     }
@@ -578,9 +586,23 @@ int strToVersionInfo(const char* s, versionInfo* version)
     /* Operate on copy of input as we want to get destructive */
     strcpy (copy, s);
 
+    /* Skip past any non-numeric values at the start */
+    for (i = 0; i < verStrLen; i++)
+    {
+        if (isdigit(copy[i]))
+        {
+            verStart = copy + i;
+            break;
+        }
+    }
+    /* If no numeric information was found, exit */
+    if (NULL == verStart)
+    {
+        return retVal;
+    }
 
     /* Only iterate 3 times for major / minor / release while tokens exist */
-    token = strtok((char*)copy, delim);
+    token = strtok((char*)verStart, delim);
     for (i = 0; i < 3; i++)
     {
         /* There are no more tokens - break out */

--- a/common/c_cpp/src/gunittest/c/utiltest.cpp
+++ b/common/c_cpp/src/gunittest/c/utiltest.cpp
@@ -23,6 +23,7 @@
 #include <gtest/gtest.h>
 #include "MainUnitTestC.h"
 #include <wombat/fileutils.h>
+#include <wombat/strutils.h>
 #include <wombat/environment.h>
 #include <stdio.h>
 
@@ -84,3 +85,52 @@ TEST_F(CommonUtilTestC, findFileInPathNotExist)
             environment_getVariable("WOMBAT_PATH"),
             NULL));
 }
+
+TEST_F(CommonUtilTestC, getVerInfoFromString)
+{
+    versionInfo v;
+    EXPECT_EQ(1, strToVersionInfo("1.2.3extra", &v));
+    EXPECT_EQ(1, v.mMajor);
+    EXPECT_EQ(2, v.mMinor);
+    EXPECT_EQ(3, v.mRelease);
+    EXPECT_STREQ("extra", v.mExtra);
+}
+
+TEST_F(CommonUtilTestC, getVersionInfoFromInvalidString)
+{
+    versionInfo v;
+    EXPECT_EQ(0, strToVersionInfo("stringwithnonumbers", &v));
+}
+
+TEST_F(CommonUtilTestC, getVersionInfoFromNullString)
+{
+    versionInfo v;
+    EXPECT_EQ(0, strToVersionInfo(NULL, &v));
+}
+
+TEST_F(CommonUtilTestC, getVersionInfoFromNullVersion)
+{
+    EXPECT_EQ(0, strToVersionInfo("1.2.3", NULL));
+}
+
+TEST_F(CommonUtilTestC, getVersionInfoFromPrefixedString)
+{
+    versionInfo v;
+    EXPECT_EQ(1, strToVersionInfo("somestuff1.2.3extra", &v));
+    EXPECT_EQ(1, v.mMajor);
+    EXPECT_EQ(2, v.mMinor);
+    EXPECT_EQ(3, v.mRelease);
+    EXPECT_STREQ("extra", v.mExtra);
+
+}
+
+TEST_F(CommonUtilTestC, getVersionInfoFromSuffixedString)
+{
+    versionInfo v;
+    EXPECT_EQ(1, strToVersionInfo("1.2.3extra but. not this", &v));
+    EXPECT_EQ(1, v.mMajor);
+    EXPECT_EQ(2, v.mMinor);
+    EXPECT_EQ(3, v.mRelease);
+    EXPECT_STREQ("extra but", v.mExtra);
+}
+


### PR DESCRIPTION
The version parsing wasn't resilient to things like versions being
mid-string. These changes makes the function much more robust and
adds some argument validation and unit tests to cover this.

Signed-off-by: Frank Quinn <fquinn.ni@gmail.com>