### PR TITLE
[MAMA] off-by-one error in endpointpool

### DIFF
--- a/mama/c_cpp/src/c/bridge/qpid/endpointpool.c
+++ b/mama/c_cpp/src/c/bridge/qpid/endpointpool.c
@@ -48,8 +48,8 @@ typedef struct endpointPoolImpl
     char*       mName;
     wtable_t    mContainer;
     void*       mBuffer;
-    size_t      mBufferOffset;
-    size_t      mBufferLimit;
+    size_t      mBufferIndex;       // 0-relative
+    size_t      mBufferSize;
 } endpointPoolImpl;
 
 typedef struct endpointExistNode
@@ -166,7 +166,7 @@ endpointPool_create (endpointPool_t* endpoints, const char* name)
     }
 
     /* On successful memory allocation, update the current limit */
-    newEndpoints->mBufferLimit = ENDPOINT_POOL_BUFFER_CHUNK_SIZE;
+    newEndpoints->mBufferSize = ENDPOINT_POOL_BUFFER_CHUNK_SIZE;
 
     /* Create the top level endpoints table */
     newEndpoints->mContainer = wtable_create (name,
@@ -377,14 +377,14 @@ endpointPool_getRegistered (endpointPool_t  endpoints,
     }
 
     /* Reset the offset for iteration */
-    impl->mBufferOffset = 0;
+	impl->mBufferIndex = 0;
 
     /* Iterate over the table, appending the results to the buffer */
     wtable_for_each (registeredTable, endpointPoolImpl_appendEachEndpoint,
                      (void*)impl);
 
     /* Populate the return values */
-    *count  = impl->mBufferOffset;
+	*count  = impl->mBufferIndex;
     *opaque = (void**)impl->mBuffer;
 
     return MAMA_STATUS_OK;
@@ -488,13 +488,13 @@ endpointPoolImpl_extendBuffer (endpointPoolImpl* impl, size_t size)
     }
 
     /* Don't need to do anything if buffer is already allocated */
-    if (size <= impl->mBufferLimit)
+    if (size <= impl->mBufferSize)
     {
         return MAMA_STATUS_OK;
     }
 
     /* Increment upfront by products of chunk size */
-    newSize = impl->mBufferLimit;
+    newSize = impl->mBufferSize;
     while (newSize < size)
     {
         newSize += ENDPOINT_POOL_BUFFER_CHUNK_SIZE;
@@ -520,10 +520,10 @@ endpointPoolImpl_appendEachEndpoint (wtable_t      table,
                                      void*         closure)
 {
     endpointPoolImpl*   impl        = (endpointPoolImpl*) closure;
-    size_t              required    = sizeof(void*) * impl->mBufferOffset;
+    size_t              required    = sizeof(void*) * (impl->mBufferIndex +1);
 
     /* Get more space if required */
-    if (required > impl->mBufferLimit)
+    if (required > impl->mBufferSize)
     {
         endpointPoolImpl_extendBuffer (impl, required);
     }
@@ -538,10 +538,10 @@ endpointPoolImpl_appendEachEndpoint (wtable_t      table,
     }
 
     /* Update the next offset with the data */
-    ((void**)impl->mBuffer)[impl->mBufferOffset] = data;
+    ((void**)impl->mBuffer)[impl->mBufferIndex] = data;
 
     /* Increment the offset */
-    impl->mBufferOffset++;
+    impl->mBufferIndex++;
 }
 
 void

--- a/mama/c_cpp/src/c/bridge/qpid/endpointpool.c
+++ b/mama/c_cpp/src/c/bridge/qpid/endpointpool.c
@@ -377,7 +377,7 @@ endpointPool_getRegistered (endpointPool_t  endpoints,
     }
 
     /* Reset the offset for iteration */
-	impl->mBufferIndex = 0;
+    impl->mBufferIndex = 0;
 
     /* Iterate over the table, appending the results to the buffer */
     wtable_for_each (registeredTable, endpointPoolImpl_appendEachEndpoint,
@@ -385,7 +385,7 @@ endpointPool_getRegistered (endpointPool_t  endpoints,
 
     /* Populate the return values */
 	*count  = impl->mBufferIndex;
-    *opaque = (void**)impl->mBuffer;
+   *opaque = (void**)impl->mBuffer;
 
     return MAMA_STATUS_OK;
 }

--- a/mama/c_cpp/src/c/bridge/qpid/endpointpool.c
+++ b/mama/c_cpp/src/c/bridge/qpid/endpointpool.c
@@ -384,8 +384,8 @@ endpointPool_getRegistered (endpointPool_t  endpoints,
                      (void*)impl);
 
     /* Populate the return values */
-	*count  = impl->mBufferIndex;
-   *opaque = (void**)impl->mBuffer;
+    *count  = impl->mBufferIndex;
+    *opaque = (void**)impl->mBuffer;
 
     return MAMA_STATUS_OK;
 }


### PR DESCRIPTION
## Summary
There is an off-by-one error in endpointPoolImpl_appendEachEndpoint which causes heap corruption.

## Areas Affected
*Place an 'x' within the braces to check the box*
- [x] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
When run under valgrind the offending code produces a memory error similar to the following, after which the program will terminate with a SEGV.

```
Invalid write of size 8
   at 0x5F4E5A2: endpointPoolImpl_appendEachEndpoint (endpointpool.c:541)
   by 0x56E8C87: wtable_for_each (wtable.c:64)
   by 0x5F4E2E5: endpointPool_getRegistered (endpointpool.c:383)
   by 0x5F4DB24: zmqBridgeMamaTransportImpl_dispatchThread (transport.c:1085)
   by 0x3456E07A50: start_thread (pthread_create.c:301)
   by 0x34566E89AC: clone (clone.S:115)
 Address 0x5b61b20 is 0 bytes after a block of size 1,024 alloc'd
   at 0x4A05EDF: calloc (vg_replace_malloc.c:710)
   by 0x5F4DE2E: endpointPool_create (endpointpool.c:159)
   by 0x5F4C368: zmqBridgeMamaTransport_create (transport.c:399)
   by 0x56D61B9: mamaTransport_create (transport.c:870)
   by 0x4F07546: Transact::MamaConnectionImpl::MamaConnectionImpl(char const*) (MamaConnectionImpl.cpp:189)
   by 0x4F082DB: Transact::IConnection::getDefaultConnection() (MamaConnectionImpl.cpp:293)
   by 0x4F2F4C4: Transact::ISession::getDefaultSession() (MamaSessionImpl.cpp:110)
   by 0x4C925C5: Transact::RequestImpl::RequestImpl(Transact::ISession*) (RequestImpl.cpp:76)
   by 0x4C928C0: Transact::IRequest::CreateRequest() (RequestImpl.cpp:50)
   by 0x403667: benchmarkRequestCreation(bool) (RequestBenchClient.cpp:231)
   by 0x403C90: main (RequestBenchClient.cpp:128)
```
Note that it is difficult to reproduce the problem with the default qpid transport, since qpid is not fast enough to trigger the behavior.

Since the zmq transport "borrows" code from qpid, it is easier to reproduce the problem with zmq.

I've also renamed the relevant variables to better describe how they are used, which also makes the bug (and fix) more clear.

## Testing
With this fix in place our internal volume/throughput tests no longer trigger the warning in valgrind, nor do they crash.
