### PR TITLE
MAMA: Cleanup ahead of OpenMAMA 6.2.0 cut

### DIFF
--- a/common/c_cpp/src/c/thread.c
+++ b/common/c_cpp/src/c/thread.c
@@ -123,6 +123,9 @@ wombatThread_destroy (const char* name)
 
     wthread_static_mutex_unlock(&gWombatThreadsMutex);
 
+    // Attempt to join the thread to ensure it has terminated
+    wthread_join (impl->mThread, NULL);
+
     if (impl)
     {
         free (impl->mThreadName);

--- a/mama/c_cpp/src/c/bridge.h
+++ b/mama/c_cpp/src/c/bridge.h
@@ -29,6 +29,7 @@
 #include "mamainternal.h"
 #include "conflation/manager_int.h"
 #include "wlock.h"
+#include <wombat/thread.h>
 
 #if defined(__cplusplus)
 extern "C" {
@@ -512,7 +513,7 @@ typedef struct mamaBridgeImpl_
     wLock     mLock;
 
     /* Track background thread for join if startBackground is used */
-    wthread_t mStartBackgroundThread;
+    wombatThread mStartBackgroundThread;
 
     /* The set of methods used to access/populate a message in native format */
     mamaPayloadBridge mNativeMsgBridge;

--- a/mama/c_cpp/src/c/mama.c
+++ b/mama/c_cpp/src/c/mama.c
@@ -1376,8 +1376,6 @@ mama_closeCount (unsigned int* count)
             if (middlewareLib && middlewareLib->bridge)
             {
                 mamaBridgeImpl_stopInternalEventQueue (middlewareLib->bridge);
-                snprintf (threadname, 256, "mama_%s_default", middlewareLib->bridge->bridgeGetName());
-                wombatThread_destroy (threadname);
             }
         }
 
@@ -1561,7 +1559,9 @@ mama_closeCount (unsigned int* count)
                     /* If there was a background thread, clean it up */
                     if (middlewareLib->bridge->mStartBackgroundThread)
                     {
-                        wthread_join (middlewareLib->bridge->mStartBackgroundThread, NULL);
+                        // Get name of start background thread and destroy it
+                        const char* threadName = wombatThread_getThreadName(middlewareLib->bridge->mStartBackgroundThread);
+                        wombatThread_destroy (threadName);
                     }
 
                     free (middlewareLib->bridge);
@@ -1705,8 +1705,9 @@ mama_startBackgroundHelper (mamaBridge   bridgeImpl,
                             void*        closure)
 {
     struct startBackgroundClosure*  closureData;
-    wombatThread        thread;
+    mamaBridgeImpl*     impl         = (mamaBridgeImpl*)bridgeImpl;
     wombatThreadStatus  threadStatus = WOMBAT_THREAD_OK;
+    wombatThread        thread;
     char                threadname[256];
 
     if (!bridgeImpl)
@@ -1743,7 +1744,7 @@ mama_startBackgroundHelper (mamaBridge   bridgeImpl,
     snprintf (threadname, 256, "mama_%s_default", bridgeImpl->bridgeGetName());
 
     threadStatus = wombatThread_create(threadname,
-                            &thread,
+                            &impl->mStartBackgroundThread,
                             NULL,
                             mamaStartThread,
                             (void*) closureData);

--- a/mama/c_cpp/src/cpp/datetime.cpp
+++ b/mama/c_cpp/src/cpp/datetime.cpp
@@ -458,9 +458,7 @@ namespace Wombat
 
     mama_u32_t MamaDateTime::getMicrosecond() const
     {
-        mama_status status = MAMA_STATUS_OK;
         mama_u32_t  result = 0;
-
         mamaTry (mamaDateTime_getMicrosecond (const_cast<const mamaDateTime>(mDateTime),
                                               &result));
 

--- a/mama/c_cpp/src/gunittest/c/mamadatetime/datetimetest.cpp
+++ b/mama/c_cpp/src/gunittest/c/mamadatetime/datetimetest.cpp
@@ -1402,8 +1402,7 @@ TEST_F (MamaDateTimeTestC, TestDiffMicrosecondsMixedValues)
     std::string szTime1 = "2013-07-04 10:03:21.123",
                 szTime2 = "2012-07-04 10:03:21.123";
 
-    mama_i64_t mics = 1000000, dd = UINT_MAX, hh = -24, mm = 60, ss = 60;
-    mama_i64_t act, expected =  dd * hh * mm * ss * mics;
+    mama_i64_t act;
 
     EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_create(&t1) );
     EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_create(&t2) );
@@ -1613,9 +1612,6 @@ TEST_F (MamaDateTimeTestC, TestGetStructTimeSpecExtended)
 {
     struct timespec         tVal1, tVal2;
     mamaDateTime            t           = NULL;
-    mama_u32_t              secs        = 0;
-    mama_u32_t              uSecs       = 0;
-    mamaDateTimePrecision   precision;
     time_t                  inSecs      = 75899345920;
     long                    inNSecs     = 123000000;
 
@@ -1640,9 +1636,6 @@ TEST_F (MamaDateTimeTestC, TestGetStructTimeSpecExtendedNegativeValues)
 {
     struct timespec         tVal1, tVal2;
     mamaDateTime            t           = NULL;
-    mama_u32_t              secs        = 0;
-    mama_u32_t              uSecs       = 0;
-    mamaDateTimePrecision   precision;
     char                    stringBuffer[50];
     const char*             expectedDate = "1969-12-31 23:59:55";
     time_t                  inSecs = -5;
@@ -1789,9 +1782,6 @@ TEST_F (MamaDateTimeTestC, GetAsFormattedStringWithTzTest)
     char         stringDate[100]       = "";
     const char*  time                  = "2013-07-04 10:03:21.123000";
     char         completeDateTime[100] = "";
-    mamaDateTime m_cDateTime           = NULL;
-    mama_f64_t   completeDateSeconds   = 0;
-    mama_f64_t   timeSeconds           = 0;
 
     /* Get todays date in a date time */
     EXPECT_EQ (MAMA_STATUS_OK, mamaDateTime_create (&t1));

--- a/mama/c_cpp/src/gunittest/c/payload/payloadgeneraltests.cpp
+++ b/mama/c_cpp/src/gunittest/c/payload/payloadgeneraltests.cpp
@@ -1992,7 +1992,7 @@ TEST_F(PayloadGeneralTests, IterAssociateTwiceValid)
     testField = aBridge->msgPayloadIterNext(testIter,testField,testPayload);
 
     result = aBridge->msgFieldPayloadGetFid(testField,NULL,NULL, &test_fid);
-    EXPECT_NE (pl1_fids.find(test_fid), pl1_fids.end());
+    EXPECT_FALSE (pl1_fids.find(test_fid) == pl1_fids.end());
 
     // reuse iterator with new payload
     result = aBridge->msgPayloadIterAssociate(testIter, testPayload2);
@@ -2007,7 +2007,7 @@ TEST_F(PayloadGeneralTests, IterAssociateTwiceValid)
     testField = aBridge->msgPayloadIterNext(testIter,testField,testPayload2); 
 
     result = aBridge->msgFieldPayloadGetFid(testField,NULL,NULL, &test_fid);
-    EXPECT_NE (pl2_fids.find(test_fid), pl2_fids.end());
+    EXPECT_FALSE (pl2_fids.find(test_fid) == pl2_fids.end());
 
     result = aBridge->msgPayloadIterDestroy(testIter);
     EXPECT_EQ (MAMA_STATUS_OK, result);

--- a/mama/c_cpp/src/gunittest/cpp/MamaDateTimeTest.cpp
+++ b/mama/c_cpp/src/gunittest/cpp/MamaDateTimeTest.cpp
@@ -192,7 +192,6 @@ TEST_F(MamaDateTimeTest, GetMicrosecondExtended)
     struct timeval      tVal;
     MamaDateTime        dt1;
     mama_u32_t          uSecs   = 0;
-    const MamaStatus&   status  = MAMA_STATUS_OK;
 
     /* The following timeval represents the time - "2106-02-07 06:28:16"
         But the microseconds will be 1 microsecond more than a uint32_t can hold */

--- a/mamda/c_cpp/src/cpp/orderbooks/MamdaOrderBookWriter.cpp
+++ b/mamda/c_cpp/src/cpp/orderbooks/MamdaOrderBookWriter.cpp
@@ -242,7 +242,7 @@ namespace Wombat
         msg.addI16 (NULL, MamdaOrderBookFields::NUM_LEVELS->getFid(),
                     (mama_i16_t)1);
 
-        if ((size_t)defaultNumAttachedEntries != entryCount)
+        if ((mama_i16_t)defaultNumAttachedEntries != entryCount)
         {
             msg.addI16 (NULL,
                         MamdaOrderBookFields::PL_NUM_ATTACH->getFid(),
@@ -375,7 +375,8 @@ namespace Wombat
 
             }
 
-            if (defaultNumAttachedEntries != entryCount)
+
+            if (defaultNumAttachedEntries != (int)entryCount)
                 plMsg.addI16 (NULL,
                             MamdaOrderBookFields::PL_NUM_ATTACH->getFid(),
                             (mama_i16_t) entryCount);


### PR DESCRIPTION
- Fixed shutdown memory leak in wombatThread on shutdown
- Fixed several compiler warnings which had crept in recently

Signed-off-by: Frank Quinn <fquinn.ni@gmail.com>