### PR TITLE
Fixed unit test not implementing publisher success

### DIFF
--- a/mama/jni/src/junittests/MamaPublisherTest.java
+++ b/mama/jni/src/junittests/MamaPublisherTest.java
@@ -202,6 +202,11 @@ public class MamaPublisherTest extends TestCase implements MamaStartBackgroundCa
     }
 
     @Override
+    public void onSuccess(MamaPublisher pub, short status, String info)
+    {
+    }
+
+    @Override
     public void onStartComplete(int status)
     {
     }


### PR DESCRIPTION
The publisher unit test did not implement the onSuccess callback. This
change corrects this.

Signed-off-by: Frank Quinn <fquinn@velatt.com>