### PR TITLE
MAMDA - Remove Duplicate Fields in Trade Listener

### DIFF
--- a/mamda/c_cpp/src/cpp/MamdaTradeListener.cpp
+++ b/mamda/c_cpp/src/cpp/MamdaTradeListener.cpp
@@ -373,8 +373,6 @@ namespace Wombat
         struct FieldUpdateSettleDate;
         struct FieldUpdateOffExchangeTradePrice;
         struct FieldUpdateOnExchangeTradePrice;
-        struct FieldUpdateTradeId;
-        struct FieldUpdateOrigTradeId;
         struct FieldUpdateGenericFlag;
         struct FieldUpdateShortSaleCircuitBreaker;
         struct FieldUpdateOrigShortSaleCircuitBreaker;


### PR DESCRIPTION
# MAMDA - Remove Duplicate Fields in Trade Listener
## Summary
Removing a few duplicate fields which were created in commit 4cd88bbf.

## Areas Affected
*Place an 'x' within the braces to check the box*
- [ ] Common
- [ ] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [x] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
Nothing really to it - clang complains. 

## Testing
Build complete now as expected, unit tests are running fine. 
