### PR TITLE
[MAMA] fix leak in mamaMsg_detach

### DIFF
--- a/mama/c_cpp/src/c/queue.c
+++ b/mama/c_cpp/src/c/queue.c
@@ -168,6 +168,7 @@ mamaQueue_createReuseableMsg (mamaQueueImpl*  impl)
 		return status;
 	}
 
+   // NOTE: this is superfluous -- earlier call to mamaMsgImpl_createForPayload sets owner to 0
 	/*We don't want to destroy the bridge message when the mamamsg is
 	 * destroyed as we won't own it*/
 	if (MAMA_STATUS_OK!=(status=mamaMsgImpl_setMessageOwner (impl->mMsg, 0)))
@@ -1201,43 +1202,12 @@ mamaQueueImpl_detachMsg (mamaQueue queue,
 
     if (msg == impl->mMsg)
     {
-        if (MAMA_STATUS_OK!=(status=mamaMsg_create (&(impl->mMsg))))
-        {
-            mama_log (MAMA_LOG_LEVEL_ERROR, "mamaQueueImpl_detachMsg():"
-                      " Could not create new message.");
-            impl->mMsg = msg;
-            return status;
-        }
-
-        /*We now have to set the bridge and queue on this new message*/
-        if (MAMA_STATUS_OK!=(status=mamaMsgImpl_setBridgeImpl (impl->mMsg,
-                        impl->mBridgeImpl)))
-        {
-            mama_log (MAMA_LOG_LEVEL_ERROR, "mamaQueueImpl_detachMsg():"
-                      " Could not set bridge on new message.");
-            mamaMsg_destroy (impl->mMsg);
-            impl->mMsg = msg;
-            return status;
-        }
-
-        /*We don't want to destroy the bridge message when the mamamsg is
-         * destroyed as we won't own it*/
-        if (MAMA_STATUS_OK!=(status=mamaMsgImpl_setMessageOwner (impl->mMsg, 0)))
-        {
-            mama_log (MAMA_LOG_LEVEL_ERROR, "mamaQueueImpl_detachMsg():"
-                      " Could not set owner on new message.");
-            return status;
-        }
-
-        if (MAMA_STATUS_OK!=(status=mamaMsgImpl_setQueue (impl->mMsg, queue)))
-        {
-            mama_log (MAMA_LOG_LEVEL_ERROR, "mamaQueueImpl_detachMsg():"
-                      " Could not set queue on new message.");
-            mamaMsg_destroy (impl->mMsg);
-            impl->mMsg = msg;
-            return status;
-        }
+       // set queue's msg to NULL -- will be re-created (properly) when needed
+       // (mamaQueueImpl_getMsg -> mamaQueue_createReuseableMsg)
+       // this resolves a leak of payload when calling detach
+       impl->mMsg = 0;
     }
+
     return MAMA_STATUS_OK;
 }
 
@@ -1394,7 +1364,7 @@ mamaDispatcher_destroy (mamaDispatcher dispatcher)
     wombatThread_destroy (impl->mThreadName);
 
     impl->mQueue->mDispatcher = NULL;
-    impl->mThread = 0; 
+    impl->mThread = 0;
     free (impl);
     return MAMA_STATUS_OK;
 }


### PR DESCRIPTION
## Summary
*This should be a brief one line description of the pull request*

## Areas Affected
*Place an 'x' within the braces to check the box*
- [x] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
### Detached messages
There is a bug in the OpenMAMA and OpenMAMA-zmq code related to detaching messages that causes the payload to leak on every detach.  

When a message is detached, MAMA calls `mamaQueueImpl_detachMsg` which detaches the reusable message that is associated with the queue (by marking its mIsOwner flag), and then calls `mamaMsg_create` to create a new queue message.  

There are two problems with this code:

- `mamaMsg_create` also creates a payload, but that payload gets overwritten later on, and so the original payload leaks
- instead of calling `mamaMsg_create`, the detach code should probably be calling `mamaQueue_createReuseableMsg`, which is what is done to create the original message in the first place (by `mamaQueueImpl_getMsg`, which calls `mamaQueue_createReuseableMsg` when the queue's mMsg pointer is NULL).

I tried modifying the existing code, but there doesn't appear to be any way to prevent the payload leak using that approach -- so I simply set the queue's mMessage member to NULL when detaching the message, and it gets recreated when needed as mentioned above (`mamaQueueImpl_getMsg`, etc.).



## Testing
Prior to the fix, running our internal test program under valgrind produced output similar to the following, after which the program would consume all memory and be killed by OOM.

```
 3,580 (640 direct, 2,940 indirect) bytes in 10 blocks are definitely lost in loss record 86 of 119
    at 0x4A05EDF: calloc (vg_replace_malloc.c:710)
    by 0x7C033F0: ???
    by 0x5C121B8: mamaMsg_create (msg.c:832)
    by 0x5C2A21E: mamaQueueImpl_detachMsg (queue.c:1204)
    by 0x5C112B4: mamaMsg_detach (msg.c:236)
    by 0x545CFD5: Transact::MamaMessageImpl::detach(Transact::IMessage*&) (MamaMessageImpl.cpp:345)
    by 0x4038C3: MyListener::onMessage(char const*, Transact::IMessage*) (detachTest.cpp:60)
    by 0x545A101: Transact::MamaListenerImpl::onMsg(mamaSubscriptionImpl_*, mamaMsgImpl_*, void*, void*) (MamaListenerImpl.cpp:148)
    by 0x5E9D85F: mamaEnvSubscription_onMsgBasic (mamaEnvSubscription.c:308)
    by 0x5C31FC4: mamaSubscription_forwardMsg (subscription.c:1420)
    by 0x5C3362D: mamaSubscription_processMsg (subscription.c:2312)
    by 0x66DF0E5: ???
    by 0x6921E9F: ???
    by 0x6900130: ???
    by 0x66DE295: ???
    by 0x5C299B9: mamaQueue_dispatch (queue.c:824)
    by 0x5C2A48D: dispatchThreadProc (queue.c:1294)
    by 0x33C0607AA0: start_thread (in /lib64/libpthread-2.12.so)
    by 0x33BFEE8BCC: clone (in /lib64/libc-2.12.so)
``` 

Unfortunately the OpenMAMA unit tests do not include a test for mamaMsg_detach, nor do they check for leaks (as far as I can tell).