### PR TITLE
Added vcpkg_build option for use with vcpkg

### DIFF
--- a/mama/c_cpp/src/c/SConscript.win
+++ b/mama/c_cpp/src/c/SConscript.win
@@ -25,8 +25,12 @@ libs = []
 aprLibName = "libapr-1"
 libs.append(aprLibName)
 
-libPath.append('%s/lib' % env['apr_home'])
-aprInstLibs = '%s/bin/%s.dll' % (env['apr_home'], aprLibName)
+if env['vcpkg_build'] and 'debug' in env['build']:
+    libPath.append('%s/debug/lib' % env['apr_home'])
+    aprInstLibs = '%s/debug/bin/%s.dll' % (env['apr_home'], aprLibName)
+else:
+    libPath.append('%s/lib' % env['apr_home'])
+    aprInstLibs = '%s/bin/%s.dll' % (env['apr_home'], aprLibName)
 
 env['CPPPATH'] = incPath
 env.Append(LIBS = libs, LIBPATH=libPath)
@@ -147,5 +151,6 @@ if ( env['build'] == 'dynamic' or len(env['buildtype']) == 1):
     env.Install('$prefix/include/mama/conflation','mama/conflation/connection.h')
     env.Install('$prefix/include/mama/playback', playbackHeaders)
     env.Install('$prefix/include/mama/fieldcache', fieldcacheHeaders)
-    if env['with_dependency_runtimes']:
-        env.Install('$bindir', aprInstLibs)
+
+if 'dynamic' in env['build'] and env['with_dependency_runtimes']:
+    env.Install('$bindir', aprInstLibs)

--- a/mama/c_cpp/src/c/bridge/qpid/SConscript.win
+++ b/mama/c_cpp/src/c/bridge/qpid/SConscript.win
@@ -40,11 +40,14 @@ else:
 
 libs.append(qpidLibName)
 
-libPath.append('%s/lib' % env['qpid_home'])
-libPath.append('%s/debug/lib' % env['qpid_home'])
-libPath.append('%s/lib' % env['libevent_home'])
-
-qpidInstLibs = '%s/bin/%s.dll' % (env['qpid_home'], qpidLibName)
+if env['vcpkg_build'] and 'debug' in env['build']:
+  libPath.append('%s/debug/lib' % env['qpid_home'])
+  libPath.append('%s/debug/lib' % env['libevent_home'])
+  qpidInstLibs = '%s/debug/bin/%s.dll' % (env['qpid_home'], qpidLibName)
+else:
+  libPath.append('%s/lib' % env['qpid_home'])
+  libPath.append('%s/lib' % env['libevent_home'])
+  qpidInstLibs = '%s/bin/%s.dll' % (env['qpid_home'], qpidLibName)
 
 env['CCFLAGS'].append(['/TP', '/WX-'])
 env['CPPPATH'] = incPath

--- a/site_scons/community/command_line.py
+++ b/site_scons/community/command_line.py
@@ -62,6 +62,7 @@ def get_command_line_opts( host, products, VERSIONS ):
                          PathVariable.PathAccept),
             PathVariable('lex', 'Path to preferred lexical analyzer generator (flex)', "flex",
                          PathVariable.PathAccept),
+            BoolVariable('vcpkg_build', 'Use the vcpkg dependency directory structure', False),
         )
 
     if host['os'] == 'Linux':

--- a/site_scons/community/windows.py
+++ b/site_scons/community/windows.py
@@ -91,6 +91,8 @@ class Windows:
         else:
             env['apr_home'] = "%s/APR" % programfiles
 
+        env['vcpkg_build'] = optsEnv['vcpkg_build']
+
         if not posixpath.exists(env['apr_home']):
             print 'ERROR: Apache APR Home (%s) must exist' % env['apr_home']
             Exit(1)


### PR DESCRIPTION
This option is a boolean which, if enabled, will expect windows
dependencies in the format produced by vcpkg.

Signed-off-by: Frank Quinn <fquinn.ni@gmail.com>