### PR TITLE
Expose Middleware and Payload Accessors

### DIFF
--- a/mama/c_cpp/src/c/mama/mama.h
+++ b/mama/c_cpp/src/c/mama/mama.h
@@ -665,6 +665,33 @@ extern "C"
     extern mama_status
     mama_removeStatsCollector (mamaStatsCollector  statsCollector);
 
+    /** 
+     * Get Middleware Bridge by middleware name
+     *
+     * @param bridge Pointer to a mamaBridge object.
+     * @param middlewareName String denoting the middleware to return
+     * @return mama_status MAMA_STATUS_OK if successful. 
+     *                     MAMA_STATUS_NULL_ARG if one of the arguments is NULL.
+     *                     MAMA_STATUS_NOT_FOUND if no bridge available.
+     */
+    MAMAExpDLL
+    extern mama_status
+    mama_getMiddlewareBridge (mamaBridge *bridge, const char *middlewareName);
+
+    /**
+     * Get Payload bridge by payload name
+     * 
+     * @param payloadBridge Pointer to the mamaPayloadBridge object.
+     * @param payloadName String denoting the payload to return
+     * @return mama_status MAMA_STATUS_OK if successful
+     *                     MAMA_STATUS_NULL_ARG if one of the arguments is NULL.
+     *                     MAMA_STATUS_NOT_FOUND if no payload available.
+     */
+    MAMAExpDLL
+    extern mama_status
+    mama_getPayloadBridge (mamaPayloadBridge *payloadBridge,
+                           const char        *payloadName);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/mama/c_cpp/src/cpp/mama/mamacpp.h
+++ b/mama/c_cpp/src/cpp/mama/mamacpp.h
@@ -192,7 +192,6 @@ public:
      * "tibrv".
      * @return mama_status Whether the call was successful or not.
      */
-
     static mamaBridge loadBridge (const char* middleware);
 
 
@@ -205,8 +204,19 @@ public:
      * @param path The path to the bridge library
      * @return mama_status Whether the call was successful or not.
      */
-
     static mamaBridge loadBridge (const char* middleware, const char* path);
+    
+    /** Load the payload bridge specified by payload string.
+     * 
+     * If the bridge has already been loaded then the existing bridge instance
+     * will be returned.
+     * 
+     * @param payload The payload to be loaded.
+     * 
+     * @return mamaPayloadBridge The payload bridge loaded.
+     */
+    static mamaPayloadBridge loadPayloadBridge (const char* payload);
+
     /**
      * Returns the version of the mama binary. The version of the underlying
      * transport is also returned in parens after the mama version.

--- a/mama/c_cpp/src/cpp/mama/mamacpp.h
+++ b/mama/c_cpp/src/cpp/mama/mamacpp.h
@@ -217,6 +217,24 @@ public:
      */
     static mamaPayloadBridge loadPayloadBridge (const char* payload);
 
