### PR TITLE
[PLAT-888] - New feature: process during conflation timer when there's an update with changes on the top of the book.

### DIFF
--- a/mamda/c_cpp/src/cpp/orderbooks/mamda/MamdaOrderBookListener.h
+++ b/mamda/c_cpp/src/cpp/orderbooks/mamda/MamdaOrderBookListener.h
@@ -240,6 +240,17 @@ namespace Wombat
         virtual void  setConflationInterval (double interval);
 
         /**
+         * Trigger callbacks for top of book price changes even when they
+         * would normally not be triggered due to happening inside a conflation
+         * interval. If a callback for a book update is triggered in this
+         * scenario, a new conflation interval will begin.
+         *
+         * @param flush Flush conflated updates when a top of book price
+         * change occurs.
+         */
+        virtual void flushConflationOnTopOfBookChange (bool flush);
+
+        /**
          * Invoke delta handlers immediately if there is a conflated delta
          * pending 
          */


### PR DESCRIPTION
# Process during conflation timer when there's an update with changes on the top of the book.
## Summary
New feature would trigger callbacks for top of book price changes even when they would normally not be triggered due to happening inside a conflation interval. If a callback for a book update is triggered in this scenario, a new conflation interval will begin.

## Areas Affected
*Place an 'x' within the braces to check the box*
- [ ] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [x] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Testing
For testing purposes I hacked bookticker mamda app to enable conflation and my new feature.
