### PR TITLE
Extended the MamaDateTime C++ class with timespec get/set.

### DIFF
--- a/mama/c_cpp/src/cpp/datetime.cpp
+++ b/mama/c_cpp/src/cpp/datetime.cpp
@@ -182,6 +182,12 @@ namespace Wombat
                                            &inputTimeVal);
     }
 
+    void MamaDateTime::setFromStructTimeSpec(struct timespec& inputTimeSpec)
+    {
+        mamaDateTime_setFromStructTimeSpec(mDateTime,
+                                           &inputTimeSpec);
+    }
+
     void MamaDateTime::set (mama_u32_t             year,
                             mama_u32_t             month,
                             mama_u32_t             day,
@@ -328,6 +334,12 @@ namespace Wombat
     {
         mamaDateTime_getStructTimeValWithTz (const_cast<const mamaDateTime>(mDateTime),
                                              &result, tz.getCValue());
+    }
+
+    void MamaDateTime::getAsStructTimeSpec(struct timespec&  result) const
+    {
+        mamaDateTime_getStructTimeSpec(const_cast<const mamaDateTime>(mDateTime),
+                                       &result);
     }
 
     void MamaDateTime::getAsStructTm (struct tm&  result) const

--- a/mama/c_cpp/src/cpp/mama/MamaDateTime.h
+++ b/mama/c_cpp/src/cpp/mama/MamaDateTime.h
@@ -112,6 +112,12 @@ public:
     void          setToMidnightToday (const MamaTimeZone*    tz = NULL);
 
     /**
+    * Set the underlying C mamaDateTime from a TimeSpec Struct.
+    *  This will allow for extended date ranges.
+    */
+    void          setFromStructTimeSpec (struct timespec& inputTimeSpec);
+
+    /**
      * Set the underlying C mamaDateTime from a TimeVal Struct.
      *  This will allow for extended date ranges.
      */
@@ -276,7 +282,9 @@ public:
     void          getAsStructTimeVal (struct timeval&       result) const;
     void          getAsStructTimeVal (struct timeval&       result,
                                       const MamaTimeZone&   tz) const;
-                                      
+
+    void          getAsStructTimeSpec(struct timespec&       result) const;
+
     void          getAsStructTm      (struct tm&            result) const;
     void          getAsStructTm      (struct tm&            result,
                                       const MamaTimeZone&   tz) const;


### PR DESCRIPTION
# Extended the MamaDateTime C++ class with timespec get/set
## Summary
Simple C++ functions which immediately pass through to the equivalent C functions.

## Areas Affected
*Place an 'x' within the braces to check the box*
- [X ] MAMACPP

## Details
The new member functions setFromStructTimeSpec and getAsStructTimeSpec simply call the equivalent C functions. This change is per the RFC for Extended MAMA Date Time https://openmama.github.io/openmama_rfc_extended_datetime.html

## Testing
Testing has been done using a client side OpenMAMA written in C++. This is such a simple change that as long as it compiles then the existing MamaDateTime C unit tests will suffice.
