### PR TITLE
Feature licensing apr update

### DIFF
--- a/LICENSE-3RD-PARTY.txt
+++ b/LICENSE-3RD-PARTY.txt
@@ -1,0 +1,531 @@
+-----------------------------------------------------------------------------
+             Libevent (https://github.com/libevent/libevent)
+-----------------------------------------------------------------------------
+
+Libevent is available for use under the following license, commonly known
+as the 3-clause (or "modified") BSD license:
+
+==============================
+Copyright (c) 2000-2007 Niels Provos <provos@citi.umich.edu>
+Copyright (c) 2007-2012 Niels Provos and Nick Mathewson
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. The name of the author may not be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+==============================
+
+Portions of Libevent are based on works by others, also made available by
+them under the three-clause BSD license above.  The copyright notices are
+available in the corresponding source files; the license is as above.  Here's
+a list:
+
+log.c:
+   Copyright (c) 2000 Dug Song <dugsong@monkey.org>
+   Copyright (c) 1993 The Regents of the University of California.
+
+strlcpy.c:
+   Copyright (c) 1998 Todd C. Miller <Todd.Miller@courtesan.com>
+
+win32select.c:
+   Copyright (c) 2003 Michael A. Davis <mike@datanerds.net>
+
+evport.c:
+   Copyright (c) 2007 Sun Microsystems
+
+ht-internal.h:
+   Copyright (c) 2002 Christopher Clark
+
+minheap-internal.h:
+   Copyright (c) 2006 Maxim Yegorushkin <maxim.yegorushkin@gmail.com>
+
+==============================
+
+The arc4module is available under the following, sometimes called the
+"OpenBSD" license:
+
+   Copyright (c) 1996, David Mazieres <dm@uun.org>
+   Copyright (c) 2008, Damien Miller <djm@openbsd.org>
+
+   Permission to use, copy, modify, and distribute this software for any
+   purpose with or without fee is hereby granted, provided that the above
+   copyright notice and this permission notice appear in all copies.
+
+   THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+   WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+   MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+   ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+   WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+   ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+   OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+==============================
+
+The Windows timer code is based on code from libutp, which is
+distributed under this license, sometimes called the "MIT" license.
+
+
+Copyright (c) 2010 BitTorrent, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+-----------------------------------------------------------------------------
+             Qpid Proton (https://github.com/apache/qpid-proton)
+-----------------------------------------------------------------------------
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+PROTON SUBCOMPONENTS:
+
+Proton includes freegetopt with a separate BSD license.  Your use
+of the source code for freegetopt is subject to the terms and
+conditions of its license in examples/include/pncompat/internal/LICENSE.
+
+The setup scripts for the python bindings include files derived by
+PyZMQ and are licensed with a separate Modified BSD license.  Use of
+the source code in these setup files are subject to the terms and
+conditions in the license:
+proton-c/bindings/python/setuputils/PYZMQ_LICENSE.BSD.
+
+
+-----------------------------------------------------------------------------
+                    Apache APR (https://apr.apache.org)
+-----------------------------------------------------------------------------
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ Documentation
 --------------------------------------------------------------------------------
 We host the latest OpenMAMA Technical documentation on [http://openmama.github.io](http://openmama.github.io)
 
+Licensing
+--------------------------------------------------------------------------------
+This software is licensed under LGPL 2.1. Full terms are included in the `LICENSE.md` file. This software also
+depends on several third party libraries, the licenses for which are listed in the `LICENSE-3RD-PARTY.txt` file.
+
 Contributing
 --------------------------------------------------------------------------------
 Information on contributing on the project can be found on our [Get Involved](http://www.openmama.org/get-involved) page.

--- a/SConstruct
+++ b/SConstruct
@@ -144,3 +144,5 @@ if not env.GetOption('help'):
     if env.get('test',None) == True:
         Test.run( env )
 
+    Alias ('install', env.Install('$prefix', ["LICENSE-3RD-PARTY.txt", "LICENSE.md", "README.md"]))
+

--- a/SConstruct
+++ b/SConstruct
@@ -145,4 +145,5 @@ if not env.GetOption('help'):
         Test.run( env )
 
     Alias ('install', env.Install('$prefix', ["LICENSE-3RD-PARTY.txt", "LICENSE.md", "README.md"]))
+    Alias ('install', env.Install('$prefix/config/', "mama/c_cpp/src/examples/mama.properties"))
 

--- a/mama/c_cpp/src/c/SConscript
+++ b/mama/c_cpp/src/c/SConscript
@@ -225,6 +225,11 @@ Alias('install', env.Install('$prefix/include/mama/conflation',
 Alias('install', env.Install('$prefix/include/mama/fieldcache',
       InstFieldCacheInclude))
 
+if env['target_arch'] == "x86_64":
+    Alias ('install', env.Install('$libdir', Glob('%s/lib64/libapr-1.so*' % env['apr_home'])))
+else:
+    Alias ('install', env.Install('$libdir', Glob('%s/lib/libapr-1.so*' % env['apr_home'])))
+
 env.SConscript('bridge/SConscript', 'env')
 env.SConscript('payload/SConscript', 'env')
 env.SConscript('entitlement/SConscript', 'env')

--- a/mama/c_cpp/src/c/bridge/qpid/SConscript
+++ b/mama/c_cpp/src/c/bridge/qpid/SConscript
@@ -52,3 +52,12 @@ lib.append(env.SharedLibrary(target, sources))
 lib.append(env.StaticLibrary(target, [sources]))
 
 Alias('install', env.Install('$libdir', lib))
+
+# Install the qpid proton and libevent shared objects
+if env['target_arch'] == "x86_64":
+    Alias ('install', env.Install('$libdir', Glob('%s/lib64/libqpid-proton.so*' % env['qpid_home'])))
+    Alias ('install', env.Install('$libdir', Glob('%s/lib64/libevent.so*' % env['libevent_home'])))
+else:
+    Alias ('install', env.Install('$libdir', Glob('%s/lib/libqpid-proton.so*' % env['qpid_home'])))
+    Alias ('install', env.Install('$libdir', Glob('%s/lib/libevent.so*' % env['libevent_home'])))
+

--- a/release_scripts/openmama-rpm.sh
+++ b/release_scripts/openmama-rpm.sh
@@ -300,7 +300,6 @@ if [ $PACKAGE_RELEASE -eq 1 ] && [ $RETURN_CODE -eq 0 ]; then
     try cp -r ${MOCK_BIN_TARBALL_DIR}/data/* ${BINARY_DIR}/data/
     try cp -r ${MOCK_BIN_TARBALL_DIR}/openmama_install*/* ${BINARY_DIR}/
     try cp    ${MOCK_BIN_TARBALL_DIR}/data/profiles/profile.openmama ${BINARY_DIR}/config/
-    try cp    ${MOCK_BIN_TARBALL_DIR}/*.md ${MOCK_BIN_TARBALL_DIR}/LICENSE-3RD-PARTY.txt ${BINARY_DIR}/
     try cp    ${MOCK_BIN_TARBALL_DIR}/mama/c_cpp/src/examples/mama.properties ${BINARY_DIR}/config/
 
     try cd ${BUILD_DIR}/binary/

--- a/release_scripts/openmama-rpm.sh
+++ b/release_scripts/openmama-rpm.sh
@@ -300,7 +300,6 @@ if [ $PACKAGE_RELEASE -eq 1 ] && [ $RETURN_CODE -eq 0 ]; then
     try cp -r ${MOCK_BIN_TARBALL_DIR}/data/* ${BINARY_DIR}/data/
     try cp -r ${MOCK_BIN_TARBALL_DIR}/openmama_install*/* ${BINARY_DIR}/
     try cp    ${MOCK_BIN_TARBALL_DIR}/data/profiles/profile.openmama ${BINARY_DIR}/config/
-    try cp    ${MOCK_BIN_TARBALL_DIR}/mama/c_cpp/src/examples/mama.properties ${BINARY_DIR}/config/
 
     try cd ${BUILD_DIR}/binary/
     try tar -zcf ${RELEASE_DIR}/openmama-${VERSION}.linux.x86_64.tar.gz openmama-${VERSION}

--- a/release_scripts/openmama-rpm.sh
+++ b/release_scripts/openmama-rpm.sh
@@ -300,7 +300,7 @@ if [ $PACKAGE_RELEASE -eq 1 ] && [ $RETURN_CODE -eq 0 ]; then
     try cp -r ${MOCK_BIN_TARBALL_DIR}/data/* ${BINARY_DIR}/data/
     try cp -r ${MOCK_BIN_TARBALL_DIR}/openmama_install*/* ${BINARY_DIR}/
     try cp    ${MOCK_BIN_TARBALL_DIR}/data/profiles/profile.openmama ${BINARY_DIR}/config/
-    try cp    ${MOCK_BIN_TARBALL_DIR}/*.md ${BINARY_DIR}/
+    try cp    ${MOCK_BIN_TARBALL_DIR}/*.md ${MOCK_BIN_TARBALL_DIR}/LICENSE-3RD-PARTY.txt ${BINARY_DIR}/
     try cp    ${MOCK_BIN_TARBALL_DIR}/mama/c_cpp/src/examples/mama.properties ${BINARY_DIR}/config/
 
     try cd ${BUILD_DIR}/binary/

--- a/release_scripts/openmama-rpm.sh
+++ b/release_scripts/openmama-rpm.sh
@@ -299,7 +299,7 @@ if [ $PACKAGE_RELEASE -eq 1 ] && [ $RETURN_CODE -eq 0 ]; then
     try mkdir ${BINARY_DIR}/config
     try cp -r ${MOCK_BIN_TARBALL_DIR}/data/* ${BINARY_DIR}/data/
     try cp -r ${MOCK_BIN_TARBALL_DIR}/openmama_install*/* ${BINARY_DIR}/
-    try cp    ${MOCK_BIN_TARBALL_DIR}/data/profiles/profile.openmama ${BINARY_DIR}/config/
+    try cp    ${MOCK_BIN_TARBALL_DIR}/data/profiles/profile.openmama ${BINARY_DIR}/
 
     try cd ${BUILD_DIR}/binary/
     try tar -zcf ${RELEASE_DIR}/openmama-${VERSION}.linux.x86_64.tar.gz openmama-${VERSION}

--- a/release_scripts/openmama.spec
+++ b/release_scripts/openmama.spec
@@ -45,6 +45,7 @@ cp -r %{_builddir}/%{name}-%{version}/openmama_install_*/* %{buildroot}/opt/open
 cp %{_builddir}/%{name}-%{version}/data/profiles/profile.openmama %{buildroot}/opt/openmama/config/
 cp %{_builddir}/%{name}-%{version}/README.md %{buildroot}/opt/openmama/
 cp %{_builddir}/%{name}-%{version}/LICENSE.md %{buildroot}/opt/openmama/
+cp %{_builddir}/%{name}-%{version}/LICENSE-3RD-PARTY.txt %{buildroot}/opt/openmama/
 cp %{_builddir}/%{name}-%{version}/mama/c_cpp/src/examples/mama.properties %{buildroot}/opt/openmama/config
 
 %clean
@@ -69,5 +70,6 @@ rm -rf %{buildroot}
 /opt/openmama/include/mamda
 /opt/openmama/README.md
 /opt/openmama/LICENSE.md
+/opt/openmama/LICENSE-3RD-PARTY.txt
 
 %changelog

--- a/release_scripts/openmama.spec
+++ b/release_scripts/openmama.spec
@@ -43,9 +43,6 @@ mkdir %{buildroot}/opt/openmama/config
 cp -r %{_builddir}/%{name}-%{version}/data/* %{buildroot}/opt/openmama/data/
 cp -r %{_builddir}/%{name}-%{version}/openmama_install_*/* %{buildroot}/opt/openmama
 cp %{_builddir}/%{name}-%{version}/data/profiles/profile.openmama %{buildroot}/opt/openmama/config/
-cp %{_builddir}/%{name}-%{version}/README.md %{buildroot}/opt/openmama/
-cp %{_builddir}/%{name}-%{version}/LICENSE.md %{buildroot}/opt/openmama/
-cp %{_builddir}/%{name}-%{version}/LICENSE-3RD-PARTY.txt %{buildroot}/opt/openmama/
 cp %{_builddir}/%{name}-%{version}/mama/c_cpp/src/examples/mama.properties %{buildroot}/opt/openmama/config
 
 %clean

--- a/release_scripts/openmama.spec
+++ b/release_scripts/openmama.spec
@@ -42,8 +42,7 @@ mkdir %{buildroot}/opt/openmama/data
 mkdir %{buildroot}/opt/openmama/config
 cp -r %{_builddir}/%{name}-%{version}/data/* %{buildroot}/opt/openmama/data/
 cp -r %{_builddir}/%{name}-%{version}/openmama_install_*/* %{buildroot}/opt/openmama
-cp %{_builddir}/%{name}-%{version}/data/profiles/profile.openmama %{buildroot}/opt/openmama/config/
-cp %{_builddir}/%{name}-%{version}/mama/c_cpp/src/examples/mama.properties %{buildroot}/opt/openmama/config
+cp %{_builddir}/%{name}-%{version}/data/profiles/profile.openmama %{buildroot}/opt/openmama/
 
 %clean
 rm -rf %{buildroot}

--- a/release_scripts/openmama.spec
+++ b/release_scripts/openmama.spec
@@ -64,6 +64,7 @@ rm -rf %{buildroot}
 /opt/openmama/include/wombat
 /opt/openmama/include/mama
 /opt/openmama/include/mamda
+/opt/openmama/profile.openmama
 /opt/openmama/README.md
 /opt/openmama/LICENSE.md
 /opt/openmama/LICENSE-3RD-PARTY.txt

--- a/site_scons/community/command_line.py
+++ b/site_scons/community/command_line.py
@@ -64,7 +64,7 @@ def get_command_line_opts( host, products, VERSIONS ):
     if host['os'] == 'Linux':
         opts.AddVariables(
             PathVariable('qpid_home','Path to QPID Proton Libraries',
-                '/usr/local/', PathVariable.PathIsDir),
+                '/usr/', PathVariable.PathIsDir),
             PathVariable('cache_dir','Path to object cache', None, PathVariable.PathIsDir),
             EnumVariable('product', 'Product to be built', 'mamda',
                          #mamda all is a windows only build


### PR DESCRIPTION
```
Updated licenses and installation files

Licensing is updated to include apache apr license details, and
configuration, readme and license files are now included in all builds
by default including RPMs and windows.

The libraries used during the build are also now included in the package
to avoid the user having to install any further dependencies. It also
ensures that versions match for compile vs run time and that we can
avoid the issue where qpid proton keeps changing its shared object name
(we may remove this from RPM builds when that volatility settles down).

Documentation in the README has also been updated to refer to the new
licensing file.

Signed-off-by: Frank Quinn <fquinn.ni@gmail.com>
```