### PR TITLE
Fix issue 295 patch.

### DIFF
--- a/mamda/c_cpp/src/cpp/orderbooks/MamdaOrderBookWriter.cpp
+++ b/mamda/c_cpp/src/cpp/orderbooks/MamdaOrderBookWriter.cpp
@@ -486,7 +486,8 @@ namespace Wombat
         msg.addU32  (NULL, MamdaOrderBookFields::PL_SIZE_CHANGE->getFid(),
                      (mama_u32_t)level->getSizeChange());
 
-        if ((NULL == bookTime || (bookTime->compare (level->getTime())!=0)))
+        if ((NULL == bookTime || (bookTime->compare (level->getTime())!=0))
+                    || bookTime->empty() != level->getTime().empty())
         {
             msg.addDateTime (NULL, MamdaOrderBookFields::PL_TIME->getFid(),
                              level->getTime());


### PR DESCRIPTION
Signed-off-by: cjwmorgan-sol-sys <Christopher.Morgan@solacesystems.com>

# Fix for Issue 295
## Summary
Allows MamdaOrderBookWriter to add datetime 1970-01-01 00:00:00 to book messages.

## Areas Affected
*Place an 'x' within the braces to check the box*
- [ ] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [x] MAMDA
- [x] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples
