### PR TITLE
[GENERAL] Add .clang-format to OpenMAMA root directory

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,15 @@
+﻿---
+BasedOnStyle: LLVM
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: 'true'
+AlignConsecutiveDeclarations: 'true'
+AlignOperands: 'true'
+BinPackArguments: 'false'
+BinPackParameters: 'false'
+BreakBeforeBraces: Linux
+ColumnLimit: '80'
+IndentWidth: 4
+ReflowComments: 'true'
+SpaceBeforeParens: Always
+SpaceInEmptyParentheses: 'true'
+SpacesInSquareBrackets: 'false'


### PR DESCRIPTION
# Add a .clang-format file to OpenMAMA 
## Summary
Add a .clang-format file which is a close approximation to the OpenMAMA
coding standard. Based on the LLVM core style, with additional changes.

Can be used by either the clang-format tool, vim plugins, or Visual
Studio code for formatting OpenMAMA src files.

## Areas Affected
*Place an 'x' within the braces to check the box*
- [X] General

