### PR TITLE
[EXAMPLES] add missing property

### DIFF
--- a/mama/c_cpp/src/examples/mama.properties
+++ b/mama/c_cpp/src/examples/mama.properties
@@ -58,6 +58,7 @@ mama.qpid.transport.broker.incoming_url=topic://127.0.0.1/MAMA/%r/%S/%s
 # This is where we listen for replies during request / reply
 mama.qpid.transport.broker.reply_url=topic://127.0.0.1/MAMA/%u
 
+mama.qpid.transport.pub.outgoing_url=amqp://127.0.0.1:6666
 # Where qpid is going to listen to for data to be pushed to
 mama.qpid.transport.pub.incoming_url=amqp://~127.0.0.1:7777
 # Where qpid publisher is to send data to once subscription is created


### PR DESCRIPTION
## Summary
Missing definition in mama.properties

## Areas Affected
*Place an 'x' within the braces to check the box*
- [ ] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [x] Examples

## Details
The definition of mama.qpid.transport.pub.outgoing_url is missing from mama.properties.

## Testing
Adding the property manually allows for running all examples.