### PR TITLE
Modified MAMA default log level to NORMAL

### DIFF
--- a/mama/c_cpp/src/c/log.c
+++ b/mama/c_cpp/src/c/log.c
@@ -77,7 +77,7 @@ static PMRSWLock g_lock = NULL;
 
 FILE*        gMamaLogFile               = NULL;
 FILE*        gMamaControlledLogFile     = NULL;
-MamaLogLevel gMamaLogLevel              = MAMA_LOG_LEVEL_WARN;
+MamaLogLevel gMamaLogLevel              = MAMA_LOG_LEVEL_NORMAL;
 mamaLogCb    gMamaLogFunc               = mama_logDefault;
 mamaLogCb    gMamaForceLogFunc          = mama_forceLogDefault;
 mamaLogCb3   gMamaForceLogPrefixFunc    = mama_forceLogPrefixDefault;


### PR DESCRIPTION
Has previously been WARN. It's unpleasant to have to set a log
level to WARN to print something by default. The onus should be
on the application to choose its default log level if NORMAL is
not efficient, but NORMAL should be the default. Otherwise
stats, versions etc have to declare themselves as warnings just
to get printed.

Signed-off-by: Frank Quinn <fquinn.ni@gmail.com>