### PR TITLE
Added support for onSuccess publisher events

### DIFF
--- a/mama/c_cpp/src/c/mama/publisher.h
+++ b/mama/c_cpp/src/c/mama/publisher.h
@@ -97,6 +97,12 @@ typedef void (MAMACALLTYPE *mama_publisherOnErrorCb) (
     const char*   info,
     void*         closure);
 
+typedef void (MAMACALLTYPE *mama_publisherOnSuccessCb) (
+    mamaPublisher publisher,
+    mama_status   status,
+    const char*   info,
+    void*         closure);
+
 /**
  * Callbacks for publisher events.
  * If any cb is NULL then the callback will not be made.
@@ -106,6 +112,7 @@ typedef struct mamaPublisherCallbacks
     mama_publisherOnCreateCb     onCreate;
     mama_publisherOnErrorCb      onError;
     mama_publisherOnDestroyCb    onDestroy;
+    mama_publisherOnSuccessCb    onSuccess;
 } mamaPublisherCallbacks;
 
 

--- a/mama/c_cpp/src/c/publisher.c
+++ b/mama/c_cpp/src/c/publisher.c
@@ -160,6 +160,7 @@ _createByIndex (mamaPublisher*              result,
     {
         impl->mUserCallbacks.onCreate = publisherCallbacks->onCreate;
         impl->mUserCallbacks.onError = publisherCallbacks->onError;
+        impl->mUserCallbacks.onSuccess = publisherCallbacks->onSuccess;
         impl->mUserCallbacks.onDestroy = publisherCallbacks->onDestroy;
     }
     impl->mQueue      = queue;
@@ -193,6 +194,7 @@ _createByIndex (mamaPublisher*              result,
     mamaPublisherCallbacks_allocate(&cb);
     cb->onCreate = publisherCallbacks ? impl->mUserCallbacks.onCreate : NULL;
     cb->onError = publisherCallbacks ? impl->mUserCallbacks.onError : NULL;
+    cb->onSuccess = publisherCallbacks ? impl->mUserCallbacks.onSuccess : NULL;
     cb->onDestroy = mamaPublisher_onPublisherDestroyed;        /* intercept onDestroy always to track state */
 
     if (NULL != bridgeImpl->bridgeMamaPublisherSetUserCallbacks)
@@ -751,6 +753,7 @@ mamaPublisher_getUserCallbacks (mamaPublisher publisher,
 
     cb->onCreate = impl->mUserCallbacks.onCreate;
     cb->onError = impl->mUserCallbacks.onError;
+    cb->onSuccess = impl->mUserCallbacks.onSuccess;
     cb->onDestroy = impl->mUserCallbacks.onDestroy;
 
     return MAMA_STATUS_OK;

--- a/mama/c_cpp/src/cpp/MamaPublisher.cpp
+++ b/mama/c_cpp/src/cpp/MamaPublisher.cpp
@@ -295,7 +295,8 @@ namespace Wombat
         {
            onPublisherCreate,
            onPublisherError,
-           onPublisherDestroy
+           onPublisherDestroy,
+           onPublisherSuccess
         };
 
         mamaTry (mamaPublisher_createWithCallbacks (&mPublisher,
@@ -480,15 +481,28 @@ namespace Wombat
    }
 
    void MAMACALLTYPE MamaPublisherImpl::onPublisherError (mamaPublisher publisher,
-                                                   mama_status status,
-                                                   const char* info,
-                                                   void*       closure)
+                                                          mama_status   status,
+                                                          const char*   info,
+                                                          void*         closure)
    {
        MamaPublisherImpl* i = (MamaPublisherImpl*) closure;
        if (NULL != i && NULL != i->mCallback)
        {
            MamaStatus cppstatus(status);
            i->mCallback->onError(i->mParent, cppstatus, info, i->mClosure);
+       }
+   }
+
+   void MAMACALLTYPE MamaPublisherImpl::onPublisherSuccess (mamaPublisher publisher,
+                                                            mama_status   status,
+                                                            const char*   info,
+                                                            void*         closure)
+    {
+       MamaPublisherImpl* i = (MamaPublisherImpl*)closure;
+       if (NULL != i && NULL != i->mCallback)
+       {
+           MamaStatus cppstatus(status);
+           i->mCallback->onSuccess(i->mParent, cppstatus, info, i->mClosure);
        }
    }
 

--- a/mama/c_cpp/src/cpp/MamaPublisherImpl.h
+++ b/mama/c_cpp/src/cpp/MamaPublisherImpl.h
@@ -102,9 +102,14 @@ namespace Wombat
                                                      void*         closure);
 
         static void MAMACALLTYPE onPublisherError (mamaPublisher publisher,
-                                                   mama_status status,
-                                                   const char* info,
-                                                   void*       closure);
+                                                   mama_status   status,
+                                                   const char*   info,
+                                                   void*         closure);
+
+        static void MAMACALLTYPE onPublisherSuccess (mamaPublisher publisher,
+                                                     mama_status   status,
+                                                     const char*   info,
+                                                     void*         closure);
 
         mamaPublisher mPublisher;
         MamaPublisherCallback* mCallback;

