### PR TITLE
OSX - Recent Updates

### DIFF
--- a/common/c_cpp/src/c/SConscript
+++ b/common/c_cpp/src/c/SConscript
@@ -38,6 +38,8 @@ elif env['host']['os'] == 'Darwin':
     symlinks = [
         ('common/c_cpp/src/c/wombat/port.h',
          'common/c_cpp/src/c/darwin/port.h'),
+        ('common/c_cpp/src/c/port.c',
+         'common/c_cpp/src/c/darwin/port.c'),
         ('common/c_cpp/src/c/wombat/wMath.h',
          'common/c_cpp/src/c/linux/wMath.h'),
         ('common/c_cpp/src/c/wombat/wUuid.h',

--- a/common/c_cpp/src/c/darwin/clock.c
+++ b/common/c_cpp/src/c/darwin/clock.c
@@ -18,6 +18,11 @@
  * 02110-1301 USA
  */
 
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12
+/* Doing nothing, since OSX now supports these */
+static void nothing(void) { }
+#else
+
 #include "wombat/port.h"
 
 #include <mach/mach.h>
@@ -120,3 +125,6 @@ int clock_gettime_process_cputime_id (struct timespec * ts)
 
     return GETTIME_SUCCESS;
 }
+
+#endif /* MAC_OS_X_VERSION_MIN_REQUIRED */
+

--- a/common/c_cpp/src/c/darwin/port.c
+++ b/common/c_cpp/src/c/darwin/port.c
@@ -1,0 +1,39 @@
+/*
+ * OpenMAMA: The open middleware agnostic messaging API
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+#include "wombat/port.h"
+
+/* OSX doesn't currently allow for specifying a specific core to bind
+ * a thread to. There is an affinity API 
+ * [https://developer.apple.com/library/content/releasenotes/Performance/RN-AffinityAPI/]
+ * but this has a focus on memory binding, which will provide a different result
+ * than most apps expect. As such leaving this as a no-op. 
+ */
+int wthread_set_affinity_mask (wthread_t         thread,
+                               size_t            cpu_set_size,
+                               CPU_AFFINITY_SET* cpu_set_mask)
+{
+    // Return a non-zero so we know it has not bound. 
+    return 1;
+}
+
+inline void CPU_SET (int i, cpu_set_t* affinity)
+{
+    affinity->count |= (1 << i);
+}

--- a/common/c_cpp/src/c/darwin/port.h
+++ b/common/c_cpp/src/c/darwin/port.h
@@ -123,6 +123,13 @@ int wsem_timedwait (wsem_t* sem, unsigned int ts);
 
 #define CPU_AFFINITY_SET    cpu_set_t
 
+/* Creating a structure to store the CPU set - we're cheating a little bit
+ * and assuming we don't need more than 64 CPUs.
+ */
+typedef struct cpu_set {
+      uint64_t    count;
+} cpu_set_t;
+
 /* Use pthreads for Mac OS X */
 #define INVALID_THREAD (-1)
 
@@ -141,6 +148,16 @@ int wsem_timedwait (wsem_t* sem, unsigned int ts);
 #define wthread_join                pthread_join
 #define wthread_create              pthread_create
 #define wthread_exit                pthread_exit
+
+/* OSX doesn't really support this, but adding a method for future
+ * implementations.
+ */
+int wthread_set_affinity_mask (wthread_t         thread,
+                               size_t            cpu_set_size,
+                               CPU_AFFINITY_SET* cpu_set_mask);
+
+/* Implementation of CPU_SET method. */
+void CPU_SET (int i, cpu_set_t* affinity);
 
 #define wthread_cond_t              pthread_cond_t
 #define wthread_cond_init           pthread_cond_init
@@ -180,6 +197,9 @@ struct wtimespec
     long tv_nsec;
 };
 
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12
+/* Do nothing, since these are now available */
+#else
 /* Add fake clock_gettime function */
 #define CLOCK_REALTIME              0
 #define CLOCK_MONOTONIC             1
@@ -188,6 +208,7 @@ struct wtimespec
 #define GETTIME_FAIL                1
 typedef int clockid_t;
 int clock_gettime (int type, struct timespec * ts);
+#endif /* MAC_OS_X_VERSION_MIN_REQUIRED */
 
 #define wnanosleep(ts, remain)      nanosleep(((struct timespec*)(ts)),(remain))
 

--- a/common/c_cpp/src/c/linux/wUuid.h
+++ b/common/c_cpp/src/c/linux/wUuid.h
@@ -31,6 +31,6 @@ typedef uuid_t wUuid;
 
 #define wUuid_unparse uuid_unparse
 
-#define wUuid_clear uuid_clear;
+#define wUuid_clear(UUID) uuid_clear(UUID);
 
 #endif /* WUUID_H__ */

--- a/site_scons/community/command_line.py
+++ b/site_scons/community/command_line.py
@@ -95,6 +95,8 @@ def get_command_line_opts( host, products, VERSIONS ):
                           '/usr/', PathVariable.PathAccept),
             PathVariable('apr_home', 'Path to Apache APR Libraries',
                 '/usr', PathVariable.PathIsDir),
+            EnumVariable('target_arch', 'Specifies if the build should target 32 or 64 bit architectures.',
+                          host['arch'], allowed_values=['i386', 'i586', 'i686', 'x86', 'x86_64']),
             )
 
     return opts


### PR DESCRIPTION
# OSX - Recent Updates
## Summary
Adding a couple of changes to support building common and MAMA on OSX. 

## Areas Affected
*Place an 'x' within the braces to check the box*
- [x] Common
- [ ] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
Couple of fixes:
- Adding target_arch support to scons for Darwin
- Disable 'clock_gettime' implementation is OSX 12+
  - Later OSX version have their own support for this, so adding version check to see if it's required.
- Implement cpu affinity support.
  - OSX doesn't have an API that actually supports binding to specific cores, so implementing most of this as a no-op.
- Fix a new compiler error with uuid_clear

## Testing
Build complete now as expected, unit tests are running fine. 
