### PR TITLE
Fix Win32 MamaPublisherTestC.EventSendWithCallbacks SEH exception.

### DIFF
--- a/mama/c_cpp/src/gunittest/c/publishertest.cpp
+++ b/mama/c_cpp/src/gunittest/c/publishertest.cpp
@@ -86,17 +86,17 @@ int pubOnDestroyCount = 0;
 /**
  * Publisher event callbacks
  */
-void pubOnCreate (mamaPublisher publisher, void* closure)
+static void MAMACALLTYPE pubOnCreate (mamaPublisher publisher, void* closure)
 {
     pubOnCreateCount++;
 }
 
-void pubOnDestroy (mamaPublisher publisher, void* closure)
+static void MAMACALLTYPE pubOnDestroy (mamaPublisher publisher, void* closure)
 {
     pubOnDestroyCount++;
 }
 
-void pubOnError (mamaPublisher publisher,
+static void MAMACALLTYPE pubOnError (mamaPublisher publisher,
                  mama_status   status,
                  const char*   info,
                  void*         closure)
@@ -105,7 +105,7 @@ void pubOnError (mamaPublisher publisher,
 }
 
 
-void pubOnSuccess (mamaPublisher publisher,
+static void MAMACALLTYPE pubOnSuccess (mamaPublisher publisher,
                    mama_status   status,
                    const char*   info,
                    void*         closure)
@@ -116,7 +116,7 @@ void pubOnSuccess (mamaPublisher publisher,
 /**
  * Publisher event callbacks via transport topic callbacks
  */
-void transportTopicCb (mamaTransport tport,
+static void MAMACALLTYPE transportTopicCb (mamaTransport tport,
                        mamaTransportTopicEvent event,
                        const char* topic,
                        const void* platformInfo,


### PR DESCRIPTION
Signed-off-by: Chris Morgan <Christopher.Morgan@solacesystems.com>

# Fix Win32 MamaPublisherTestC.EventSendWithCallbacks SEH exception.
## Summary
On Win32 an SEH exception is thrown in the test body of MamaPublisherTestC.EventSendWithCallbacks when calling the onCreate callback of the publisher create function.  

## Areas Affected
*Place an 'x' within the braces to check the box*
- [ ] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [x] Unit Tests
- [ ] Examples

## Details
From issue #271 : 

> I also, found one SEH exception in raise during one test, that gtest seemed to handle properly in the UnitTestMamaC on Win32, in publishertest.cpp.
The Test prints unknown file: error: SEH exception with code 0xc0000005 thrown in the test body.
It seems the publisher callback functions do not have the MAMACALLTYPE macro for __stdcall which seems to crash the test MamaPublisherTestC.EventSendWithCallbacks on Win32, surprisingly it does not crash in Win64.

The callbacks in publishertest.cpp do not have the `MAMACALLTYPE` macro ends up being `__stdcall` in Windows and seems to be ignored in Win64 but is necessary for Win32.

## Testing
With this fix I ran the unit test on Win32 and Win64 platform and it passed.