### PR TITLE
Linux 32 bit heap corruption in  TEST_F (FieldPriceTestsC, updatePriceValid)

### DIFF
--- a/mama/c_cpp/src/gunittest/c/mamamsg/msgfieldcompositetests.cpp
+++ b/mama/c_cpp/src/gunittest/c/mamamsg/msgfieldcompositetests.cpp
@@ -522,8 +522,7 @@ protected:
     mamaMsgField    mField;
 
     FieldPriceTestsC()
-         : mOut    (NULL)
-         , mField  (NULL)
+         : mField  (NULL)
     {
         mIn = NULL;
         mamaPrice_create(&mIn);
@@ -531,12 +530,16 @@ protected:
         mUpdate = NULL;
         mamaPrice_create(&mUpdate);
         mamaPrice_setValue(mUpdate, 13.45);
+        mOut = NULL;
+        mamaPrice_create(&mOut);
+        mamaPrice_clear(mOut);
     }
 
     ~FieldPriceTestsC()
     {
         mamaPrice_destroy(mIn);
         mamaPrice_destroy(mUpdate);
+        mamaPrice_destroy(mOut);
     }
 
 };
@@ -560,12 +563,12 @@ TEST_F (FieldPriceTestsC, getPriceValid)
 {
     ASSERT_EQ (mamaMsg_addPrice(mMsg, "Gary", 10101, mIn), MAMA_STATUS_OK);
     ASSERT_EQ (mamaMsg_getField(mMsg, "Gary", 10101, &mField), MAMA_STATUS_OK);
-    ASSERT_EQ (mamaMsgField_getPrice(mField, &mOut), MAMA_STATUS_OK);
+    ASSERT_EQ (mamaMsgField_getPrice(mField, mOut), MAMA_STATUS_OK);
 }
 
 TEST_F (FieldPriceTestsC, getPriceInValidField)
 {
-    ASSERT_EQ (mamaMsgField_getPrice(NULL, &mOut), MAMA_STATUS_INVALID_ARG);
+    ASSERT_EQ (mamaMsgField_getPrice(NULL, mOut), MAMA_STATUS_INVALID_ARG);
 }
 
 

--- a/mama/c_cpp/src/gunittest/c/publishertest.cpp
+++ b/mama/c_cpp/src/gunittest/c/publishertest.cpp
@@ -86,17 +86,17 @@ int pubOnDestroyCount = 0;
 /**
  * Publisher event callbacks
  */
-void pubOnCreate (mamaPublisher publisher, void* closure)
+static void MAMACALLTYPE pubOnCreate (mamaPublisher publisher, void* closure)
 {
     pubOnCreateCount++;
 }
 
-void pubOnDestroy (mamaPublisher publisher, void* closure)
+static void MAMACALLTYPE pubOnDestroy (mamaPublisher publisher, void* closure)
 {
     pubOnDestroyCount++;
 }
 
-void pubOnError (mamaPublisher publisher,
+static void MAMACALLTYPE pubOnError (mamaPublisher publisher,
                  mama_status   status,
                  const char*   info,
                  void*         closure)
@@ -105,7 +105,7 @@ void pubOnError (mamaPublisher publisher,
 }
 
 
-void pubOnSuccess (mamaPublisher publisher,
+static void MAMACALLTYPE pubOnSuccess (mamaPublisher publisher,
                    mama_status   status,
                    const char*   info,
                    void*         closure)
@@ -116,7 +116,7 @@ void pubOnSuccess (mamaPublisher publisher,
 /**
  * Publisher event callbacks via transport topic callbacks
  */
-void transportTopicCb (mamaTransport tport,
+static void MAMACALLTYPE transportTopicCb (mamaTransport tport,
                        mamaTransportTopicEvent event,
                        const char* topic,
                        const void* platformInfo,


### PR DESCRIPTION
# Linux 32 bit heap corruption in  TEST_F (FieldPriceTestsC, updatePriceValid)
## Summary
The test TEST_F (FieldPriceTestsC, updatePriceValid) Linux 32 bit cause heap corruption. The test uses the address of a mamaPrice instead mamaPrice casuing a sigabort on Linux 32 bit systems.

## Areas Affected
- [ ] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [x] Unit Tests
- [ ] Examples

## Details
Both TEST_F (FieldPriceTestsC, getPriceValid), and TEST_F (FieldPriceTestsC, getPriceInValidField) use the address of a NULL mamaPrice instead of an initialize mamaPrice. This causes invalid writes during TEST_F (FieldPriceTestsC, getPriceValid) leading to heap corruption. 

## Testing
When Running the Test without the fix a sigabort core happens. With the fix the test passes with a sigabort signal or core.
