### PR TITLE
Reset plugins to null to avoid double free

### DIFF
--- a/mama/c_cpp/src/c/plugin.c
+++ b/mama/c_cpp/src/c/plugin.c
@@ -375,6 +375,7 @@ mama_shutdownPlugins (void)
     }
 
     free(gPlugins);
+    gPlugins  = NULL;
     gPluginNo = 0;
 
     return status;


### PR DESCRIPTION
Double free was introduced by recent plugin change. This should
prevent it.

Signed-off-by: Frank Quinn <fquinn.ni@gmail.com>