### PR TITLE
Getting out of range date value now returns error

### DIFF
--- a/mama/c_cpp/src/c/datetime.c
+++ b/mama/c_cpp/src/c/datetime.c
@@ -973,7 +973,12 @@ mamaDateTime_getStructTimeValWithTz(const mamaDateTime dateTime,
                                     struct timeval*    result,
                                     const mamaTimeZone tz)
 {
+    time_t seconds = 0;
     if (!dateTime || !result)
+        return MAMA_STATUS_INVALID_ARG;
+
+    seconds = (time_t)mamaDateTimeImpl_getSeconds((mama_datetime_t*)dateTime);
+    if ((int64_t)seconds != mamaDateTimeImpl_getSeconds((mama_datetime_t*)dateTime))
         return MAMA_STATUS_INVALID_ARG;
 
     result->tv_sec  = mamaDateTimeImpl_getSeconds      ((mama_datetime_t*)dateTime);
@@ -1020,11 +1025,17 @@ mama_status
 mamaDateTime_getStructTimeSpec(const mamaDateTime dateTime,
                                struct timespec*   result)
 {
-    mama_datetime_t* impl = (mama_datetime_t*)dateTime;
+    mama_datetime_t* impl    = (mama_datetime_t*)dateTime;
+    time_t           seconds = 0;
+
     if (!dateTime || !result)
         return MAMA_STATUS_INVALID_ARG;
 
-    result->tv_sec = (time_t) impl->mSeconds;
+    seconds = (time_t) mamaDateTimeImpl_getSeconds(impl);
+    if ((int64_t)seconds != mamaDateTimeImpl_getSeconds(impl))
+        return MAMA_STATUS_INVALID_ARG;
+
+    result->tv_sec = (time_t)seconds;
     result->tv_nsec = impl->mNanoseconds;
 
     return MAMA_STATUS_OK;


### PR DESCRIPTION
This is specifically for 32 bit linux which uses a 32-bit time_t,
therefore any timespec or timeval based accessors cannot sufficiently
represent a 64 bit value on such a platform.

This change will now advise the caller when an overflow would have
been caused by returning MAMA_STATUS_INVALID_ARG.

Signed-off-by: Frank Quinn <fquinn@velatt.com>