### PR TITLE
Fixed issue with date time on 32 bit linux

### DIFF
--- a/mama/c_cpp/src/c/datetimeimpl.h
+++ b/mama/c_cpp/src/c/datetimeimpl.h
@@ -28,7 +28,11 @@ extern "C" {
 
 typedef struct mama_datetime_t_
 {
+#if defined(__i386__) && (defined(unix) || defined(__unix__) || defined(__unix))
+    int64_t                 mSeconds;
+#else
     time_t                  mSeconds;
+#endif
     long                    mNanoseconds;
     mamaDateTimePrecision   mPrecision;
     mamaDateTimeHints       mHints;

--- a/mama/c_cpp/src/gunittest/c/mamadatetime/datetimetest.cpp
+++ b/mama/c_cpp/src/gunittest/c/mamadatetime/datetimetest.cpp
@@ -88,11 +88,14 @@ MamaDateTimeTestC::~MamaDateTimeTestC(void)
 void
 MamaDateTimeTestC::SetUp(void)
 {
+    mama_loadBridge (&mBridge, getMiddleware());
+    mama_open();
 }
 
 void
 MamaDateTimeTestC::TearDown(void)
 {
+    mama_close();
 }
 
 // Test Create function with valid and NULL parameters


### PR DESCRIPTION
See issue #275. Only 32 bit linux effected.

The internal date type of MAMA Date Time was changes to ensure it is
explicitly 64 bit where time_t is not big enough. This is to allow
extended datetime methods to be used even on 32 bit linux machines
(it already worked fine on 32 bit windows machines). It still
prefers time_t though and when support for 32 bit linux is
eventually dropped, the explicit value will be removed in favour
of the more OS-native type.

This issue is concerned with large year values (i.e. beyond the year
2038). Processing dates before 1970 is unlikely to cause a problem
(since that time_t range starts at 1902).

There are still limitations on 32 bit linux though. In order to get /
set an extended date time, the F64 accessors will need to be used:

    mamaDateTime_getEpochTimeSeconds
    mamaDateTime_setEpochTimeF64

The other methods will all work, but they may not all support extended
date time due to limitations which the size of time_t enforces in the
OS. In these instances, the effected methods will now return a
STATUS_INVALID_ARG, since the timestamp cannot be processed
correctly. This is mostly for string formatting functions and
functions for breaking strings out into their calendar components.

Signed-off-by: Frank Quinn <fquinn@velatt.com>