### PR TITLE
PLAT-1078: Extend support of environment variables

### DIFF
--- a/common/c_cpp/src/c/properties.l
+++ b/common/c_cpp/src/c/properties.l
@@ -27,6 +27,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "wombat/strutils.h"
 #include "wombat/wincompat.h"
 
 #define YY_NO_INPUT ()
@@ -129,7 +130,7 @@ WS                  [ \t]
 
 <value>{NEWLINE}                 { /* value is complete. start over.*/
                                    replaceValue = 
-                                       propertiesImpl_ReplaceEnvironmentVariable(curValue);
+                                       strReplaceEnvironmentVariable(curValue);
                                    if(replaceValue != NULL)
                                    {
                                         /* Delete the original value */
@@ -161,7 +162,7 @@ WS                  [ \t]
                                     if ( curKey && curValue )
                                     {
                                         replaceValue = 
-                                            propertiesImpl_ReplaceEnvironmentVariable(curValue);
+                                            strReplaceEnvironmentVariable(curValue);
                                         if(replaceValue != NULL)
                                         {
                                              /* Delete the original value */

--- a/common/c_cpp/src/c/property.c
+++ b/common/c_cpp/src/c/property.c
@@ -130,88 +130,6 @@ properties_Load( const char* path, const char* fileName )
     return NULL;
 }
 
-/* This function will replace any environment variables with their
- * equivalents in the string passed in.
- *
- * @param value [I] The string that may contain environment variables.
- *
- * @return NULL if the value string did not containing any environment variables.
- * A valid string is variables were replaced, delete the memory with free.
- */
-char* propertiesImpl_ReplaceEnvironmentVariable( const char* value )
-{
-	/* Returns */
-	char* ret = NULL;
-    if( value != NULL )
-    {
-	    /* Scan the property value for a $( which indicates an environment
-         * variable */
-	    char* envStart = strstr(value, "$(");
-	    if( envStart != NULL )
-	    {
-		    /* Get a pointer to the first character of the variable itself. */
-		    char* variableStart = (envStart + 2);
-
-		    /* Locate the end of the string */
-		    char* envEnd = strchr( variableStart, ')' );
-		    if( envEnd != NULL )
-		    {
-                /* Obtain the length of the value string, this must be done
-                 * before any replacements. */
-			    int valueLength = strlen( value );
-
-			    /* Save the character at the end of the string */
-			    char endChar = *envEnd;
-
-			    /* Replace it will a NULL to extract the variable name. */
-			    *envEnd = '\0';
-			    {
-				    /* Extract the variable name. */
-				    char* envValue = getenv( variableStart );
-
-                    /* If a value was returned then a new property value must
-                     * be formatted. */
-				    if(envValue != NULL)
-				    {
-                        /* Determine the number of characters needed to store
-                         * the new string. This is the length of the original
-                         * value plus the length of the environment variable
-                         * value minus the length of the environment variable
-                         * name.  The -2 at the end is due to the 3 characters
-                         * that wrap the environment variable name plus 1 for
-                         * the null terminator.
-					     */
-					    int newStringLength = (valueLength -
-                                strlen(variableStart) + strlen(envValue) - 2);
-
-					    /* Allocate a buffer to contain the new string */
-					    ret = (char* )calloc(newStringLength, sizeof(char));
-					    if(ret != NULL)
-					    {
-                            /* Write a temporary NULL into the input string
-                             * where the environment variable symbol starts.
-						     */
-						    char startChar = *envStart;
-						    *envStart = '\0';
-
-						    /* Format the buffer */
-						    sprintf(ret, "%s%s%s", value, envValue, (envEnd + 1));
-
-						    /* Restore the NULL at the start of the string. */
-						    *envStart = startChar;
-					    }
-				    }
-			    }
-
-			    /* Restore the NULL at the end of the string. */
-			    *envEnd = endChar;
-		    }
-	    }
-    }
-
-	return ret;
-}
-
 /**
  * Create an empty properties object.
  */
@@ -251,7 +169,7 @@ properties_AddString( wproperty_t handle, const char* propString )
 		propertiesImpl_ *impl = (propertiesImpl_ *)handle;
 
 		/* Replace any environment variables in the properties string. */
-		char* localString = propertiesImpl_ReplaceEnvironmentVariable(propString);
+		char* localString = strReplaceEnvironmentVariable(propString);
 		if(NULL == localString)
 		{
 			/* No variables were replaced, just make a straight copy. */
@@ -381,7 +299,7 @@ properties_setProperty (wproperty_t handle,
     name_c  =   strdup (name);
 
     /* The value will need to have any environment variables replaced. */
-    value_c = (const char* )propertiesImpl_ReplaceEnvironmentVariable(value);
+    value_c = (const char* )strReplaceEnvironmentVariable(value);
     if(NULL == value_c)
     {
         value_c = strdup(value);

--- a/common/c_cpp/src/c/propertyinternal.h
+++ b/common/c_cpp/src/c/propertyinternal.h
@@ -26,5 +26,3 @@ propertiesImpl_AddProperty( propertiesImpl this,
                             const char* name, 
                             const char* value );
 
-char* propertiesImpl_ReplaceEnvironmentVariable(const char* value);
-

--- a/common/c_cpp/src/c/strutils.c
+++ b/common/c_cpp/src/c/strutils.c
@@ -646,3 +646,124 @@ int strToVersionInfo(const char* s, versionInfo* version)
     }
     return retVal;
 }
+
+COMMONExpDLL
+char* strReplaceEnvironmentVariable(const char* value)
+{
+    /* Returns */
+    char* variableStart = NULL;
+    char* envValue      = NULL;
+    char* envStart      = NULL;
+    char* envEnd        = NULL;
+    char* startString   = "$(";
+    char* ret           = NULL;
+    char envVar[1024]   = "";
+    char startStr[4096] = "";
+    char endStr[4096]   = "";
+    char endChar        = ')';
+    int valueLength     = 0;
+    int startLength     = 0;
+    int newStringLength = 0;
+    size_t envVarLen    = 0;
+    
+    if (value != NULL && strchr(value, '$'))
+    {
+        ret = strdup(value);
+
+        /* Make sure strdup didn't fail */
+        if (NULL == ret)
+        {
+            goto out;
+        }
+
+        /* Scan the property for a $( which indicates an environment
+         * variable or set ${ as the environment variable notation */
+        if (NULL == strstr(ret, startString))
+        {
+            /* Change the start string */
+            startString = "${";
+            /* Change the end character */
+            endChar = '}';
+        }
+
+        while (envStart = strstr(ret, startString))
+        {
+
+            /* Get a pointer to the first character of the variable itself. */
+            variableStart = (envStart + 2);
+
+            /* Locate the end of the string */
+            envEnd = strchr( variableStart, endChar );
+
+            if (envEnd == NULL)
+            {
+                goto out;
+            }
+
+            /* Save off the end of the string as later we realloc the source of the string */
+            snprintf (endStr, strlen(envEnd)+1, "%s", envEnd);
+
+            /* Obtain the length of the ret string, this must be done
+             * before any replacements. */
+            valueLength = strlen( ret );
+
+            /* Obtain the length of the string before the $ variable */
+            startLength = valueLength - strlen(variableStart) - 1;
+
+            /* Make sure that we wouldn't overrun the buffer, otherwise return NULL */
+            if (startLength > sizeof(startStr))
+            {
+                goto out;
+            }
+
+            /* Save off the string up to the $ variable */
+            snprintf (startStr, startLength, "%s", ret);
+
+            /* Work out the length of the environment variable */
+            envVarLen = strlen(variableStart)-strlen(endStr)+1;
+
+            snprintf (envVar, envVarLen, "%s", variableStart);
+
+            /* Extract the variable name. */
+            envValue = getenv (envVar);
+
+            /* If a value was returned then a new property value must
+             * be formatted. */
+            if (envValue == NULL)
+            {
+                goto out;
+            }
+
+            /* Determine the number of characters needed to store
+             * the new string. This is the length of the original
+             * value plus the length of the environment variable
+             * value minus the length of the environment variable
+             * name.  The -2 at the end is due to the 3 characters
+             * that wrap the environment variable name plus 1 for
+             * the null terminator.
+             */
+            newStringLength = (valueLength -
+                    strlen(envVar) + strlen(envValue) - 2);
+
+            /* Reallocate a buffer to contain the new string if needed */
+            if (newStringLength > strlen(ret))
+            {
+                ret = (char* )realloc((char*)ret, newStringLength);
+            }
+
+            if (ret == NULL)
+            {
+                goto out;
+            }
+
+            snprintf(ret, newStringLength, "%s%s%s", startStr, envValue, (endStr + 1));
+        }
+    }
+
+    return ret;
+
+out:
+    free (ret);
+    return NULL;
+}
+

--- a/common/c_cpp/src/c/wombat/strutils.h
+++ b/common/c_cpp/src/c/wombat/strutils.h
@@ -156,6 +156,18 @@ int strtobool(const char* s);
 COMMONExpDLL
 int strToVersionInfo(const char* s, versionInfo* version);
 
+/* 
+ * Replace any environment variables with their
+ * equivalents in the string passed in.
+ *
+ * @param value [I] The string that may contain environment variables.
+ *
+ * @return NULL if the value string did not containing any environment variables.
+ * A valid string if variables were replaced.  This string must be freed with free().
+ */
+COMMONExpDLL
+char* strReplaceEnvironmentVariable(const char* value);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/common/c_cpp/src/gunittest/c/Makefile.sample
+++ b/common/c_cpp/src/gunittest/c/Makefile.sample
@@ -58,7 +58,8 @@ all: UnitTestCommonC
 
 UnitTestCommonC: ../MainUnitTestC.o \
                       timertest.o \
-                      queuetest.o
+                      queuetest.o \
+					  strutilstest.o
 	$(LINK.C) -o $@ $^ $(LIBS) $(SYS_LIBS)
 
 timertest: ../MainUnitTestC.o timertest.o
@@ -67,4 +68,6 @@ timertest: ../MainUnitTestC.o timertest.o
 queuetest: ../MainUnitTestC.o queuetest.o
 	$(LINK.C) -o $@ $^ $(LIBS) $(SYS_LIBS)
 
+strutilstest: ../MainUnitTestC.o strutilstest.o
+	$(LINK.C) -o $@ $^ $(LIBS) $(SYS_LIBS)
 

--- a/common/c_cpp/src/gunittest/c/SConscript
+++ b/common/c_cpp/src/gunittest/c/SConscript
@@ -31,6 +31,7 @@ port.cpp
 queuetest.cpp
 timertest.cpp
 utiltest.cpp
+strutilstest.cpp
 """)
 
 MainUnitTest = env.Object( '../MainUnitTestC.cpp' ) 

--- a/common/c_cpp/src/gunittest/c/strutilstest.cpp
+++ b/common/c_cpp/src/gunittest/c/strutilstest.cpp
@@ -1,0 +1,266 @@
+/* $Id:
+ *
+ * OpenMAMA: The open middleware agnostic messaging API
+ * Copyright (C) 2011 NYSE Technologies, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+#include <gtest/gtest.h>
+#include "MainUnitTestC.h"
+#include "wombat/strutils.h"
+#include "stdlib.h"
+
+class CommonStrutilsTestC : public ::testing::Test
+{
+protected:
+    CommonStrutilsTestC();
+    virtual ~CommonStrutilsTestC();
+
+    virtual void SetUp();
+    virtual void TearDown ();
+public:
+};
+
+CommonStrutilsTestC::CommonStrutilsTestC()
+{
+}
+
+CommonStrutilsTestC::~CommonStrutilsTestC()
+{
+}
+
+void CommonStrutilsTestC::SetUp(void)
+{
+}
+
+void CommonStrutilsTestC::TearDown(void)
+{
+}
+
+/* ************************************************************************* */
+/* Test Functions */
+/* ************************************************************************* */
+TEST_F (CommonStrutilsTestC, replaceEnvironmentVariableValidBrackets)
+{
+    const char* envVar      = "$(TMPDIR)";
+    const char* baseDir     = "/tmp";
+    const char* logfileName = "/test/logfile.log";
+    char*       outputStr   = NULL;
+    char        inputString[20];
+    char        expectedStr[20];
+
+    setenv ("TMPDIR", baseDir, 1);
+
+    inputString[0] = '\0';
+    strncat (inputString, envVar, 9);
+    strncat (inputString, logfileName, 17);
+
+    outputStr = strReplaceEnvironmentVariable (inputString);
+
+    expectedStr[0] = '\0';
+    strncat (expectedStr, baseDir, 4);
+    strncat (expectedStr, logfileName, 17);
+
+    ASSERT_STREQ (outputStr, expectedStr);
+
+    free (outputStr);
+}
+
+TEST_F (CommonStrutilsTestC, replaceEnvironmentVariableValidBracketsAlternative)
+{
+    const char* envVar      = "${TMPDIR}";
+    const char* baseDir     = "/tmp";
+    const char* logfileName = "/test/logfile.log";
+    char*       outputStr   = NULL;
+    char        inputString[20];
+    char        expectedStr[20];
+
+    setenv ("TMPDIR", baseDir, 1);
+
+    inputString[0] = '\0';
+    strncat (inputString, envVar, 9);
+    strncat (inputString, logfileName, 17);
+
+    outputStr = strReplaceEnvironmentVariable (inputString);
+
+    expectedStr[0] = '\0';
+    strncat (expectedStr, baseDir, 4);
+    strncat (expectedStr, logfileName, 17);
+
+    ASSERT_STREQ (outputStr, expectedStr);
+
+    free (outputStr);
+}
+
+TEST_F (CommonStrutilsTestC, replaceEnvironmentVariableValidMixedBrackets)
+{
+    const char* envVar      = "$(TMPDIR}";
+    const char* baseDir     = "/tmp";
+    const char* logfileName = "/test/logfile.log";
+    char*       outputStr   = NULL;
+    char        inputString[20];
+
+    setenv ("TMPDIR", baseDir, 1);
+
+    inputString[0] = '\0';
+    strncat (inputString, envVar, 9);
+    strncat (inputString, logfileName, 17);
+
+    outputStr = strReplaceEnvironmentVariable (inputString);
+
+    ASSERT_STREQ (outputStr, NULL);
+
+    free (outputStr);
+}
+
+TEST_F (CommonStrutilsTestC, replaceEnvironmentVariableValidMixedBracketsReverse)
+{
+    const char* envVar      = "${TMPDIR)";
+    const char* baseDir     = "/tmp";
+    const char* logfileName = "/test/logfile.log";
+    char*       outputStr   = NULL;
+    char        inputString[20];
+
+    setenv ("TMPDIR", baseDir, 1);
+
+    inputString[0] = '\0';
+    strncat (inputString, envVar, 9);
+    strncat (inputString, logfileName, 17);
+
+    outputStr = strReplaceEnvironmentVariable (inputString);
+
+    ASSERT_STREQ (outputStr, NULL);
+
+    free (outputStr);
+}
+
+TEST_F (CommonStrutilsTestC, replaceEnvironmentVariableNoEnvVar)
+{
+    const char* logfileName = "/test/logfile.log";
+    char*       outputStr   = NULL;
+    char        inputString[20];
+
+    inputString[0] = '\0';
+    strncat (inputString, logfileName, 17);
+
+    outputStr = strReplaceEnvironmentVariable (inputString);
+
+    ASSERT_STREQ (outputStr, NULL);
+
+    free (outputStr);
+}
+
+TEST_F (CommonStrutilsTestC, replaceEnvironmentVariableLargeLogfileStr)
+{
+    const char* envVar      = "$(TMPDIR)";
+    const char* baseDir     = "/tmp";
+    const char* logfileName = "/test/llllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllogfile.log";
+    char*       outputStr   = NULL;
+    char        inputString[20];
+    char        expectedStr[20];
+
+    setenv ("TMPDIR", baseDir, 1);
+
+    inputString[0] = '\0';
+    strncat (inputString, envVar, 9);
+    strncat (inputString, logfileName, 17);
+
+    outputStr = strReplaceEnvironmentVariable (inputString);
+
+    expectedStr[0] = '\0';
+    strncat (expectedStr, baseDir, 4);
+    strncat (expectedStr, logfileName, 17);
+
+    ASSERT_STREQ (outputStr, expectedStr);
+
+    free (outputStr);
+}
+
+TEST_F (CommonStrutilsTestC, replaceEnvironmentVariableLargePathStr)
+{
+    const char* envVar      = "$(TMPDIR)";
+    const char* baseDir     = "/tmp";
+    const char* logfileName = "/this/is/a/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/long/path/to/a/logfile.log";
+    char*       outputStr   = NULL;
+    char        inputString[20];
+    char        expectedStr[20];
+
+    setenv ("TMPDIR", baseDir, 1);
+
+    inputString[0] = '\0';
+    strncat (inputString, envVar, 9);
+    strncat (inputString, logfileName, 17);
+
+    outputStr = strReplaceEnvironmentVariable (inputString);
+
+    expectedStr[0] = '\0';
+    strncat (expectedStr, baseDir, 4);
+    strncat (expectedStr, logfileName, 17);
+
+    ASSERT_STREQ (outputStr, expectedStr);
+
+    free (outputStr);
+}
+
+TEST_F (CommonStrutilsTestC, replaceMultipleEnvironmentVariableValid)
+{
+    const char* envVar      = "$(TMPDIR)$(TMPLOGFILE)";
+    const char* baseDir     = "/tmp";
+    const char* logfileName = "/test/logfile.log";
+    char*       outputStr   = NULL;
+    char        expectedStr[20];
+
+    setenv ("TMPDIR", baseDir, 1);
+    setenv ("TMPLOGFILE", logfileName, 1);
+
+    outputStr = strReplaceEnvironmentVariable (envVar);
+
+    expectedStr[0] = '\0';
+    strncat (expectedStr, baseDir, 4);
+    strncat (expectedStr, logfileName, 17);
+
+    ASSERT_STREQ (outputStr, expectedStr);
+
+    free (outputStr);
+}
+
+TEST_F (CommonStrutilsTestC, replaceMultipleEmbeddedEnvironmentVariableValid)
+{
+    const char* envVar      = "$(TMPDIR)$(TMPLOGFILE)";
+    const char* baseDirEx   = "/tmp$(TMPSECONDDIR)";
+    const char* baseDir     = "/tmp";
+    const char* secondDir   = "/for";
+    const char* logfileName = "/test/logfile.log";
+    char*       outputStr   = NULL;
+    char        expectedStr[20];
+
+    setenv ("TMPDIR", baseDirEx, 1);
+    setenv ("TMPSECONDDIR", secondDir, 1);
+    setenv ("TMPLOGFILE", logfileName, 1);
+
+    outputStr = strReplaceEnvironmentVariable (envVar);
+
+    expectedStr[0] = '\0';
+    strncat (expectedStr, baseDir, 4);
+    strncat (expectedStr, secondDir, 4);
+    strncat (expectedStr, logfileName, 17);
+
+    ASSERT_STREQ (outputStr, expectedStr);
+
+    free (outputStr);
+}
+

--- a/common/c_cpp/src/gunittest/c/strutilstest.cpp
+++ b/common/c_cpp/src/gunittest/c/strutilstest.cpp
@@ -60,8 +60,8 @@ TEST_F (CommonStrutilsTestC, replaceEnvironmentVariableValidBrackets)
     const char* baseDir     = "/tmp";
     const char* logfileName = "/test/logfile.log";
     char*       outputStr   = NULL;
-    char        inputString[20];
-    char        expectedStr[20];
+    char        inputString[30];
+    char        expectedStr[30];
 
     setenv ("TMPDIR", baseDir, 1);
 
@@ -86,8 +86,8 @@ TEST_F (CommonStrutilsTestC, replaceEnvironmentVariableValidBracketsAlternative)
     const char* baseDir     = "/tmp";
     const char* logfileName = "/test/logfile.log";
     char*       outputStr   = NULL;
-    char        inputString[20];
-    char        expectedStr[20];
+    char        inputString[30];
+    char        expectedStr[30];
 
     setenv ("TMPDIR", baseDir, 1);
 
@@ -112,7 +112,7 @@ TEST_F (CommonStrutilsTestC, replaceEnvironmentVariableValidMixedBrackets)
     const char* baseDir     = "/tmp";
     const char* logfileName = "/test/logfile.log";
     char*       outputStr   = NULL;
-    char        inputString[20];
+    char        inputString[30];
 
     setenv ("TMPDIR", baseDir, 1);
 
@@ -133,7 +133,7 @@ TEST_F (CommonStrutilsTestC, replaceEnvironmentVariableValidMixedBracketsReverse
     const char* baseDir     = "/tmp";
     const char* logfileName = "/test/logfile.log";
     char*       outputStr   = NULL;
-    char        inputString[20];
+    char        inputString[30];
 
     setenv ("TMPDIR", baseDir, 1);
 
@@ -170,20 +170,20 @@ TEST_F (CommonStrutilsTestC, replaceEnvironmentVariableLargeLogfileStr)
     const char* baseDir     = "/tmp";
     const char* logfileName = "/test/llllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllogfile.log";
     char*       outputStr   = NULL;
-    char        inputString[20];
-    char        expectedStr[20];
+    char        inputString[810];
+    char        expectedStr[810];
 
     setenv ("TMPDIR", baseDir, 1);
 
     inputString[0] = '\0';
     strncat (inputString, envVar, 9);
-    strncat (inputString, logfileName, 17);
+    strncat (inputString, logfileName, 795);
 
     outputStr = strReplaceEnvironmentVariable (inputString);
 
     expectedStr[0] = '\0';
     strncat (expectedStr, baseDir, 4);
-    strncat (expectedStr, logfileName, 17);
+    strncat (expectedStr, logfileName, 795);
 
     ASSERT_STREQ (outputStr, expectedStr);
 
@@ -196,20 +196,20 @@ TEST_F (CommonStrutilsTestC, replaceEnvironmentVariableLargePathStr)
     const char* baseDir     = "/tmp";
     const char* logfileName = "/this/is/a/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/long/path/to/a/logfile.log";
     char*       outputStr   = NULL;
-    char        inputString[20];
-    char        expectedStr[20];
+    char        inputString[540];
+    char        expectedStr[540];
 
     setenv ("TMPDIR", baseDir, 1);
 
     inputString[0] = '\0';
     strncat (inputString, envVar, 9);
-    strncat (inputString, logfileName, 17);
+    strncat (inputString, logfileName,515);
 
     outputStr = strReplaceEnvironmentVariable (inputString);
 
     expectedStr[0] = '\0';
     strncat (expectedStr, baseDir, 4);
-    strncat (expectedStr, logfileName, 17);
+    strncat (expectedStr, logfileName, 515);
 
     ASSERT_STREQ (outputStr, expectedStr);
 
@@ -222,7 +222,7 @@ TEST_F (CommonStrutilsTestC, replaceMultipleEnvironmentVariableValid)
     const char* baseDir     = "/tmp";
     const char* logfileName = "/test/logfile.log";
     char*       outputStr   = NULL;
-    char        expectedStr[20];
+    char        expectedStr[30];
 
     setenv ("TMPDIR", baseDir, 1);
     setenv ("TMPLOGFILE", logfileName, 1);
@@ -246,7 +246,7 @@ TEST_F (CommonStrutilsTestC, replaceMultipleEmbeddedEnvironmentVariableValid)
     const char* secondDir   = "/for";
     const char* logfileName = "/test/logfile.log";
     char*       outputStr   = NULL;
-    char        expectedStr[20];
+    char        expectedStr[30];
 
     setenv ("TMPDIR", baseDirEx, 1);
     setenv ("TMPSECONDDIR", secondDir, 1);


### PR DESCRIPTION
# Extend support of environment variables
## Summary
This pull request will add support for extended environment variables

Signed-off-by: Gary Molloy <gmolloy@velatt.com>

## Areas Affected
- [x] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [x] SCons
- [x] Unit Tests
- [ ] Examples

## Details
Adds extended support for environment variables, including support for:

- both the $() and ${} notations
- multiple environment variables

## Testing
A new unittest file has been added containing 9 tests