### PR TITLE
MAMAC: bug in mamaMsg_updateSubMsg (#297)

### DIFF
--- a/mama/c_cpp/src/c/msg.c
+++ b/mama/c_cpp/src/c/msg.c
@@ -2253,10 +2253,14 @@ mamaMsg_updateSubMsg (
     if (!impl || !impl->mPayloadBridge) return MAMA_STATUS_NULL_ARG;
     CHECK_MODIFY (impl->mMessageOwner);
 
+    // need to pass in payload, not mamaMsg
+    mamaMsgImpl*    impl2    = (mamaMsgImpl*)value;
+    if (!impl2 || !impl2->mPayloadBridge) return MAMA_STATUS_NULL_ARG;
+
     return impl->mPayloadBridge->msgPayloadUpdateSubMsg (impl->mPayload,
                                                          name,
                                                          fid,
-                                                         value);
+                                                         impl2->mPayload);
 }
 
 mama_status


### PR DESCRIPTION
The payload function takes a payload object, but mamaMsg_updateSubMsg passes in the Mama message -- since both are defined as void* there is no compiler checking of these types.

Signed-off-by: Bill Torpey <bill.torpey@ullink.com>

## Testing
With this change, internal Ullink tests pass (had been failing).