--- a/mama/c_cpp/src/cpp/mama/MamaPublisherCallback.h
+++ b/mama/c_cpp/src/cpp/mama/MamaPublisherCallback.h
@@ -45,6 +45,12 @@ namespace Wombat
             const MamaStatus& status,
             const char* info,
             void* closure) = 0;
+
+        virtual void onSuccess(
+            MamaPublisher* publisher,
+            const MamaStatus& status,
+            const char* info,
+            void* closure) = 0;
     };
 
 } // namespace Wombat

--- a/mama/c_cpp/src/examples/c/mamapublisherc.c
+++ b/mama/c_cpp/src/examples/c/mamapublisherc.c
@@ -223,6 +223,21 @@ static void MAMACALLTYPE publisherOnErrorCb (
     }
 }
 
+static void MAMACALLTYPE publisherOnSuccessCb (
+                         mamaPublisher publisher,
+                         mama_status   status,
+                         const char*   info,
+                         void*         closure)
+{
+    if (gQuietLevel < 1)
+    {
+        const char* symbol = "";
+        mamaPublisher_getSymbol(publisher, &symbol);
+        mama_log(MAMA_LOG_LEVEL_FINEST, "publisherOnSuccessCb: %s status=%d/%s info=%s",
+            symbol, status, mamaStatus_stringForStatus(status), info);
+    }
+}
+
 static void createPublisher (void)
 {
     mama_status status;
@@ -233,6 +248,7 @@ static void createPublisher (void)
         mamaPublisherCallbacks_allocate (&cb);
         cb->onCreate = publisherOnCreateCb;
         cb->onError = publisherOnErrorCb;
+        cb->onSuccess = publisherOnSuccessCb;
         cb->onDestroy = publisherOnDestroyCb;
         status = mamaPublisher_createWithCallbacks (&gPublisher,
                                                     gTransport,

--- a/mama/c_cpp/src/examples/cpp/mamapublishercpp.cpp
+++ b/mama/c_cpp/src/examples/cpp/mamapublishercpp.cpp
@@ -123,6 +123,12 @@ public:
         const char* info,
         void* closure);
 
+    void onSuccess (
+        MamaPublisher* publisher,
+        const MamaStatus& status,
+        const char* info,
+        void* closure);
+
 private:
     int msgNumber;
 
@@ -336,6 +342,16 @@ void MamaPublisherSample::onError (
     void* closure)
 {
     mama_log(MAMA_LOG_LEVEL_ERROR, "onPublishError: %s.%s %s %s",
+        publisher->getSource(), publisher->getSymbol(), status.toString(), info);
+}
+
+void MamaPublisherSample::onSuccess(
+    MamaPublisher* publisher,
+    const MamaStatus& status,
+    const char* info,
+    void* closure)
+{
+    mama_log(MAMA_LOG_LEVEL_FINEST, "onPublishSuccess: %s.%s %s %s",
         publisher->getSource(), publisher->getSymbol(), status.toString(), info);
 }
 

--- a/mama/c_cpp/src/gunittest/c/publishertest.cpp
+++ b/mama/c_cpp/src/gunittest/c/publishertest.cpp
@@ -80,6 +80,7 @@ void MamaPublisherTestC::TearDown(void)
  */
 int pubOnCreateCount = 0;
 int pubOnErrorCount = 0;
+int pubOnSuccessCount = 0;
 int pubOnDestroyCount = 0;
 
 /**
@@ -101,6 +102,15 @@ void pubOnError (mamaPublisher publisher,
                  void*         closure)
 {
     pubOnErrorCount++;
+}
+
+
+void pubOnSuccess (mamaPublisher publisher,
+                   mama_status   status,
+                   const char*   info,
+                   void*         closure)
+{
+    ++pubOnSuccessCount;
 }
 
 /**
@@ -136,6 +146,7 @@ TEST_F (MamaPublisherTestC, CreateDestroy)
    
     pubOnCreateCount = 0;
     pubOnErrorCount = 0;
+    pubOnSuccessCount = 0;
     pubOnDestroyCount = 0;
 
     ASSERT_EQ (MAMA_STATUS_OK,
@@ -186,6 +197,7 @@ TEST_F (MamaPublisherTestC, GetTransportImpl)
 
     ASSERT_EQ (0, pubOnCreateCount);
     ASSERT_EQ (0, pubOnErrorCount);
+    ASSERT_EQ (0, pubOnSuccessCount);
     ASSERT_EQ (0, pubOnDestroyCount);
 }
 
@@ -204,6 +216,7 @@ TEST_F (MamaPublisherTestC, Send)
 
     pubOnCreateCount = 0;
     pubOnErrorCount = 0;
+    pubOnSuccessCount = 0;
     pubOnDestroyCount = 0;
 
     ASSERT_EQ (MAMA_STATUS_OK, mama_open());
@@ -238,6 +251,7 @@ TEST_F (MamaPublisherTestC, Send)
 
     ASSERT_EQ (0, pubOnCreateCount);
     ASSERT_EQ (0, pubOnErrorCount);
+    ASSERT_EQ (0, pubOnSuccessCount);
     ASSERT_EQ (0, pubOnDestroyCount);
 }
 
@@ -260,10 +274,12 @@ TEST_F (MamaPublisherTestC, EventSendWithCallbacks)
 
     pubOnCreateCount = 0;
     pubOnErrorCount = 0;
+    pubOnSuccessCount = 0;
     pubOnDestroyCount = 0;
 
     mamaPublisherCallbacks_allocate(&cb);
     cb->onError = (mama_publisherOnErrorCb) pubOnError;
+    cb->onSuccess = (mama_publisherOnSuccessCb) pubOnSuccess;
     cb->onCreate = (mama_publisherOnCreateCb) pubOnCreate;
     cb->onDestroy = (mama_publisherOnDestroyCb) pubOnDestroy;
 
@@ -308,6 +324,7 @@ TEST_F (MamaPublisherTestC, EventSendWithCallbacks)
 
     ASSERT_EQ (1, pubOnCreateCount);
     ASSERT_EQ (0, pubOnErrorCount);
+    ASSERT_EQ (0, pubOnSuccessCount); // this should be numPublishers but no bridge calls onSuccess yet 
     ASSERT_EQ (1, pubOnDestroyCount);
 
     mamaPublisherCallbacks_deallocate(cb);
@@ -333,10 +350,12 @@ TEST_F (MamaPublisherTestC, DISABLED_EventSendWithCallbacksBadSource)
 
     pubOnCreateCount = 0;
     pubOnErrorCount = 0;
+    pubOnSuccessCount = 0;
     pubOnDestroyCount = 0;
 
     mamaPublisherCallbacks_allocate(&cb);
     cb->onError = (mama_publisherOnErrorCb) pubOnError;
+    cb->onSuccess = (mama_publisherOnSuccessCb) pubOnSuccess;
     cb->onCreate = (mama_publisherOnCreateCb) pubOnCreate;
     cb->onDestroy = (mama_publisherOnDestroyCb) pubOnDestroy;
 
@@ -379,6 +398,7 @@ TEST_F (MamaPublisherTestC, DISABLED_EventSendWithCallbacksBadSource)
 
     ASSERT_EQ (1, pubOnCreateCount);
     ASSERT_EQ (numErrors, pubOnErrorCount);
+    ASSERT_EQ (0, pubOnSuccessCount);
     ASSERT_EQ (1, pubOnDestroyCount);
 
     mamaPublisherCallbacks_deallocate(cb);
@@ -405,12 +425,14 @@ TEST_F (MamaPublisherTestC, EventSendWithCallbacksNoErrorCallback)
 
     pubOnCreateCount = 0;
     pubOnErrorCount = 0;
+    pubOnSuccessCount = 0;
     pubOnDestroyCount = 0;
 
     mamaPublisherCallbacks_allocate(&cb);
     cb->onError = NULL;
     cb->onCreate = (mama_publisherOnCreateCb) pubOnCreate;    /* No error callback */
     cb->onDestroy = (mama_publisherOnDestroyCb) pubOnDestroy;
+    cb->onSuccess = (mama_publisherOnSuccessCb) pubOnSuccess;
 
     ASSERT_EQ (MAMA_STATUS_OK, mama_open());
 
@@ -453,6 +475,7 @@ TEST_F (MamaPublisherTestC, EventSendWithCallbacksNoErrorCallback)
 
     ASSERT_EQ (1, pubOnCreateCount);
     ASSERT_EQ (0, pubOnErrorCount);
+    ASSERT_EQ (0, pubOnSuccessCount);
     ASSERT_EQ (1, pubOnDestroyCount);
 
     mamaPublisherCallbacks_deallocate(cb);
@@ -479,10 +502,12 @@ TEST_F (MamaPublisherTestC, EventSendWithCallbacksNoCallbacks)
 
     pubOnCreateCount = 0;
     pubOnErrorCount = 0;
+    pubOnSuccessCount = 0;
     pubOnDestroyCount = 0;
 
     mamaPublisherCallbacks_allocate(&cb);
     cb->onError = NULL;
+    cb->onSuccess = NULL;
     cb->onCreate = NULL;
     cb->onDestroy = NULL;
 
@@ -527,6 +552,7 @@ TEST_F (MamaPublisherTestC, EventSendWithCallbacksNoCallbacks)
 
     ASSERT_EQ (0, pubOnCreateCount);
     ASSERT_EQ (0, pubOnErrorCount);
+    ASSERT_EQ (0, pubOnSuccessCount);
     ASSERT_EQ (0, pubOnDestroyCount);
 
     mamaPublisherCallbacks_deallocate(cb);

--- a/mama/c_cpp/src/gunittest/cpp/MamaPublisherTest.cpp
+++ b/mama/c_cpp/src/gunittest/cpp/MamaPublisherTest.cpp
@@ -74,18 +74,21 @@ class TestCallback : public MamaPublisherCallback
 private:
     int onCreateCount;
     int onErrorCount;
+    int onSuccessCount;
     int onDestroyCount;
 
 public:
 
     int getOnCreateCount() { return onCreateCount; }
     int getOnErrorCount() { return onErrorCount; }
+    int getOnSuccessCount() { return onSuccessCount; }
     int getOnDestroyCount() { return onDestroyCount; }
     
        TestCallback()
        {
         onCreateCount = 0;
         onErrorCount = 0;
+        onSuccessCount = 0;
         onDestroyCount = 0;
        }
 
@@ -103,6 +106,15 @@ public:
            void*             closure)
        {
          onErrorCount++;
+       }
+
+       virtual void onSuccess (
+           MamaPublisher*    publisher,
+           const MamaStatus& status,
+           const char*       info,
+           void*             closure)
+       {
+         ++onSuccessCount;
        }
 
        virtual void onDestroy (
@@ -205,6 +217,7 @@ TEST_F(MamaPublisherTest, PublishWithCallbacks)
 
     ASSERT_EQ(1, testCallback->getOnCreateCount());
     ASSERT_EQ(0, testCallback->getOnErrorCount());
+    ASSERT_EQ(0, testCallback->getOnSuccessCount()); // this should be 1 but no bridge calls onSuccess yet
 
     delete testCallback;
 }