+    /** Return a middleware bridge which matches the middleware string.
+     * 
+     * @param middleware The middleware to be returned
+     *
+     * @return mamaBridge The middleware bridge to be returned. Returns NULL
+     * if none available.
+     */
+    static mamaBridge getMiddlewareBridge (const char* middleware);
+
+    /** Return a payload bridge which matches the payload string.
+     * 
+     * @param payload The payload to be returned
+     *
+     * @return mamaBridge The payload bridge to be returned. Returns NULL
+     * if none available.
+     */
+    static mamaPayloadBridge getPayloadBridge (const char* payload);
+
     /**
      * Returns the version of the mama binary. The version of the underlying
      * transport is also returned in parens after the mama version.

--- a/mama/c_cpp/src/cpp/mamacpp.cpp
+++ b/mama/c_cpp/src/cpp/mamacpp.cpp
@@ -66,6 +66,59 @@ namespace Wombat
         return (payloadBridge);
     }
 
+    /** Return a middleware bridge which matches the middleware string.
+     * 
+     * @param middleware The middleware to be returned
+     *
+     * @return mamaBridge The middleware bridge to be returned. Returns NULL
+     * if none available. 
+     */
+    mamaBridge Mama::getMiddlewareBridge (const char* middleware)
+    {
+        mamaBridge bridge = NULL;
+        mama_status status = MAMA_STATUS_OK; 
+
+        if (NULL == middleware)
+        {
+            return bridge;
+        }
+
+        /* We could check the status here, but we know the bridge and
+         * middleware can't be NULL. Clients can infer that a bridge isn't
+         * available from a NULL return.
+         */
+        status = mama_getMiddlewareBridge (&bridge, middleware);
+        
+        return bridge;
+    }
+
+    /** Return a payload bridge which matches the payload string.
+     * 
+     * @param payload The payload to be returned
+     *
+     * @return mamaBridge The payload bridge to be returned. Returns NULL
+     * if none available. 
+     */
+    mamaPayloadBridge Mama::getPayloadBridge (const char* payload)
+    {
+        mamaPayloadBridge payloadBridge = NULL;
+        mama_status       status = MAMA_STATUS_OK;
+
+        if (NULL == payload)
+        {
+            return payloadBridge;
+        }
+
+        /* We could check the status here, but we know the bridge and
+         * payload can't be NULL. Clients can infer that a bridge isn't
+         * available from a NULL return.
+         */
+        status = mama_getPayloadBridge (&payloadBridge, payload);
+
+        return payloadBridge;
+    }
+
+
     void Mama::open ()
     {
         openCount (NULL, NULL);

--- a/mama/c_cpp/src/cpp/mamacpp.cpp
+++ b/mama/c_cpp/src/cpp/mamacpp.cpp
@@ -59,6 +59,13 @@ namespace Wombat
         return (bridge);
     }
 
+    mamaPayloadBridge Mama::loadPayloadBridge (const char* payload)
+    {
+        mamaPayloadBridge payloadBridge = NULL;
+        mamaTry (mama_loadPayloadBridge (&payloadBridge, payload));
+        return (payloadBridge);
+    }
+
     void Mama::open ()
     {
         openCount (NULL, NULL);

--- a/mama/c_cpp/src/gunittest/c/openclosetest.cpp
+++ b/mama/c_cpp/src/gunittest/c/openclosetest.cpp
@@ -178,3 +178,106 @@ TEST_F (MamaOpenCloseTestC, StartStopDifferentThreads)
     ASSERT_EQ (MAMA_STATUS_OK, mama_close());
 }
 
