### PR TITLE
[COMMON] Fix potential buffer overflow in strToVersionInfo

### DIFF
--- a/common/c_cpp/src/c/strutils.c
+++ b/common/c_cpp/src/c/strutils.c
@@ -629,7 +629,7 @@ int strToVersionInfo(const char* s, versionInfo* version)
                     {
                         /* From this point on is the extra string - grab it */
                         strncpy (version->mExtra, token + j, sizeof(version->mExtra));
-                        version->mExtra[VERSION_INFO_EXTRA_MAX] = '\0';
+                        version->mExtra[VERSION_INFO_EXTRA_MAX - 1] = '\0';
 
                         /* Chop the string where the numbers stop */
                         token[j] = '\0';


### PR DESCRIPTION
Potential buffer overflow in strToVersionInfo. Detected using clang with
address sanitizer. No longer visible after fix. Common unit tests pass
as expected.

Signed-off By: Damian Maguire <dmaguire@velatt.com>

## Areas Affected
*Place an 'x' within the braces to check the box*
- [x] Common

## Testing
Address sanitizer reported issue when running `UnitTestCommonC`. Resolved after implementation of fix. 
