### PR TITLE
Reset number of plugins on shutdown

### DIFF
--- a/mama/c_cpp/src/c/plugin.c
+++ b/mama/c_cpp/src/c/plugin.c
@@ -367,6 +367,9 @@ mama_shutdownPlugins (void)
             }
         }
     }
+    
+    gPluginNo = 0;
+
     return status;
 }
 

--- a/mama/c_cpp/src/gunittest/c/openclosetest.cpp
+++ b/mama/c_cpp/src/gunittest/c/openclosetest.cpp
@@ -281,3 +281,28 @@ TEST_F (MamaOpenCloseTestC, GetNullPayloadBridge)
 
     ASSERT_EQ (MAMA_STATUS_NULL_ARG, mama_getPayloadBridge (&foundBridge, NULL));
 }
+
+/*  Description:     Load the middleware bridge, open and close
+ *                   150 times, then ensure that you can continue
+ *                   to open and close without errors due to limit
+ *                   of plugins having been reached.
+ *
+ *  Expected Result: MAMA_STATUS_OK
+ */
+
+TEST_F(MamaOpenCloseTestC, OpenCloseReopenManyTimes)
+{
+    mamaBridge bridge;
+
+    for(int i = 0; i < 150; i++)
+    {
+        mama_loadBridge (&bridge, getMiddleware());
+        mama_open();
+        mama_close();
+
+    }
+        ASSERT_EQ (MAMA_STATUS_OK, mama_loadBridge (&bridge, getMiddleware()));
+        ASSERT_EQ(MAMA_STATUS_OK, mama_open());
+        ASSERT_EQ(MAMA_STATUS_OK, mama_close());
+}
+


### PR DESCRIPTION
# Reset number of plugins on shutdown
## Summary
Tracking variable of plugins "gPluginNo" is reset to 0 on shutdown of plugins.

## Areas Affected
*Place an 'x' within the braces to check the box*
- [X] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [X] Unit Tests
- [ ] Examples

## Details
This change resets the number of plugins back to 0, when shutting down plugins. This means that it is harder to reach the hardcoded limit of 100 Plugins by accident and removes certain program crashes and exceptions.

## Testing
Added a unit test for this change, it opens and closes mama 150 times (well over the limit of 100). This unittest effectively tests that the number of plugins is reset on shutdown every time. 
