### PR TITLE
LoadPlugins Realloc

### DIFF
--- a/mama/c_cpp/src/c/plugin.c
+++ b/mama/c_cpp/src/c/plugin.c
@@ -39,10 +39,13 @@
 #define PLUGIN_PROPERTY "mama.plugin.name_"
 #define PLUGIN_NAME "mamaplugin"
 
-#define MAX_PLUGINS 100
+#define INITIAL_PLUGIN_ARRAY_SIZE 1
 #define MAX_PLUGIN_STRING 1024
 
 #define MAX_FUNC_STRING 256
+
+int gNumPlugins = 0;
+int gCurrentPluginSize = INITIAL_PLUGIN_ARRAY_SIZE;
 
 /**
  * @brief Mechanism for registering required plugin functions.
@@ -118,7 +121,7 @@ typedef struct mamaPluginImpl_
 
 } mamaPluginImpl;
 
-static mamaPluginImpl*      gPlugins[MAX_PLUGINS];
+static mamaPluginImpl**      gPlugins;
 static volatile int         gPluginNo = 0;
 
 /**
@@ -159,6 +162,11 @@ mamaPlugin_findPlugin (const char* name);
 mama_status
 mama_loadPlugin (const char* pluginName);
 
+/**
+*   Reallocate space for plugins when current limit is reached
+*/
+static void
+pluginPropertiesCb(const char* name, const char* value, void* closure);
 
 /**
  * Register function pointers associated with a specific plugin.
@@ -202,19 +210,17 @@ mama_initPlugins(void)
     const char*     prop             = NULL;
     char            propString[MAX_PLUGIN_STRING];
 
-    for (pluginCount = 0; pluginCount < MAX_PLUGINS; pluginCount++)
+    if(!gPlugins)
     {
-        snprintf(propString, MAX_PLUGIN_STRING,
-            PLUGIN_PROPERTY"%d",
-            pluginCount);
-
-        prop = properties_Get (mamaInternal_getProperties (), propString);
-        if (prop != NULL && strlen(prop)!= 0)
-        {
-            mama_log (MAMA_LOG_LEVEL_FINE, "mama_initPlugins(): Initialising [%s] %s", propString, prop);
-            mama_loadPlugin (prop);
-        }
+        gPlugins = calloc (INITIAL_PLUGIN_ARRAY_SIZE, sizeof(mamaPluginImpl*));
     }
+
+    properties_ForEach (mamaInternal_getProperties(), pluginPropertiesCb, NULL);
+
+#ifdef WITH_ENTERPRISE
+    mama_log (MAMA_LOG_LEVEL_FINE, "mama_initPlugins(): Initialising mamacenterprise");
+    mama_loadPlugin ("mamacenterprise");
+#endif /* WITH_ENTERPRISE */
 
     return MAMA_STATUS_OK;
 }
@@ -335,7 +341,7 @@ mama_shutdownPlugins (void)
     int          plugin = 0;
     int          ret    = 0;
 
-    for (plugin = 0; plugin <= gPluginNo; plugin++)
+    for (plugin = 0; plugin < gPluginNo; plugin++)
     {
         if (gPlugins[plugin] != NULL)
         {
@@ -367,6 +373,10 @@ mama_shutdownPlugins (void)
             }
         }
     }
+
+    free(gPlugins);
+    gPluginNo = 0;
+
     return status;
 }
 
@@ -376,7 +386,7 @@ mamaPlugin_firePublisherPreSendHook (mamaPublisher publisher, mamaMsg message)
     mama_status  status = MAMA_STATUS_OK;
     int          plugin = 0;
 
-    for (plugin = 0; plugin <= gPluginNo; plugin++)
+    for (plugin = 0; plugin < gPluginNo; plugin++)
     {
         if (gPlugins[plugin] != NULL)
         {
@@ -402,7 +412,7 @@ mamaPlugin_fireTransportPostCreateHook (mamaTransport transport)
     mama_status  status = MAMA_STATUS_OK;
     int          plugin = 0;
 
-    for (plugin = 0; plugin <= gPluginNo; plugin++)
+    for (plugin = 0; plugin < gPluginNo; plugin++)
     {
         if (gPlugins[plugin] != NULL)
         {
@@ -464,4 +474,25 @@ mamaPlugin_findPlugin (const char* name)
         }
     }
     return NULL;
+}
+
+static void pluginPropertiesCb(const char* name, const char* value, void* closure)
+{
+    if(name)
+    {
+        if(strstr(name, PLUGIN_PROPERTY) != NULL)
+        {
+            gNumPlugins++;
+            if(gNumPlugins > gCurrentPluginSize)
+            {
+                gCurrentPluginSize *= 2;
+                printf("current plugin size realloced, now: %d \n ",gCurrentPluginSize);
+                gPlugins = (mamaPluginImpl**) realloc (gPlugins,  sizeof(mamaPluginImpl*) * gCurrentPluginSize);
+            }
+
+            mama_log (MAMA_LOG_LEVEL_FINE, "mama_initPlugins(): Initialising %s", value);
+            mama_loadPlugin (value);
+
+        }
+    }
 }


### PR DESCRIPTION
# LoadPlugins Realloc
## Summary
loadPlugins can realloc to provide for more plugins

## Areas Affected
*Place an 'x' within the braces to check the box*
- [x] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
Changed max plugin limit to 20, when this is reached, the program now reallocs the memory assigned for it and doubles the amount of plugins it can store each time the limit is hit.

## Testing
For testing, I changed the limit to be very low (2, then 1) and printed out when the memory was reallocated. I did this because I had 4 plugins with which I could test the change, and I could watch the limit be changed and the memory reallocated by using printf statements. However, since I dont have 20 plugins with which to test this change I cannot test this change with the current limit of 20 as it is. 

Signed-off-by: Aaron Sneddon <asneddon@velatt.com>