### PR TITLE
Added OpenMAMA Version to Log

### DIFF
--- a/mama/c_cpp/src/c/mama.c
+++ b/mama/c_cpp/src/c/mama.c
@@ -947,14 +947,13 @@ mama_openWithPropertiesCount (const char* path,
 
     if (strlen( (char*) gEntitlementBridges))
     {
-        mama_log (MAMA_LOG_LEVEL_FINE, "%s (entitled)",mama_version);
+        mama_log (MAMA_LOG_LEVEL_WARN, "%s (entitled)",mama_version);
     }
     else
     {
-        mama_log (MAMA_LOG_LEVEL_FINE, "%s (non entitled)",mama_version);
+        mama_log (MAMA_LOG_LEVEL_WARN, "%s (non entitled)",mama_version);
     }
-
-
+    
     /* Iterate the currently loaded middleware bridges, log their version, and
      * increment the count of open bridges.
      */
@@ -965,7 +964,7 @@ mama_openWithPropertiesCount (const char* path,
 
         if (middlewareLib)
         {
-            mama_log (MAMA_LOG_LEVEL_FINE,
+            mama_log (MAMA_LOG_LEVEL_WARN,
                     middlewareLib->bridge->bridgeGetVersion());
 
             /* Increment the reference count for each bridge loaded */


### PR DESCRIPTION
# Added OpenMAMA Version to Log
## Summary
This change ensures the OpenMAMA version is output by default

## Areas Affected
*Place an 'x' within the braces to check the box*
- [X] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
This changes the log level of the statement which prints the version of OpenMAMA, meaning that OpenMAMA now logs its version by default.

## Testing
Tested this change by running OpenMAMA with the change and found that the version was logged.