@@ -262,6 +275,7 @@ TEST_F(MamaPublisherTest, DISABLED_PublishWithCallbacksBadSource)
 
     ASSERT_EQ(1, testCallback->getOnCreateCount());
     ASSERT_EQ(numPublishes, testCallback->getOnErrorCount());
+    ASSERT_EQ(0, testCallback->getOnSuccessCount());
 }
 
 /**

--- a/mama/dotnet/src/cs/MamaPublisher.cs
+++ b/mama/dotnet/src/cs/MamaPublisher.cs
@@ -582,6 +582,22 @@ namespace Wombat
             }
         }
 
+        private static void onSuccess(IntPtr nativeHandle, short status, string topic, IntPtr closure)
+        {
+            // Obtain the handle from the closure
+            GCHandle handle = (GCHandle)closure;
+
+            // Extract the impl from the handle
+            MamaPublisher pub = (MamaPublisher)handle.Target;
+
+            // Use the impl to invoke the success callback
+            if (null != pub)
+            {
+                // Invoke the callback
+                pub.mCallback.onSuccess(pub, (MamaStatus.mamaStatus)status, topic);
+            }
+        }
+
         private static void onDestroy(IntPtr nativeHandle, IntPtr closure)
         {
             // Obtain the handle from the closure
@@ -613,11 +629,14 @@ namespace Wombat
             mCallbackDelegates.mCreate    = new OnPublisherCreateDelegate(MamaPublisher.onCreate);
             mCallbackDelegates.mDestroy   = new OnPublisherDestroyDelegate(MamaPublisher.onDestroy);
             mCallbackDelegates.mError     = new OnPublisherErrorDelegate(MamaPublisher.onError);
+            mCallbackDelegates.mSuccess   = new OnPublisherSuccessDelegate(MamaPublisher.onSuccess);
         }
 
         private delegate void OnPublisherCreateDelegate(IntPtr nativeHandle, IntPtr closure);
 
         private delegate void OnPublisherErrorDelegate(IntPtr nativeHandle, short status, string topic, IntPtr closure);
+
+        private delegate void OnPublisherSuccessDelegate(IntPtr nativeHandle, short status, string topic, IntPtr closure);
 
         private delegate void OnPublisherDestroyDelegate(IntPtr nativeHandle, IntPtr closure);
         // =====================================================================================
@@ -630,6 +649,7 @@ namespace Wombat
             {
                 public OnPublisherCreateDelegate mCreate;
                 public OnPublisherErrorDelegate mError;
+                public OnPublisherSuccessDelegate mSuccess;
                 public OnPublisherDestroyDelegate mDestroy;
                 public IntPtr mReserved;
             }

--- a/mama/dotnet/src/cs/MamaPublisherCallback.cs
+++ b/mama/dotnet/src/cs/MamaPublisherCallback.cs
@@ -47,6 +47,13 @@ namespace Wombat
         /// <summary>
         /// See interface remarks for details
         /// </summary>
+        void onSuccess(MamaPublisher publisher,
+                       MamaStatus.mamaStatus status,
+                       string topic);
+
+        /// <summary>
+        /// See interface remarks for details
+        /// </summary>
         void onDestroy(MamaPublisher publisher);
     }
 }

--- a/mama/dotnet/src/examples/MamaPublisher/MamaPublisherCS.cs
+++ b/mama/dotnet/src/examples/MamaPublisher/MamaPublisherCS.cs
@@ -197,10 +197,17 @@ namespace Wombat
         }
 
         public void onError(MamaPublisher publisher,
-                     MamaStatus.mamaStatus status,
-                     string topic)
+                            MamaStatus.mamaStatus status,
+                            string topic)
         {
             Console.WriteLine("onPublishError: " + topic + " " + status.ToString());
+        }
+
+        public void onSuccess(MamaPublisher publisher,
+                              MamaStatus.mamaStatus status,
+                              string topic)
+        {
+            Console.WriteLine("onPublishSuccess: " + topic + " " + status.ToString());
         }
 
         public void onDestroy(MamaPublisher publisher)

--- a/mamda/c_cpp/src/examples/mamdapublisher.cpp
+++ b/mamda/c_cpp/src/examples/mamdapublisher.cpp
@@ -44,6 +44,7 @@
 #include <list>
 using std::list;
 
+using namespace std;
 using namespace Wombat;
 
 typedef vector<const char*>      SymbolList;

--- a/mamda/c_cpp/src/examples/orderbooks/listenerBookPublisher.cpp
+++ b/mamda/c_cpp/src/examples/orderbooks/listenerBookPublisher.cpp
@@ -48,6 +48,7 @@
 #include "../dictrequester.h"
 #include <sstream>
 
+using namespace std;
 using namespace Wombat;
 
 typedef list<MamdaSubscription*> SubscriptionList;

--- a/mamda/dotnet/src/examples/MamdaTradeTicker/MamdaTradeTicker.cs
+++ b/mamda/dotnet/src/examples/MamdaTradeTicker/MamdaTradeTicker.cs
@@ -20,9 +20,7 @@
  */
 
 using System;
