### PR TITLE
Fixed issue with crash for years prior to 1601

### DIFF
--- a/mama/c_cpp/src/c/mama/datetime.h
+++ b/mama/c_cpp/src/c/mama/datetime.h
@@ -869,7 +869,7 @@ mamaDateTime_getAsFormattedStringWithTz(const mamaDateTime dateTime,
                                         const mamaTimeZone tz);
 
 /**
- * Get the year (1970 onwards).
+ * Get the year (1601 onwards).
  *
  * @param dateTime      The dateTime from which to get the result.
  * @param result        The result of the get method.

--- a/mama/c_cpp/src/gunittest/c/mamadatetime/datetimetest.cpp
+++ b/mama/c_cpp/src/gunittest/c/mamadatetime/datetimetest.cpp
@@ -2300,7 +2300,6 @@ TEST_F (MamaDateTimeTestC, TestGetEpochTimePreWindowsEpoch)
     mamaDateTime          t            = NULL;
     int64_t               inSecs       = -30064771071LL;
     uint32_t              inNSecs      = 0;
-    mamaDateTimeHints     inHints      = MAMA_DATE_TIME_HAS_DATE;
     struct tm             resultTm;
     char                  buf[64];
 

--- a/mama/c_cpp/src/gunittest/c/mamadatetime/datetimetest.cpp
+++ b/mama/c_cpp/src/gunittest/c/mamadatetime/datetimetest.cpp
@@ -2293,3 +2293,30 @@ TEST_F (MamaDateTimeTestC, TestGetEpochTimeExtGranularFunctions)
 
     EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_destroy(t) );
 }
+
+TEST_F (MamaDateTimeTestC, TestGetEpochTimePreWindowsEpoch)
+{
+    /* The following test represents the time - "April 15, 1017 2:42:09" */
+    mamaDateTime          t            = NULL;
+    int64_t               inSecs       = -30064771071LL;
+    uint32_t              inNSecs      = 0;
+    mamaDateTimeHints     inHints      = MAMA_DATE_TIME_HAS_DATE;
+    struct tm             resultTm;
+    char                  buf[64];
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_create(&t) );
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_setEpochTimeExt(t, inSecs, inNSecs) );
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_setHints(t, MAMA_DATE_TIME_HAS_TIME) );
+
+    ASSERT_EQ( MAMA_STATUS_INVALID_ARG, mamaDateTime_getAsFormattedString(t, buf, sizeof(buf), "%Y") );
+    ASSERT_EQ( MAMA_STATUS_INVALID_ARG, mamaDateTime_getStructTm(t, &resultTm) );
+    ASSERT_EQ( MAMA_STATUS_INVALID_ARG, mamaDateTime_getAsString(t, buf, sizeof(buf)) );
+    ASSERT_EQ( MAMA_STATUS_INVALID_ARG, mamaDateTime_getDateAsString(t, buf, sizeof(buf)) );
+
+    // This method should work since it does arithmetic to extract time if necessary
+    ASSERT_EQ( MAMA_STATUS_OK, mamaDateTime_getTimeAsString(t, buf, sizeof(buf)) );
+    EXPECT_STREQ("02:42:09.000", buf);
+
+    EXPECT_EQ ( MAMA_STATUS_OK, mamaDateTime_destroy(t) );
+}


### PR DESCRIPTION
Windows string formatting crashed for years prior to 1601. Impacted
functions will now exit gracefully in this scenario with an error
code instead.

Signed-off-by: Frank Quinn <fquinn@velatt.com>