### PR TITLE
[MAMA] Add ability to suppress logging of payload load failure.

### DIFF
--- a/mama/c_cpp/src/c/mama.c
+++ b/mama/c_cpp/src/c/mama.c
@@ -1986,6 +1986,7 @@ mama_loadPayloadBridgeInternal  (mamaPayloadBridge* impl,
     char                    payloadImplName [256];
     char                    initFuncName    [256];
     char                    payloadVersion  [MAX_INTERNAL_PROP_LEN];
+    const char*             suppressLoadFailLogging;
     msgPayload_init         initFunc        = NULL;
     void*                   vp              = NULL;
 
@@ -2054,11 +2055,25 @@ mama_loadPayloadBridgeInternal  (mamaPayloadBridge* impl,
     if (!payloadLibHandle)
     {
         status = MAMA_STATUS_NO_BRIDGE_IMPL;
-        mama_log (MAMA_LOG_LEVEL_ERROR,
-                "mama_loadPayloadBridge(): "
-                "Could not open payload bridge library [%s] [%s]",
-                 payloadImplName,
-                 getLibError());
+
+        /* In some instances middleware's attempt to load payloads that may
+         * not be available to all clients. As this results in an 'ERROR' logged
+         * we want to be able to suppress this where it's an understood problem.
+         *
+         * Note: We don't want to suppress the other logs, as they would
+         * indicate real problems that need fixed.
+         */
+        suppressLoadFailLogging = mama_getProperty ("mama.payload.suppress_load_failure_logging");
+
+        if (NULL == suppressLoadFailLogging ||
+            (!strtobool (suppressLoadFailLogging)))
+        {
+            mama_log (MAMA_LOG_LEVEL_ERROR,
+                     "mama_loadPayloadBridge(): "
+                      "Could not open payload bridge library [%s] [%s]",
+                      payloadImplName,
+                      getLibError());
+        }
         goto error_handling_unlock;
     }
 


### PR DESCRIPTION
# Suppress Payload load failure logging
## Summary
Some middlewares may attempt to load multiple payload bridges during
initialization, some of which may not always exist. This unfortunately
results in MAMA clients having to deal with spurious 'ERROR' logging and
may make them miss occasions when the logging actually indicates a
problem.



## Areas Affected

- [x] MAMAC

## Details
This changes adds support for configurable suppressing of this logging
using the following parameter:

    mama.payload.suppress_load_failure_logging

Note: this has only been enabled for the specific case of missing
libraries for the payload. Other logging relating to payload loading
failures remains 'ERROR' level, as they represent a real issue which
should not be ignored.

Signed-off By: Damian Maguire <dmaguire@velatt.com>

## Testing
Tested using the results of the
`MamaInternalTestC.loadPayloadBridgeInvalidName` test, and a variety of
boolean values in the properties.

```
bash-4.2$ vi ../openmama-test/config/mama.properties
# mama.payload.suppress_load_failure_logging=1
bash-4.2$ UnitTestMamaC -m qpid -p wmsg -i Q --gtest_filter=MamaInternalTestC.loadPayloadBridgeInvalidName
Note: Google Test filter = MamaInternalTestC.loadPayloadBridgeInvalidName
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from MamaInternalTestC
[ RUN      ] MamaInternalTestC.loadPayloadBridgeInvalidName
2017-07-25 12:09:47: mama_loadPayloadBridge(): Could not open payload bridge library [mamaTESTimpl] [libmamaTESTimpl.so: cannot open shared object file: No such file or directory]
[       OK ] MamaInternalTestC.loadPayloadBridgeInvalidName (7 ms)
[----------] 1 test from MamaInternalTestC (7 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (7 ms total)
[  PASSED  ] 1 test.

  YOU HAVE 2 DISABLED TESTS

bash-4.2$ vi ../openmama-test/config/mama.properties
mama.payload.suppress_load_failure_logging=True
bash-4.2$ UnitTestMamaC -m qpid -p wmsg -i Q --gtest_filter=MamaInternalTestC.loadPayloadBridgeInvalidName
Note: Google Test filter = MamaInternalTestC.loadPayloadBridgeInvalidName
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from MamaInternalTestC
[ RUN      ] MamaInternalTestC.loadPayloadBridgeInvalidName
[       OK ] MamaInternalTestC.loadPayloadBridgeInvalidName (10 ms)
[----------] 1 test from MamaInternalTestC (10 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (10 ms total)
[  PASSED  ] 1 test.

  YOU HAVE 2 DISABLED TESTS

bash-4.2$ vi ../openmama-test/config/mama.properties
mama.payload.suppress_load_failure_logging=0
bash-4.2$ UnitTestMamaC -m qpid -p wmsg -i Q --gtest_filter=MamaInternalTestC.loadPayloadBridgeInvalidName
Note: Google Test filter = MamaInternalTestC.loadPayloadBridgeInvalidName
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from MamaInternalTestC
[ RUN      ] MamaInternalTestC.loadPayloadBridgeInvalidName
2017-07-25 12:10:31: mama_loadPayloadBridge(): Could not open payload bridge library [mamaTESTimpl] [libmamaTESTimpl.so: cannot open shared object file: No such file or directory]
[       OK ] MamaInternalTestC.loadPayloadBridgeInvalidName (5 ms)
[----------] 1 test from MamaInternalTestC (6 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (6 ms total)
[  PASSED  ] 1 test.

  YOU HAVE 2 DISABLED TESTS

bash-4.2$ vi ../openmama-test/config/mama.properties
mama.payload.suppress_load_failure_logging=1
bash-4.2$ UnitTestMamaC -m qpid -p wmsg -i Q --gtest_filter=MamaInternalTestC.loadPayloadBridgeInvalidName
Note: Google Test filter = MamaInternalTestC.loadPayloadBridgeInvalidName
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from MamaInternalTestC
[ RUN      ] MamaInternalTestC.loadPayloadBridgeInvalidName
[       OK ] MamaInternalTestC.loadPayloadBridgeInvalidName (7 ms)
[----------] 1 test from MamaInternalTestC (7 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (9 ms total)
[  PASSED  ] 1 test.

  YOU HAVE 2 DISABLED TESTS
```