### PR TITLE
[MAMA] Add logging of thread names during creation

### DIFF
--- a/mama/c_cpp/src/c/mama.c
+++ b/mama/c_cpp/src/c/mama.c
@@ -1743,6 +1743,9 @@ mama_startBackgroundHelper (mamaBridge   bridgeImpl,
 
     snprintf (threadname, 256, "mama_%s_default", bridgeImpl->bridgeGetName());
 
+    mama_log (MAMA_LOG_LEVEL_FINER, "mama_startBackgroundHelper (): "
+              "Creating new background thread (name=%s).", threadname);
+
     threadStatus = wombatThread_create(threadname,
                             &impl->mStartBackgroundThread,
                             NULL,

--- a/mama/c_cpp/src/c/queue.c
+++ b/mama/c_cpp/src/c/queue.c
@@ -1339,6 +1339,10 @@ mamaDispatcher_create (mamaDispatcher *result,
     impl->mQueue = queue;
 
     snprintf (impl->mThreadName, 256, "%s%s", MAMAQUEUE_THREAD_PREFIX, qImpl->mQueueName);
+
+    mama_log (MAMA_LOG_LEVEL_FINER, "mamaDispatcher_create (): "
+              "Creating new background thread (name=%s).", impl->mThreadName);
+
     threadStatus = wombatThread_create(impl->mThreadName,
                             &thread,
                             NULL,


### PR DESCRIPTION
# Add logging of thread names during creation

## Areas Affected
*Place an 'x' within the braces to check the box*
- [x] MAMAC

## Details
When trying to optimise the deployment of MAMA based applications,
we want to make use of the thread affinity logic to bind to specific
cores. In order to do that, we need to know the names of the threads
being started by MAMA, but this is currently difficult (in particular if
you're working on an application with potentially large numbers of
threads).

This change adds standard logging to both locations where MAMA can start
new named threads - mama_startBackground, and mamaDispatcher_create. In
both cases, logging of the format:

<Method Name> (): Creating new background thread (name=<tread name>).

Has been added.

Signed-off By: Damian Maguire <dmaguire@velatt.com>

## Testing
No functional changes have been made. Testing has been performed with
unit tests and example apps, with logging observed as expected:
```
2017-07-25 08:06:02: (1ac44780) : mama 6.2.1 (entitled)
2017-07-25 08:06:02: (1ac44780) : 1.0
2017-07-25 08:06:02: (1ac44780) : mama_startBackgroundHelper ():
Creating new background thread (name=mama_qpid_default).
...
2017-07-25 08:06:34: (c7a2a780) : mamaDispatcher_create (): Creating new
background thread (name=mama_dispatcher_NO_NAME_2).
2017-07-25 08:06:34: (c7a2a780) : mamaDispatcher_create (): Creating new
background thread (name=mama_dispatcher_NO_NAME_3).
2017-07-25 08:06:34: (c7a2a780) : mamaDispatcher_create (): Creating new
background thread (name=mama_dispatcher_NO_NAME_4).
2017-07-25 08:06:34: (c7a2a780) : mamaDispatcher_create (): Creating new
background thread (name=mama_dispatcher_NO_NAME_5).
```