+/* Description:     Load the middleware bridge, search for the same bridge.  
+ */
+TEST_F (MamaOpenCloseTestC, GetBridge)
+{
+    mamaBridge bridge;
+    mamaBridge foundBridge;
+
+    ASSERT_EQ (MAMA_STATUS_OK, mama_loadBridge (&bridge, getMiddleware ()));
+
+    ASSERT_EQ (MAMA_STATUS_OK, mama_getMiddlewareBridge (&foundBridge, getMiddleware ()));
+    ASSERT_EQ (bridge, foundBridge);
+    ASSERT_TRUE (NULL != foundBridge);
+}
+
+/* Description:     Load the middleware bridge, search for a different bridge.  
+ */
+TEST_F (MamaOpenCloseTestC, GetNotFoundBridge)
+{
+    mamaBridge bridge;
+    mamaBridge foundBridge;
+
+    ASSERT_EQ (MAMA_STATUS_OK, mama_loadBridge (&bridge, getMiddleware ()));
+
+    /* Using "pizza"" as an example, in case someone decides "test" is a good name. */
+    ASSERT_EQ (MAMA_STATUS_NOT_FOUND, mama_getMiddlewareBridge (&foundBridge, "pizza"));
+    ASSERT_NE (bridge, foundBridge);
+    ASSERT_TRUE (NULL == foundBridge);
+}
+
+/* Description:     Load the middleware bridge, pass a NULL bridge.  
+ */
+TEST_F (MamaOpenCloseTestC, GetNullBridge)
+{
+    mamaBridge bridge;
+
+    ASSERT_EQ (MAMA_STATUS_OK, mama_loadBridge (&bridge, getMiddleware ()));
+
+    ASSERT_EQ (MAMA_STATUS_NULL_ARG, mama_getMiddlewareBridge (NULL, getMiddleware ()));
+}
+
+/* Description:     Load the middleware bridge, search for a different bridge.  
+ */
+TEST_F (MamaOpenCloseTestC, GetNullBridgeName)
+{
+    mamaBridge bridge;
+    mamaBridge foundBridge;
+
+    ASSERT_EQ (MAMA_STATUS_OK, mama_loadBridge (&bridge, getMiddleware ()));
+
+    ASSERT_EQ (MAMA_STATUS_NULL_ARG, mama_getMiddlewareBridge (&foundBridge, NULL));
+}
+
+/* Description:     Load the payload bridge, search for the same bridge.
+ */
+TEST_F (MamaOpenCloseTestC, GetPayload)
+{
+    mamaPayloadBridge bridge;
+    mamaPayloadBridge foundBridge;
+
+    ASSERT_EQ (MAMA_STATUS_OK, mama_loadPayloadBridge (&bridge, getPayload ()));
+
+    ASSERT_EQ (MAMA_STATUS_OK, mama_getPayloadBridge (&foundBridge, getPayload ()));
+    ASSERT_EQ (bridge, foundBridge);
+    ASSERT_TRUE (NULL   != foundBridge);
+}
+
+/* Description:     Load the payload bridge, search for the same bridge.
+ */
+TEST_F (MamaOpenCloseTestC, GetNotFoundPayload)
+{
+    mamaPayloadBridge bridge;
+    mamaPayloadBridge foundBridge;
+
+    ASSERT_EQ (MAMA_STATUS_OK, mama_loadPayloadBridge (&bridge, getPayload ()));
+
+    /* Use "pizza" in case someone decides to use a "test" payload */ 
+    ASSERT_EQ (MAMA_STATUS_NOT_FOUND, mama_getPayloadBridge (&foundBridge, "pizza"));
+    ASSERT_NE (bridge, foundBridge);
+    ASSERT_TRUE (NULL   == foundBridge);
+}
+
+/* Description:     Load the payload bridge, pass a NULL bridge.  
+ */
+TEST_F (MamaOpenCloseTestC, GetNullPayload)
+{
+    mamaPayloadBridge bridge;
+
+    ASSERT_EQ (MAMA_STATUS_OK, mama_loadPayloadBridge (&bridge, getPayload ()));
+
+    ASSERT_EQ (MAMA_STATUS_NULL_ARG, mama_getPayloadBridge (NULL, getPayload ()));
+}
+
+/* Description:     Load the payload bridge, pass a null bridge name.  
+ */
+TEST_F (MamaOpenCloseTestC, GetNullPayloadBridge)
+{
+    mamaPayloadBridge bridge;
+    mamaPayloadBridge foundBridge;
+
+    ASSERT_EQ (MAMA_STATUS_OK, mama_loadPayloadBridge (&bridge, getPayload ()));
+
+    ASSERT_EQ (MAMA_STATUS_NULL_ARG, mama_getPayloadBridge (&foundBridge, NULL));
+}

--- a/mama/c_cpp/src/gunittest/cpp/MainUnitTestCpp.cpp
+++ b/mama/c_cpp/src/gunittest/cpp/MainUnitTestCpp.cpp
@@ -43,6 +43,7 @@ static const char*  gTransport = "test_tport";
 static const char*  gSource = "SRC";
 static const char*  gSymbol = "SYM";
 static const char*  gBadSource = "BADSRC";
+static const char*  gPayload = "wmsg";
 
 const char* getMiddleware (void) { return gMiddleware; }
 const char* getTransport (void) { return gTransport; }
@@ -50,6 +51,7 @@ const char* getSource (void) { return gSource; }
 const char* getSymbol (void) { return gSymbol; }
 const char* getTopic (void) { return gSymbol; }
 const char* getBadSource (void) { return gBadSource; }