-using System.Collections;
 using System.Threading;
-using System.Collections;
 
 namespace Wombat.Mamda.Examples
 {


### PR DESCRIPTION
# PR_TITLE
## Summary
Added support for onSuccess publisher events 

## Areas Affected
*Place an 'x' within the braces to check the box*
- [X] MAMAC
- [X] MAMACPP
- [X] MAMADOTNET
- [X] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [X] Unit Tests
- [ ] Examples

## Details
OpenMama clients using MamaPublisher in a Request/Response configuration can register MamaPublisherCallbacks to receive events from the bridge. This has been in place since 2.4.x. MamaPublisherCallbacks has a onError function but no onSuccess. A use-case for some OpenMama Request/Response clients is to expect asynchronous ack/nak events from the bridge. This PR adds onSuccess to enable the reporting of ack events to the client. 

## Testing
C and C++ unit tests have been expanded to cover the onSuccess callback. These all pass on CentOS 7 except for MamaDictionaryTestC.LoadFromFileAndWriteToMsg which I couldn't get to pass even on the vanilla 'next' branch as dictionary1.txt seems to be missing from WOMBAT_PATH. 

The unit test results for onSuccess publisher events are set to expect no calls as the reference Qpid bridge does not call the onSuccess callback at the moment. Existing unit tests for onError publisher events were already disabled or modified for similar reasons. Unit test expectations for both these publisher events will have to be modified if/when the bridge used for executing the unit tests does issue these callbacks.

Mama JNI and .NET unit tests were also updated, but we were unable to execute the JUnit tests and the .NET tests are hardcoded to use the LBM bridge which is unavailable to us. Speaking to Frank he suggested that we can rely on the JUnit tests to be executed by the CI server.

The Pub/Sub examples still work as expected.