### PR TITLE
Added new option for disabling runtime install

### DIFF
--- a/mama/c_cpp/src/c/SConscript
+++ b/mama/c_cpp/src/c/SConscript
@@ -225,10 +225,11 @@ Alias('install', env.Install('$prefix/include/mama/conflation',
 Alias('install', env.Install('$prefix/include/mama/fieldcache',
       InstFieldCacheInclude))
 
-if env['target_arch'] == "x86_64":
-    Alias ('install', env.Install('$libdir', Glob('%s/lib64/libapr-1.so*' % env['apr_home'])))
-else:
-    Alias ('install', env.Install('$libdir', Glob('%s/lib/libapr-1.so*' % env['apr_home'])))
+if env['with_dependency_runtimes']:
+    if env['target_arch'] == "x86_64":
+        Alias ('install', env.Install('$libdir', Glob('%s/lib64/libapr-1.so*' % env['apr_home'])))
+    else:
+        Alias ('install', env.Install('$libdir', Glob('%s/lib/libapr-1.so*' % env['apr_home'])))
 
 env.SConscript('bridge/SConscript', 'env')
 env.SConscript('payload/SConscript', 'env')

--- a/mama/c_cpp/src/c/SConscript.win
+++ b/mama/c_cpp/src/c/SConscript.win
@@ -147,4 +147,5 @@ if ( env['build'] == 'dynamic' or len(env['buildtype']) == 1):
     env.Install('$prefix/include/mama/conflation','mama/conflation/connection.h')
     env.Install('$prefix/include/mama/playback', playbackHeaders)
     env.Install('$prefix/include/mama/fieldcache', fieldcacheHeaders)
-    env.Install('$bindir', aprInstLibs)
+    if env['with_dependency_runtimes']:
+        env.Install('$bindir', aprInstLibs)

--- a/mama/c_cpp/src/c/bridge/qpid/SConscript
+++ b/mama/c_cpp/src/c/bridge/qpid/SConscript
@@ -54,10 +54,11 @@ lib.append(env.StaticLibrary(target, [sources]))
 Alias('install', env.Install('$libdir', lib))
 
 # Install the qpid proton and libevent shared objects
-if env['target_arch'] == "x86_64":
-    Alias ('install', env.Install('$libdir', Glob('%s/lib64/libqpid-proton.so*' % env['qpid_home'])))
-    Alias ('install', env.Install('$libdir', Glob('%s/lib64/libevent.so*' % env['libevent_home'])))
-else:
-    Alias ('install', env.Install('$libdir', Glob('%s/lib/libqpid-proton.so*' % env['qpid_home'])))
-    Alias ('install', env.Install('$libdir', Glob('%s/lib/libevent.so*' % env['libevent_home'])))
+if env['with_dependency_runtimes']:
+    if env['target_arch'] == "x86_64":
+        Alias ('install', env.Install('$libdir', Glob('%s/lib64/libqpid-proton.so*' % env['qpid_home'])))
+        Alias ('install', env.Install('$libdir', Glob('%s/lib64/libevent.so*' % env['libevent_home'])))
+    else:
+        Alias ('install', env.Install('$libdir', Glob('%s/lib/libqpid-proton.so*' % env['qpid_home'])))
+        Alias ('install', env.Install('$libdir', Glob('%s/lib/libevent.so*' % env['libevent_home'])))
 

--- a/mama/c_cpp/src/c/bridge/qpid/SConscript.win
+++ b/mama/c_cpp/src/c/bridge/qpid/SConscript.win
@@ -41,6 +41,7 @@ else:
 libs.append(qpidLibName)
 
 libPath.append('%s/lib' % env['qpid_home'])
+libPath.append('%s/debug/lib' % env['qpid_home'])
 libPath.append('%s/lib' % env['libevent_home'])
 
 qpidInstLibs = '%s/bin/%s.dll' % (env['qpid_home'], qpidLibName)
@@ -53,5 +54,5 @@ sources = Glob('*.c')
 
 env.InstallLibrary(sources, target)
 
-if 'dynamic' in env['build']:
+if 'dynamic' in env['build'] and env['with_dependency_runtimes']:
     Alias ('install', env.Install('$bindir', qpidInstLibs))

--- a/mama/c_cpp/src/c/payload/qpidmsg/SConscript.win
+++ b/mama/c_cpp/src/c/payload/qpidmsg/SConscript.win
@@ -31,6 +31,7 @@ else:
   buildType = "Release"
 
 libPath.append('%s/lib' % env['qpid_home'])
+libPath.append('%s/debug/lib' % env['qpid_home'])
 
 env['CCFLAGS'].append(['/TP', '/WX-'])
 env.Append(LIBS=libs, LIBPATH=libPath, CPPPATH=[includePath])

--- a/site_scons/community/command_line.py
+++ b/site_scons/community/command_line.py
@@ -31,6 +31,7 @@ def get_command_line_opts( host, products, VERSIONS ):
        PathVariable('junit_home','Path to Junit home',None, PathVariable.PathIsDir),
        ListVariable('middleware','Middleware(s) to be compiled in', 'qpid', names = ['qpid'] ),
        ('jobs', 'Number of scons threads to spawn, if n is passed the number of availabe cores is calculated and used', '1'),
+       BoolVariable('with_dependency_runtimes','Whether or not to include dependency runtimes in the installation', True),
 
     )
 


### PR DESCRIPTION
Adding runtime libraries to the install package was causing
problems with packaging for shared deployment environments, so
making the behaviour configurable.

Signed-off-by: Frank Quinn <fquinn.ni@gmail.com>