### PR TITLE
Fixed issue with multiple subscribers for same topic in qpid

### DIFF
--- a/common/c_cpp/src/c/mempool.c
+++ b/common/c_cpp/src/c/mempool.c
@@ -176,7 +176,7 @@ memoryPool_iterate (memoryPool* pool, memoryPoolIteratorCb callback)
     tracker = (memoryNode**)pool->mAllocatedNodes.mNodeBuffer;
     for (i = 0; i < pool->mNumNodesTotal; i++)
     {
-        node = tracker[pool->mNumNodesTotal];
+        node = tracker[i];
         if (NULL != node)
         {
             if (NULL != callback)

--- a/mama/c_cpp/src/c/bridge/qpid/transport.c
+++ b/mama/c_cpp/src/c/bridge/qpid/transport.c
@@ -1483,7 +1483,13 @@ void* qpidBridgeMamaTransportImpl_dispatchThread (void* closure)
                 {
                     tmpNode = memoryPool_getNode (impl->mQpidMsgPool,
                                                   sizeof(qpidMsgNode));
-                    tmpMsgNode = (qpidMsgNode*) tmpNode;
+                    tmpMsgNode = (qpidMsgNode*) tmpNode->mNodeBuffer;
+
+                    /* Create the message if it has not already been initialized */
+                    if (NULL == tmpMsgNode->mMsg)
+                    {
+                        tmpMsgNode->mMsg = pn_message ();
+                    }
 
                     /*
                      * Copy the original msg node to a new one. Note that
@@ -1502,7 +1508,7 @@ void* qpidBridgeMamaTransportImpl_dispatchThread (void* closure)
                     qpidBridgeMamaQueue_enqueueEvent (
                             (queueBridge) subscription->mQpidQueue,
                             qpidBridgeMamaTransportImpl_queueCallback,
-                            tmpMsgNode);
+                            tmpNode);
                 }
                 /*
                  * If this is the last (or only) element and all copies are


### PR DESCRIPTION
See issue #262. This was most likely introduced when memoryPool changes were
made, but there was an issue where a proton message was not initialized for
the temporary copies that are created when multiple subscribers are consuming
the same message. In addition there was another issue where the memory node
itself rather than its underlying buffer was being manipulated. This change
fixes both of the above.

Also fixed an issue with memoryPool_iterate which could cause all members
of the memory pool not to trigger a callback.

Signed-off-by: Frank Quinn <fquinn.ni@gmail.com>