### PR TITLE
New extended epoch, hints and precision methods

### DIFF
--- a/mama/c_cpp/src/c/datetime.c
+++ b/mama/c_cpp/src/c/datetime.c
@@ -153,6 +153,32 @@ int mamaDateTime_compare (const mamaDateTime lhs,
 }
 
 mama_status
+mamaDateTime_getEpochTimeExt(const mamaDateTime     dateTime,
+                             mama_i64_t*            seconds,
+                             mama_u32_t*            nanoseconds)
+{
+    if (!dateTime || !seconds || !nanoseconds)
+        return MAMA_STATUS_NULL_ARG;
+
+    *seconds = mamaDateTimeImpl_getSeconds((mama_datetime_t*)dateTime);
+    *nanoseconds = (mama_u32_t) mamaDateTimeImpl_getNanoSeconds((mama_datetime_t*)dateTime);
+    return MAMA_STATUS_OK;
+}
+
+extern mama_status
+mamaDateTime_setEpochTimeExt(mamaDateTime           dateTime,
+                             mama_i64_t             seconds,
+                             mama_u32_t             nanoseconds)
+{
+    if (!dateTime)
+        return MAMA_STATUS_NULL_ARG;
+
+    mamaDateTimeImpl_setSeconds((mama_datetime_t*)dateTime, seconds);
+    mamaDateTimeImpl_setNanoSeconds((mama_datetime_t*)dateTime, (long)nanoseconds);
+    return MAMA_STATUS_OK;
+}
+
+mama_status
 mamaDateTime_setEpochTime(mamaDateTime           dateTime,
                           mama_u32_t             seconds,
                           mama_u32_t             microseconds,
@@ -273,6 +299,36 @@ mamaDateTime_setWithHints(mamaDateTime           dateTime,
     mamaDateTimeImpl_setHint         ((mama_datetime_t*)dateTime, hints);
     if (seconds > SECONDS_IN_A_DAY)
         mamaDateTimeImpl_setHasDate ((mama_datetime_t*)dateTime);
+    return MAMA_STATUS_OK;
+}
+
+mama_status
+mamaDateTime_getHints(const mamaDateTime     dateTime,
+                      mamaDateTimeHints*     hints)
+{
+    if (!dateTime || !hints)
+        return MAMA_STATUS_NULL_ARG;
+    *hints = mamaDateTimeImpl_getHint((mama_datetime_t*)dateTime);
+    return MAMA_STATUS_OK;
+}
+
+mama_status
+mamaDateTime_setHints(mamaDateTime           dateTime,
+                      mamaDateTimeHints      hints)
+{
+    if (!dateTime)
+        return MAMA_STATUS_NULL_ARG;
+    mamaDateTimeImpl_setHint((mama_datetime_t*)dateTime, hints);
+    return MAMA_STATUS_OK;
+}
+
+mama_status
+mamaDateTime_getPrecision(const mamaDateTime     dateTime,
+                          mamaDateTimePrecision* precision)
+{
+    if (!dateTime || !precision)
+        return MAMA_STATUS_NULL_ARG;
+    *precision = mamaDateTimeImpl_getPrecision((mama_datetime_t*)dateTime);
     return MAMA_STATUS_OK;
 }
 

--- a/mama/c_cpp/src/c/datetimeimpl.h
+++ b/mama/c_cpp/src/c/datetimeimpl.h
@@ -28,11 +28,7 @@ extern "C" {
 
 typedef struct mama_datetime_t_
 {
-#if defined(__i386__) && (defined(unix) || defined(__unix__) || defined(__unix))
     int64_t                 mSeconds;
-#else
-    time_t                  mSeconds;
-#endif
     long                    mNanoseconds;
     mamaDateTimePrecision   mPrecision;
     mamaDateTimeHints       mHints;

--- a/mama/c_cpp/src/c/mama/datetime.h
+++ b/mama/c_cpp/src/c/mama/datetime.h
@@ -42,6 +42,7 @@ typedef enum mamaDateTimePrecision_
     MAMA_DATE_TIME_PREC_CENTISECONDS = 2,
     MAMA_DATE_TIME_PREC_MILLISECONDS = 3,
     MAMA_DATE_TIME_PREC_MICROSECONDS = 6,
+    MAMA_DATE_TIME_PREC_NANOSECONDS  = 9,
     MAMA_DATE_TIME_PREC_DAYS         = 10,
     MAMA_DATE_TIME_PREC_MINUTES      = 12,
     MAMA_DATE_TIME_PREC_UNKNOWN      = 15
@@ -139,6 +140,35 @@ mamaDateTime_compare (const mamaDateTime lhs,
                       const mamaDateTime rhs);
 
 /**
+* Get the extended datetime values expressed in seconds since the
+* Epoch (UTC) and nanoseconds since this epoch time.
+*
+* @param dateTime      The dateTime to use.
+* @param seconds       The number of seconds since the Epoch.
+* @param nanoseconds   The number of nanoseconds since the seconds
+*                      parameter.
+*/
+MAMAExpDLL
+extern mama_status
+mamaDateTime_getEpochTimeExt(const mamaDateTime     dateTime,
+                             mama_i64_t*            seconds,
+                             mama_u32_t*            nanoseconds);
+
+/**
+* Set the extended datetime from seconds since the Epoch (UTC)
+* and nanoseconds since this epoch time.
+*
+* @param dateTime      The dateTime to use.
+* @param seconds       The number of seconds since the Epoch.
+* @param microseconds  The number of microseconds.
+* @param precision     The precision of the time stamp.
+*/
+MAMAExpDLL
+extern mama_status
+mamaDateTime_setEpochTimeExt(mamaDateTime           dateTime,
+                             mama_i64_t             seconds,
+                             mama_u32_t             nanoseconds);
+/**
  * Set the date and time as seconds and microseconds since the Epoch
  * (UTC time zone) with an option to designate the accuracy of the
  * time.
@@ -210,8 +240,42 @@ mamaDateTime_setWithHints(mamaDateTime           dateTime,
                           mamaDateTimePrecision  precision,
                           mamaDateTimeHints      hints);
 
+
 /**
- * Set the precision hint.
+* Get the hints flags.
+*
+* @param dateTime      The dateTime to use.
+* @param precision     The output precision of the date/time stamp.
+*/
+MAMAExpDLL
+extern mama_status
+mamaDateTime_getHints(const mamaDateTime     dateTime,
+                      mamaDateTimeHints*     hints);
+
+/**
+* Set the hints flags.
+*
+* @param dateTime      The dateTime to set.
+* @param precision     The precision of the date/time stamp.
+*/
+MAMAExpDLL
+extern mama_status
+mamaDateTime_setHints(mamaDateTime           dateTime,
+                      mamaDateTimeHints      hints);
+
+/**
+* Get the precision.
+*
+* @param dateTime      The dateTime to use.
+* @param precision     The output precision of the date/time stamp.
+*/
+MAMAExpDLL
+extern mama_status
+mamaDateTime_getPrecision(const mamaDateTime     dateTime,
+                          mamaDateTimePrecision* precision);
+
+/**
+ * Set the precision.
  *
  * @param dateTime      The dateTime to set.
  * @param precision     The precision of the date/time stamp.

--- a/mama/c_cpp/src/cpp/datetime.cpp
+++ b/mama/c_cpp/src/cpp/datetime.cpp
@@ -132,9 +132,28 @@ namespace Wombat
                                    hints);
     }
 
+    mamaDateTimePrecision MamaDateTime::getPrecision()
+    {
+        mamaDateTimePrecision precision;
+        mamaDateTime_getPrecision(mDateTime, &precision);
+        return precision;
+    }
+
     void MamaDateTime::setPrecision (mamaDateTimePrecision  precision)
     {
         mamaDateTime_setPrecision (mDateTime, precision);
+    }
+
+    mamaDateTimeHints MamaDateTime::getHints()
+    {
+        mamaDateTimeHints hints;
+        mamaDateTime_getHints(mDateTime, &hints);
+        return hints;
+    }
+
+    void MamaDateTime::setHints(mamaDateTimeHints  hints)
+    {
+        mamaDateTime_setHints(mDateTime, hints);
     }
 
     void MamaDateTime::setFromString (const char*           str,
@@ -321,6 +340,27 @@ namespace Wombat
         mamaDateTime_getEpochTimeSecondsWithCheck (
             const_cast<const mamaDateTime>(mDateTime), &result);
         return result;
+    }
+
+    mama_i64_t MamaDateTime::getEpochTimeExtSeconds() const
+    {
+        mama_i64_t  seconds = 0;
+        uint32_t    nanoseconds = 0;
+        mamaDateTime_getEpochTimeExt(const_cast<const mamaDateTime>(mDateTime), &seconds, &nanoseconds);
+        return seconds;
+    }
+
+    uint32_t MamaDateTime::getEpochTimeExtNanoseconds() const
+    {
+        mama_i64_t  seconds = 0;
+        uint32_t    nanoseconds = 0;
+        mamaDateTime_getEpochTimeExt(const_cast<const mamaDateTime>(mDateTime), &seconds, &nanoseconds);
+        return nanoseconds;
+    }
+
+    void MamaDateTime::setEpochTimeExt(mama_i64_t seconds, uint32_t nanoseconds) const
+    {
+        mamaDateTime_setEpochTimeExt(mDateTime, seconds, nanoseconds);
     }
 
     void MamaDateTime::getAsStructTimeVal (struct timeval&  result) const

--- a/mama/c_cpp/src/cpp/mama/MamaDateTime.h
+++ b/mama/c_cpp/src/cpp/mama/MamaDateTime.h
@@ -102,7 +102,12 @@ public:
                                    mamaDateTimePrecision  precision =
                                                   MAMA_DATE_TIME_PREC_UNKNOWN,
                                    mamaDateTimeHints      hints = 0);
+    mamaDateTimePrecision
+                  getPrecision    ();
     void          setPrecision    (mamaDateTimePrecision  precision);
+    mamaDateTimeHints
+                  getHints        ();
+    void          setHints        (mamaDateTimeHints      hints);
     void          setFromString   (const char*            str,
                                    const MamaTimeZone*    tz = NULL);
     void          setFromString   (const char*            str,
@@ -243,15 +248,41 @@ public:
     mama_f64_t    getEpochTimeSeconds      () const;
     mama_f64_t    getEpochTimeSeconds      (const MamaTimeZone&  tz) const;
 
-	/**
-	 * Get the date and time as seconds since the Epoch, (using the UTC timezone). 
-	 * If no date value is contained in the dateTime then it will be set to today's date
-	 * and the calculation made.
-	 *	 
-	 * @return The number of seconds, (including partial seconds), since the Epoch.
-	 */
-	mama_f64_t    getEpochTimeSecondsWithCheck() const;	
-    
+    /**
+     * Get the extended datetime value in whole seconds since the
+     * Epoch (UTC).
+     *
+     * @return The number of whole seconds since the Epoch.
+     */
+    mama_i64_t    getEpochTimeExtSeconds() const;
+
+    /**
+     * Get the extended datetime subsecond portion of the datetime
+     * value in nanoseconds.
+     *
+     * @return The nanosecond portion of the datetime value.
+     */
+    uint32_t      getEpochTimeExtNanoseconds() const;
+
+    /**
+     * Set the extended datetime values expressed in seconds since the
+     * Epoch (UTC) and nanoseconds since this epoch time.
+     *
+     * @param seconds       The number of seconds since the Epoch.
+     * @param nanoseconds   The number of nanoseconds since the seconds
+     *                      parameter.
+     */
+    void          setEpochTimeExt(mama_i64_t  seconds, uint32_t  nanoseconds) const;
+
+    /**
+     * Get the date and time as seconds since the Epoch, (using the UTC timezone). 
+     * If no date value is contained in the dateTime then it will be set to today's date
+     * and the calculation made.
+     *
+     * @return The number of seconds, (including partial seconds), since the Epoch.
+     */
+    mama_f64_t    getEpochTimeSecondsWithCheck() const;
+
     void          getAsString     (char*        result,
                                    mama_size_t  maxLen) const;
     void          getTimeAsString (char*        result,

--- a/mama/c_cpp/src/gunittest/c/mamadatetime/datetimetest.cpp
+++ b/mama/c_cpp/src/gunittest/c/mamadatetime/datetimetest.cpp
@@ -2262,3 +2262,34 @@ TEST_F (MamaDateTimeTestC, TestGetStructTmWithTzLargeExtendedValues)
     EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_destroy(t) );
 }
 
+
+TEST_F (MamaDateTimeTestC, TestGetEpochTimeExtGranularFunctions)
+{
+    /* The following test represents the time - "3001-01-01 10:03:21" */
+    mamaDateTime          t            = NULL;
+    int64_t               inSecs       = 32535252201;
+    uint32_t              inNSecs      = 123456789;
+    mamaDateTimeHints     inHints      = MAMA_DATE_TIME_HAS_DATE;
+    mamaDateTimePrecision inPrecision  = MAMA_DATE_TIME_PREC_NANOSECONDS;
+    int64_t               outSecs      = 0;
+    uint32_t              outNSecs     = 0;
+    mamaDateTimeHints     outHints     = 0;
+    mamaDateTimePrecision outPrecision = MAMA_DATE_TIME_PREC_UNKNOWN;
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_create(&t) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_setEpochTimeExt(t, inSecs, inNSecs) );
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_setHints(t, inHints) );
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_setPrecision(t, inPrecision) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_getEpochTimeExt(t, &outSecs, &outNSecs) );
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_getHints(t, &outHints) );
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_getPrecision(t, &outPrecision) );
+
+    EXPECT_EQ ( inSecs, outSecs );
+    EXPECT_EQ ( inNSecs, outNSecs );
+    EXPECT_EQ ( inHints, outHints );
+    EXPECT_EQ ( inPrecision, outPrecision );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_destroy(t) );
+}

