### PR TITLE
Fixed few JVM crashes when calling Mama.loadPayloadBridge of Java API

### DIFF
--- a/mama/c_cpp/src/c/mama.c
+++ b/mama/c_cpp/src/c/mama.c
@@ -384,7 +384,7 @@ mamaInternal_loadProperties (const char *path,
      * non-defaults were specified */
     if( fileProperties == 0 && (!usingDefaults || 0 == properties_Count(gProperties)))
     {
-        mama_log (MAMA_LOG_LEVEL_ERROR, "Failed to open properties file.\n");
+        mama_log (MAMA_LOG_LEVEL_ERROR, "Failed to open properties file.");
         return;
     }
 
@@ -2098,6 +2098,7 @@ mama_loadPayloadBridgeInternal  (mamaPayloadBridge* impl,
 
     if (NULL == initFunc)
     {
+        status = MAMA_STATUS_INVALID_ARG;
         mama_log (MAMA_LOG_LEVEL_ERROR,
                   "mama_loadPayloadBridgeInternal (): "
                   "Failed to initialise payload bridge [%s]. "
@@ -2159,6 +2160,7 @@ mama_loadPayloadBridgeInternal  (mamaPayloadBridge* impl,
             mamaInternal_getMetaProperty (payloadVersion),
             &bridgeMamaVersion))
     {
+        status = MAMA_STATUS_INVALID_ARG;
         mama_log (MAMA_LOG_LEVEL_ERROR,
                   "mama_loadBridge (): "
                   "Failed to initialise middleware bridge [%s]. "
@@ -2170,6 +2172,7 @@ mama_loadPayloadBridgeInternal  (mamaPayloadBridge* impl,
     /* Fail to load if bridge and API versions are incompatible */
     if (! mama_areVersionsCompatibleInternal (gImpl.version, bridgeMamaVersion))
     {
+        status = MAMA_STATUS_INVALID_ARG;
         mama_log (MAMA_LOG_LEVEL_ERROR,
                   "mama_loadPayloadBridgeInternal (): "
                   "Failed to initialise payload bridge [%s]. "
@@ -2609,6 +2612,7 @@ mama_loadBridgeWithPathInternal (mamaBridge* impl,
 
     if (NULL == initFunc)
     {
+        status = MAMA_STATUS_INVALID_ARG;
         mama_log (MAMA_LOG_LEVEL_ERROR,
                   "mama_loadBridge (): "
                   "Failed to initialise middleware bridge [%s]. "
@@ -2678,6 +2682,7 @@ mama_loadBridgeWithPathInternal (mamaBridge* impl,
             mamaBridgeImpl_getMetaProperty (*impl, MAMA_PROP_BARE_COMPILE_TIME_VER),
             &bridgeMamaVersion))
     {
+        status = MAMA_STATUS_INVALID_ARG;
         mama_log (MAMA_LOG_LEVEL_ERROR,
                   "mama_loadBridge (): "
                   "Failed to initialise middleware bridge [%s]. "
@@ -2689,6 +2694,7 @@ mama_loadBridgeWithPathInternal (mamaBridge* impl,
     /* Fail to load if bridge and API versions are incompatible */
     if (! mama_areVersionsCompatibleInternal (gImpl.version, bridgeMamaVersion))
     {
+        status = MAMA_STATUS_INVALID_ARG;
         mama_log (MAMA_LOG_LEVEL_ERROR,
                   "mama_loadBridge (): "
                   "Failed to initialise middleware bridge [%s]. "

--- a/mama/c_cpp/src/cpp/mamacpp.cpp
+++ b/mama/c_cpp/src/cpp/mamacpp.cpp
@@ -77,7 +77,6 @@ namespace Wombat
     mamaBridge Mama::getMiddlewareBridge (const char* middleware)
     {
         mamaBridge bridge = NULL;
-        mama_status status = MAMA_STATUS_OK; 
 
         if (NULL == middleware)
         {
@@ -88,7 +87,7 @@ namespace Wombat
          * middleware can't be NULL. Clients can infer that a bridge isn't
          * available from a NULL return.
          */
-        status = mama_getMiddlewareBridge (&bridge, middleware);
+        mama_getMiddlewareBridge (&bridge, middleware);
         
         return bridge;
     }
@@ -103,7 +102,6 @@ namespace Wombat
     mamaPayloadBridge Mama::getPayloadBridge (const char* payload)
     {
         mamaPayloadBridge payloadBridge = NULL;
-        mama_status       status = MAMA_STATUS_OK;
 
         if (NULL == payload)
         {
@@ -114,7 +112,7 @@ namespace Wombat
          * payload can't be NULL. Clients can infer that a bridge isn't
          * available from a NULL return.
          */
-        status = mama_getPayloadBridge (&payloadBridge, payload);
+        mama_getPayloadBridge (&payloadBridge, payload);
 
         return payloadBridge;
     }

--- a/mama/jni/src/c/mamajni.c
+++ b/mama/jni/src/c/mamajni.c
@@ -98,6 +98,9 @@ JNIEXPORT jobject JNICALL Java_com_wombat_mama_Mama_loadBridge
     const char* path_c          = NULL;
     jclass      bridgeClass     =
                     (*env)->FindClass(env,"com/wombat/mama/MamaBridge");
+
+    if(!bridgeClass) return NULL;/*Exception auto thrown*/
+
     if (middleware)
     {
         middleware_c = (*env)->GetStringUTFChars (env,middleware,0);
@@ -160,6 +163,9 @@ JNIEXPORT jobject JNICALL Java_com_wombat_mama_Mama_loadPayloadBridge
     jobject             result             = NULL;
     jclass              payloadBridgeClass =
                     (*env)->FindClass(env,"com/wombat/mama/MamaPayloadBridge");
+
+    if(!payloadBridgeClass) return NULL;/*Exception auto thrown*/
+
     if (name)
     {
         name_c = (*env)->GetStringUTFChars (env,name,0);

--- a/mama/jni/src/c/mamamsgjni.c
+++ b/mama/jni/src/c/mamamsgjni.c
@@ -4016,11 +4016,11 @@ JNIEXPORT void JNICALL Java_com_wombat_mama_MamaMsg_createForPayloadBridge
 
     payloadBridgePointer = (*env)->GetLongField (env,
                                                  payloadBridge,
-                                                 (jfieldID)payloadBridgePointer);
+                                                 payloadBridgePointerFieldId_g);
     assert (0!=payloadBridgePointer);
 
     if(MAMA_STATUS_OK!=(status=mamaMsg_createForPayloadBridge(
-                    &cMessage, (mamaPayloadBridge)payloadBridgePointer)))
+                    &cMessage, CAST_JLONG_TO_POINTER(mamaPayloadBridge, payloadBridgePointer))))
     {
         utils_buildErrorStringForStatus(
                 errorString,

--- a/mama/jni/src/c/mamamsgjni.c
+++ b/mama/jni/src/c/mamamsgjni.c
@@ -478,8 +478,8 @@ JNIEXPORT void JNICALL Java_com_wombat_mama_MamaMsg__1setNewBuffer(JNIEnv *env, 
 
 					/* Call the native function. */
 					status = mamaMsg_setNewBuffer (
-						(mamaMsg)&messagePointer,
-						(void*)newBuffer,
+						messagePointer,
+						newBuffer,
 						(mama_size_t)arrayLength);
 
 					/* If something went wrong then delete the global array. */

--- a/mama/jni/src/c/mamapayloadbridgejni.c
+++ b/mama/jni/src/c/mamapayloadbridgejni.c
@@ -48,7 +48,7 @@ JNIEXPORT void JNICALL Java_com_wombat_mama_MamaPayloadBridge_initIDs
   (JNIEnv* env, jclass class)
 {
     payloadBridgePointerFieldId_g = (*env)->GetFieldID(
-            env, class,"bridgePointer_i",
+            env, class,"payloadBridgePointer_i",
             UTILS_JAVA_POINTER_TYPE_SIGNATURE);
     if (!payloadBridgePointerFieldId_g) return;/*Exception auto thrown*/
 


### PR DESCRIPTION
# JVM crash in Mama.loadPayloadBridge
## Summary
Fixed two JVM crash scenarios when calling Mama.loadPayloadBridge of Java API

## Areas Affected
*Place an 'x' within the braces to check the box*
- [x] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [x] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
Create a very simple dynamic library and compile:
foo.c:
```c
int f() {
  return 1;
}
```
```shell
gcc -shared -o libmamafooimpl.so foo.c
```
This simple Java example will crash JVM:
```java
import com.wombat.mama.Mama;

public class Test {
    public static void main(String[] args) {
        Mama.loadPayloadBridge("foo");     // Test case 1 - Crash
        Mama.loadPayloadBridge("qpidmsg"); // Test vase 2 - Crash
    }
}
```
There are two crash scenarios:
1. Loading any (not MAMA bridge) dynamic library - crash because mama_loadPayloadBridge returns MAMA_STATUS_OK even if it can't find init function.
2. Loading MAMA payload bridge library - because of incorrect field name in Java_com_wombat_mama_MamaPayloadBridge_initIDs and lack of NULL checks.

## Testing
When running Java code above with latest OpenMAMA code the crash occur, example - 
[hs_err_pid3573.log](https://github.com/OpenMAMA/OpenMAMA/files/1468766/hs_err_pid3573.log)
After applying the patch:
 Test case 1:
```
2017-11-14 01:01:35: mamaInternal_registerBridgeFunctions: Cannot load bridge, does not implement required function: [fooPayload_create]
2017-11-14 01:01:35: mama_loadPayloadBridgeInternal (): Failed to register payload functions for [foo] payload bridge from [mamafooimpl] library.
Exception in thread "main" com.wombat.mama.MamaException: Mama.loadPayloadBridge(): Failed to load payload bridge. [STATUS_PLATFORM] [2]
        at com.wombat.mama.Mama.loadPayloadBridge(Native Method)
        at Test.main(Test.java:5)
```
Test case 2:
```
2017-11-14 01:06:35: Using path specified in WOMBAT_PATH
2017-11-14 01:06:35: Using default properties file mama.properties
2017-11-14 01:06:35: Attempting to load MAMA properties from 
2017-11-14 01:06:35: Failed to open properties file.
```