+const char* getPayload (void) { return gPayload; }
 
 static void parseCommandLine (int argc, char** argv)
 {
@@ -80,6 +82,11 @@ static void parseCommandLine (int argc, char** argv)
         else if (strcmp ("-s", argv[i]) == 0)
         {
             gSymbol = argv[i+1];
+            i += 2;
+        }
+        else if (strcmp ("-p", argv[i]) == 0)
+        {
+            gPayload = argv[i+1];
             i += 2;
         }
         else

--- a/mama/c_cpp/src/gunittest/cpp/MainUnitTestCpp.h
+++ b/mama/c_cpp/src/gunittest/cpp/MainUnitTestCpp.h
@@ -23,6 +23,7 @@
 
 
 const char* getMiddleware(void);
+const char* getPayload(void);
 const char* getTransport(void);
 const char* getSource(void);
 const char* getSymbol(void);

--- a/mama/c_cpp/src/gunittest/cpp/MamaOpenCloseTest.cpp
+++ b/mama/c_cpp/src/gunittest/cpp/MamaOpenCloseTest.cpp
@@ -175,3 +175,49 @@ TEST_F(MamaOpenCloseTest, LoadPayloadBridge)
 
     ASSERT_TRUE (NULL != payload);
 }
+
+TEST_F(MamaOpenCloseTest, GetMiddlewareBridge)
+{
+    mamaBridge bridge      = NULL;
+    mamaBridge foundBridge = NULL;
+
+    bridge      = Mama::loadBridge (getMiddleware ());
+    foundBridge = Mama::getMiddlewareBridge (getMiddleware ());
+
+    ASSERT_EQ(bridge, foundBridge);
+}
+
+TEST_F(MamaOpenCloseTest, GetNoMiddlewareBridge)
+{
+    mamaBridge bridge      = NULL;
+    mamaBridge foundBridge = NULL;
+
+    bridge      = Mama::loadBridge (getMiddleware ());
+    foundBridge = Mama::getMiddlewareBridge ("pizza");
+
+    ASSERT_NE(bridge, foundBridge);
+    ASSERT_TRUE(NULL == foundBridge);
+}
+
+TEST_F(MamaOpenCloseTest, GetPayloadBridge)
+{
+    mamaPayloadBridge bridge      = NULL;
+    mamaPayloadBridge foundBridge = NULL;
+
+    bridge      = Mama::loadPayloadBridge (getPayload ());
+    foundBridge = Mama::getPayloadBridge (getPayload ());
+
+    ASSERT_EQ(bridge, foundBridge);
+}
+
+TEST_F(MamaOpenCloseTest, GetNoPayloadBridge)
+{
+    mamaPayloadBridge bridge      = NULL;
+    mamaPayloadBridge foundBridge = NULL;
+
+    bridge      = Mama::loadPayloadBridge (getPayload ());
+    foundBridge = Mama::getPayloadBridge ("pizza");
+
+    ASSERT_NE(bridge, foundBridge);
+    ASSERT_TRUE(NULL == foundBridge);
+}

--- a/mama/c_cpp/src/gunittest/cpp/MamaOpenCloseTest.cpp
+++ b/mama/c_cpp/src/gunittest/cpp/MamaOpenCloseTest.cpp
@@ -168,3 +168,10 @@ TEST_F(MamaOpenCloseTest, StartStopDifferentThreads)
     // Cleanup
     delete startBackgroundCB;
 }
+
+TEST_F(MamaOpenCloseTest, LoadPayloadBridge)
+{
+    mamaPayloadBridge payload = Mama::loadPayloadBridge(getPayload ());
+
+    ASSERT_TRUE (NULL != payload);
+}


### PR DESCRIPTION
# Expose Middleware and Payload bridge accessors
## Summary
Exposing new accessors to find middleware and payload bridges which have already been loaded. 

## Areas Affected
*Place an 'x' within the braces to check the box*
- [X] MAMAC
- [X] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [X] Unit Tests
- [ ] Examples

## Details
Changes are relatively simple - adding new get*Bridge accessors to both C and C++, as well as exposing the loadPayloadBridge C++ method. 

## Testing
New unit tests added to both C and C++ layers. 