### PR TITLE
MAMA: Moved background thread destroy to stop

### DIFF
--- a/mama/c_cpp/src/c/mama.c
+++ b/mama/c_cpp/src/c/mama.c
@@ -1568,14 +1568,6 @@ mama_closeCount (unsigned int* count)
                         wlock_destroy(middlewareLib->bridge->mLock);
                     }
 
-                    /* If there was a background thread, clean it up */
-                    if (middlewareLib->bridge->mStartBackgroundThread)
-                    {
-                        // Get name of start background thread and destroy it
-                        const char* threadName = wombatThread_getThreadName(middlewareLib->bridge->mStartBackgroundThread);
-                        wombatThread_destroy (threadName);
-                    }
-
                     free (middlewareLib->bridge);
                     middlewareLib->bridge = NULL;
                 }
@@ -1833,6 +1825,15 @@ mama_stop (mamaBridge bridgeImpl)
         }
     }
     wthread_static_mutex_unlock(&gImpl.myLock);
+
+    /* If there was a background thread, clean it up */
+    if (impl->mStartBackgroundThread)
+    {
+        // Get name of start background thread and destroy it
+        const char* threadName = wombatThread_getThreadName(impl->mStartBackgroundThread);
+        wombatThread_destroy(threadName);
+    }
+
     return rval;
 }
 


### PR DESCRIPTION
Was previously in mama_close when it should have been in mama_stop

For details, see #319

Signed-off-by: Frank Quinn <fquinn.ni@gmail.com>