### PR TITLE
Fixed crash with entitlement subscription

### DIFF
--- a/mama/c_cpp/src/c/subscription.c
+++ b/mama/c_cpp/src/c/subscription.c
@@ -1239,7 +1239,7 @@ mamaSubscription_getSubjectContext (mamaSubscription subscription,
                 mamaSubscription_getTransport(subscription, &tport);
                 mamaTransportImpl_getEntitlementBridge(tport, &entBridge);
 
-                entBridge->createSubscription (entBridge, &(self->mSubjectContext));
+                entBridge->createSubscription (entBridge, context);
             }
         }
 


### PR DESCRIPTION
As reported in #300 - there was a copy and paste error
when the code was last refactored which is corrected with
this fix.

Signed-off-by: Frank Quinn <fquinn.ni@gmail.com>