### PR TITLE
MAMA: Added defensive code to mamaMsg_destroy (#264)

### DIFF
--- a/mama/c_cpp/src/c/msg.c
+++ b/mama/c_cpp/src/c/msg.c
@@ -118,13 +118,6 @@ mamaMsg_destroy (mamaMsg msg)
 
     if (!impl) return MAMA_STATUS_NULL_ARG;
 
-    if (NULL == mamaInternal_findPayload(impl->mPayloadId))
-    {
-        mama_log(MAMA_LOG_LEVEL_WARN, "mamaMsg_destroy(): "
-            "Could not clean up MAMA message as payload bridge has already been closed. Possible leak.");
-        return MAMA_STATUS_OK;
-    }
-
     if (impl->mLastVectorMsg != NULL || impl->mLastVectorPayloadMsg != NULL)
     {
         mamaMsgImpl_destroyLastVectorMsg (impl);
@@ -132,7 +125,12 @@ mamaMsg_destroy (mamaMsg msg)
 
     if (impl->mPayloadBridge && impl->mMessageOwner)
     {
-        if (MAMA_STATUS_OK != impl->mPayloadBridge->msgPayloadDestroy (impl->mPayload))
+        if (NULL == mamaInternal_findPayload(impl->mPayloadId))
+        {
+            mama_log(MAMA_LOG_LEVEL_WARN, "mamaMsg_destroy(): "
+                "Could not clean up MAMA message as payload bridge has already been closed. Possible leak.");
+        }
+        else if (MAMA_STATUS_OK != impl->mPayloadBridge->msgPayloadDestroy (impl->mPayload))
         {
             mama_log (MAMA_LOG_LEVEL_ERROR, "mamaMsg_destroy(): "
                      "Could not clear message payload.");

--- a/mama/c_cpp/src/gunittest/cpp/MamaMsgTest.cpp
+++ b/mama/c_cpp/src/gunittest/cpp/MamaMsgTest.cpp
@@ -237,3 +237,24 @@ TEST_F (MamaMsgTestCPP, MemoryLeakTest)
         delete msgs[j];
     }
 }
+
+TEST_F (MamaMsgTestCPP, TestDestroyAfterClose)
+{
+    // Close the instance opened in setUp
+    Mama::close();
+
+    // Load the bridge fresh
+    m_bridge = Mama::loadBridge(getMiddleware());
+    Mama::open();
+
+    // Will create a qpid message
+    MamaMsg* mainMsg = new MamaMsg();
+    mainMsg->create();
+    mainMsg->addI32("test", 4, (mama_i32_t)123);
+
+    // Close the bridge
+    Mama::close();
+
+    // Destroy the message via destructor - will throw exception on fail
+    delete mainMsg;
+}

--- a/release_scripts/ci-run.py
+++ b/release_scripts/ci-run.py
@@ -123,6 +123,7 @@ for root, dirs, files in os.walk(install_dir):
                                   "--show-reachable=no",
                                   "--undef-value-errors=no",
                                   "--track-origins=no",
+                                  "--suppressions=release_scripts/intentionalunittestleaks.supp",
                                   "--xml=yes",
                                   "--xml-file=%s.result" % file,
                                   os.path.join('.', root, file),

--- a/release_scripts/intentionalunittestleaks.supp
+++ b/release_scripts/intentionalunittestleaks.supp
@@ -1,0 +1,17 @@
+{
+   Known leak for https://github.com/OpenMAMA/OpenMAMA/issues/264
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:calloc
+   obj:*
+   fun:mamaMsg_create
+   fun:_ZN6Wombat7MamaMsg6createEv
+   fun:_ZN41MamaMsgTestCPP_TestDestroyAfterClose_Test8TestBodyEv
+   fun:_ZN7testing8internal38HandleSehExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc
+   fun:_ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc
+   fun:_ZN7testing4Test3RunEv
+   fun:_ZN7testing8TestInfo3RunEv
+   fun:_ZN7testing8TestCase3RunEv
+   fun:_ZN7testing8internal12UnitTestImpl11RunAllTestsEv
+   fun:_ZN7testing8internal38HandleSehExceptionsInMethodIfSupportedINS0_12UnitTestImplEbEET0_PT_MS4_FS3_vEPKc
+}

--- a/release_scripts/intentionalunittestleaks.supp
+++ b/release_scripts/intentionalunittestleaks.supp
@@ -1,7 +1,6 @@
 {
    Known leak for https://github.com/OpenMAMA/OpenMAMA/issues/264
    Memcheck:Leak
-   match-leak-kinds: definite
    fun:calloc
    obj:*
    fun:mamaMsg_create


### PR DESCRIPTION
Added defensive code to mamaMsg_destroy so that it will not attempt
to destroy the underlying payload if the bridge has already been
unloaded. Includes unit test that crashed before fix was applied.

Signed-off-by: Frank Quinn <fquinn@cascadium.io>