--- a/mama/c_cpp/src/gunittest/cpp/MamaDateTimeTest.cpp
+++ b/mama/c_cpp/src/gunittest/cpp/MamaDateTimeTest.cpp
@@ -187,3 +187,31 @@ TEST_F(MamaDateTimeTest, SetFromStructTimeVal)
     ASSERT_STREQ (timeStr, stringBuffer);
 }
 
+TEST_F (MamaDateTimeTest, TestGetEpochTimeExtGranularFunctions)
+{
+    /* The following test represents the time - "3001-01-01 10:03:21" */
+	MamaDateTime          dt1;
+    int64_t               inSecs       = 32535252201;
+    uint32_t              inNSecs      = 123456789;
+    mamaDateTimeHints     inHints      = MAMA_DATE_TIME_HAS_DATE;
+    mamaDateTimePrecision inPrecision  = MAMA_DATE_TIME_PREC_NANOSECONDS;
+    int64_t               outSecs      = 0;
+    uint32_t              outNSecs     = 0;
+    mamaDateTimeHints     outHints     = 0;
+    mamaDateTimePrecision outPrecision = MAMA_DATE_TIME_PREC_UNKNOWN;
+
+    dt1.setEpochTimeExt(inSecs, inNSecs);
+    dt1.setHints(inHints);
+    dt1.setPrecision(inPrecision);
+
+    outSecs = dt1.getEpochTimeExtSeconds();
+    outNSecs = dt1.getEpochTimeExtNanoseconds();
+    outHints = dt1.getHints();
+    outPrecision = dt1.getPrecision();
+
+    EXPECT_EQ ( inSecs, outSecs );
+    EXPECT_EQ ( inNSecs, outNSecs );
+    EXPECT_EQ ( inHints, outHints );
+    EXPECT_EQ ( inPrecision, outPrecision );
+
+}


### PR DESCRIPTION
The interface for getting and setting hints and precision was mixed up
with the non-extended methods for getting and setting the epoch time,
so this change introduces a few new methods for access to hints,
precision and epoch time with explicit 64 bit second types and
nanosecond resolution.

Relates to issues #285 and #286.

Signed-off-by: Frank Quinn <fquinn@velatt.com>