### PR TITLE
MAMACPP: Remove mCvectorMsg tracking in MamaMsg.

### DIFF
--- a/mama/c_cpp/src/cpp/mama/MamaMsg.h
+++ b/mama/c_cpp/src/cpp/mama/MamaMsg.h
@@ -2930,8 +2930,6 @@ namespace Wombat
         mutable MamaMsg**      mVectorMsg;
         mutable size_t         mVectorMsgSize;
         mutable size_t         mVectorMsgAllocSize;
-        mutable mamaMsg*       mCvectorMsg;
-        mutable size_t         mCvectorMsgAllocSize;
         mutable MamaMsg*       mTmpMsg;
         mutable const char*    mString;
         mutable MamaMsgField*  mMsgField;

--- a/mama/c_cpp/src/gunittest/cpp/MamaMsgTest.cpp
+++ b/mama/c_cpp/src/gunittest/cpp/MamaMsgTest.cpp
@@ -215,25 +215,25 @@ TEST_F (MamaMsgTestCPP, IteratorTest)
     ASSERT_EQ(4, counter);
 }
 
+// This test executes a sequence that was known to leak memory.  There's no
+// ASSERT here to pass/fail, but the intent of the test is to let a valgrind
+// run on the unit test expose a leak if there is one.
 TEST_F (MamaMsgTestCPP, MemoryLeakTest)
 {
     MamaMsg* msgs[10];
     MamaMsg* mainMsg = new MamaMsg();
 
-    for (int i=0; i < 1000000; ++i) {
-        for (int j=0; j < 10; ++j) {
-            msgs[j] = new MamaMsg();
-            msgs[j]->create();
-        }
+    for (int j=0; j < 10; ++j) {
+        msgs[j] = new MamaMsg();
+        msgs[j]->create();
+    }
 
-        mainMsg = new MamaMsg();
-        mainMsg->create();
-        mainMsg->addVectorMsg("foo", 1000, msgs, 10);
-        mainMsg->clear();
-        delete mainMsg;
+    mainMsg->create();
+    mainMsg->addVectorMsg("foo", 1000, msgs, 10);
+    mainMsg->clear();
+    delete mainMsg;
 
-        for (int j=0; j < 10; ++j) {
-            delete msgs[j];
-        }
+    for (int j=0; j < 10; ++j) {
+        delete msgs[j];
     }
 }

--- a/mama/c_cpp/src/gunittest/cpp/MamaMsgTest.cpp
+++ b/mama/c_cpp/src/gunittest/cpp/MamaMsgTest.cpp
@@ -214,3 +214,26 @@ TEST_F (MamaMsgTestCPP, IteratorTest)
     }
     ASSERT_EQ(4, counter);
 }
+
+TEST_F (MamaMsgTestCPP, MemoryLeakTest)
+{
+    MamaMsg* msgs[10];
+    MamaMsg* mainMsg = new MamaMsg();
+
+    for (int i=0; i < 1000000; ++i) {
+        for (int j=0; j < 10; ++j) {
+            msgs[j] = new MamaMsg();
+            msgs[j]->create();
+        }
+
+        mainMsg = new MamaMsg();
+        mainMsg->create();
+        mainMsg->addVectorMsg("foo", 1000, msgs, 10);
+        mainMsg->clear();
+        delete mainMsg;
+
+        for (int j=0; j < 10; ++j) {
+            delete msgs[j];
+        }
+    }
+}


### PR DESCRIPTION
- Add unit test to demonstrate memory leak in pre-existing OpenMAMA
  codebase.
- Remove unnecessary C-layer mamaMsg tracking of vector messages in a
  MamaMsg.  This fixes the memory leak.

Signed-off-by: Duane Pauls <duane.pauls@solace.com>

# MAMACPP: Fix `mamaMsg` Memory Leak
## Summary
*Fix `mamaMsg` memory leak caused by tracking of `mamaMsg` objects parts of a `MamaMsg` vector within another `MamaMsg`.*

## Areas Affected
*Place an 'x' within the braces to check the box*
- [ ] MAMAC
- [X] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [X] Unit Tests
- [ ] Examples

## Details
The way `mamaMsg` objects belonging to a `MamaMsg` vector within another `MamaMsg` is flawed.  I am unable to determine why this tracking is being done.  Removing the tracking solves the memory leak, and all unit tests pass.

## Testing
The following scenarios were tested:
- The original scenario where the bug was discovered.  This scenario involved a modified `bookpublisher.cpp` publishing into a Solace OpenMAMA setup.  The bug was observed in the cache component which applied the book updates via a `MamdaListener`.  The process performing the book merges quickly ran out of memory.
- Unit tests were run with the Solace bridge.  The results were the same as before the change, except for the newly added MamaMsg.MemoryLeakTest, which now passes.

After modifying the unit test in commit f9d111b, I ran the unit tests under valgrind with the qpid bridge both with and without the fix.  Here is the output of the test runs:

### Without fix:
```
 valgrind --leak-check=yes ./bin/UnitTestMamaCPP -m qpid -p qpidmsg -i 1 --gtest_oitTestMamaCPP-log.-log.xml --gtest_filter=MamaMsgTestCPP.MemoryLeakTest
==18634== Memcheck, a memory error detector
==18634== Copyright (C) 2002-2012, and GNU GPL'd, by Julian Seward et al.
==18634== Using Valgrind-3.8.1 and LibVEX; rerun with -h for copyright info
==18634== Command: ./bin/UnitTestMamaCPP -m qpid -p qpidmsg -i 1 --gtest_output=xml:UnitTestMamaCPP-log.-log.xml --gtest_filter=MamaMsgTestCPP.MemoryLeakTest
==18634==
Middleware=qpid transport=test_tport
Note: Google Test filter = MamaMsgTestCPP.MemoryLeakTest
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from MamaMsgTestCPP
[ RUN      ] MamaMsgTestCPP.MemoryLeakTest
2017-03-29 17:44:26:836:
********************************************************************************
Note: This build of the MAMA API is not enforcing entitlement checks.
Please see the Licensing file for details
**********************************************************************************
[       OK ] MamaMsgTestCPP.MemoryLeakTest (1576 ms)
[----------] 1 test from MamaMsgTestCPP (1589 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (1643 ms total)
[  PASSED  ] 1 test.
==18634==
==18634== HEAP SUMMARY:
==18634==     in use at exit: 136,492 bytes in 1,005 blocks
==18634==   total heap usage: 3,122 allocs, 2,117 frees, 406,771 bytes allocated
==18634==
==18634== 116,080 (880 direct, 115,200 indirect) bytes in 10 blocks are definitely lost in loss record 114 of 114
==18634==    at 0x4A0577B: calloc (vg_replace_malloc.c:593)
==18634==    by 0x76A611C: ???
==18634==    by 0x50F2C70: mamaMsg_create (msg.c:832)
==18634==    by 0x53AD855: Wombat::MamaMsg::create() (MamaMsg.cpp:78)
==18634==    by 0x407D94: MamaMsgTestCPP_MemoryLeakTest_Test::TestBody() (MamaMsgTest.cpp:225)
==18634==    by 0x4C92A23: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (in /usr/lib64/libgtest.so.0.0.0)
==18634==    by 0x4C8D76B: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (in /usr/lib64/libgtest.so.0.0.0)
==18634==    by 0x4C722C1: testing::Test::Run() (in /usr/lib64/libgtest.so.0.0.0)
==18634==    by 0x4C72B75: testing::TestInfo::Run() (in /usr/lib64/libgtest.so.0.0.0)
==18634==    by 0x4C73295: testing::TestCase::Run() (in /usr/lib64/libgtest.so.0.0.0)
==18634==    by 0x4C7A5BC: testing::internal::UnitTestImpl::RunAllTests() (in /usr/lib64/libgtest.so.0.0.0)
==18634==    by 0x4C93E1F: bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(t*) (in /usr/lib64/libgtest.so.0.0.0)
==18634==
==18634== LEAK SUMMARY:
==18634==    definitely lost: 880 bytes in 10 blocks
==18634==    indirectly lost: 115,200 bytes in 980 blocks
==18634==      possibly lost: 0 bytes in 0 blocks
==18634==    still reachable: 20,412 bytes in 15 blocks
==18634==         suppressed: 0 bytes in 0 blocks
==18634== Reachable blocks (those to which a pointer was found) are not shown.
==18634== To see them, rerun with: --leak-check=full --show-reachable=yes
==18634==
==18634== For counts of detected and suppressed errors, rerun with: -v
==18634== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 53 from 9)
```

### With Fix
```valgrind --leak-check=yes ./bin/UnitTestMamaCPP -m qpid -p qpidmsg -i 1 --gtest_oitTestMamaCPP-log.-log.xml --gtest_filter=MamaMsgTestCPP.MemoryLeakTest
==18508== Memcheck, a memory error detector
==18508== Copyright (C) 2002-2012, and GNU GPL'd, by Julian Seward et al.
==18508== Using Valgrind-3.8.1 and LibVEX; rerun with -h for copyright info
==18508== Command: ./bin/UnitTestMamaCPP -m qpid -p qpidmsg -i 1 --gtest_output=xml:UnitTestMamaCPP-log.-log.xml --gtest_filter=MamaMsgTestCPP.MemoryLeakTest
==18508==
Middleware=qpid transport=test_tport
Note: Google Test filter = MamaMsgTestCPP.MemoryLeakTest
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from MamaMsgTestCPP
[ RUN      ] MamaMsgTestCPP.MemoryLeakTest
2017-03-29 17:43:27:999:
********************************************************************************
Note: This build of the MAMA API is not enforcing entitlement checks.
Please see the Licensing file for details
**********************************************************************************
[       OK ] MamaMsgTestCPP.MemoryLeakTest (2046 ms)
[----------] 1 test from MamaMsgTestCPP (2065 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (2140 ms total)
[  PASSED  ] 1 test.
==18508==
==18508== HEAP SUMMARY:
==18508==     in use at exit: 20,412 bytes in 15 blocks
==18508==   total heap usage: 3,122 allocs, 3,107 frees, 406,571 bytes allocated
==18508==
==18508== LEAK SUMMARY:
==18508==    definitely lost: 0 bytes in 0 blocks
==18508==    indirectly lost: 0 bytes in 0 blocks
==18508==      possibly lost: 0 bytes in 0 blocks
==18508==    still reachable: 20,412 bytes in 15 blocks
==18508==         suppressed: 0 bytes in 0 blocks
==18508== Reachable blocks (those to which a pointer was found) are not shown.
==18508== To see them, rerun with: --leak-check=full --show-reachable=yes
==18508==
==18508== For counts of detected and suppressed errors, rerun with: -v
==18508== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 53 from 9)
```

## Notes
For reference, see the attached diff showing how the `bookpublisher.cpp` we used was modified from the official sample.
[bookpublisher.cpp.diff.txt](https://github.com/OpenMAMA/OpenMAMA/files/876957/bookpublisher.cpp.diff.txt)