### PR TITLE
Initialize MamaBasicSubscription::mTransport in MamaSubscription::setup

### DIFF
--- a/mama/c_cpp/src/cpp/MamaSubscription.cpp
+++ b/mama/c_cpp/src/cpp/MamaSubscription.cpp
@@ -505,6 +505,7 @@ namespace Wombat
         // Save the callback in the member variable
         mCallback = callback;
         mClosure  = closure;
+        mTransport = transport;
 
         // Save the queue so that calls to MamaBasicSubscription->getQueue () work
         mQueue = queue;

--- a/mama/c_cpp/src/gunittest/cpp/MamaSubscriptionTest.cpp
+++ b/mama/c_cpp/src/gunittest/cpp/MamaSubscriptionTest.cpp
@@ -899,6 +899,7 @@ TEST_F(MamaSubscriptionTest, BasicSubscriptionRecreateOnMsg)
 /* ************************************************************************* */
 /* Test Functions - Subscription */
 /* ************************************************************************* */
+#endif
 
 TEST_F(MamaSubscriptionTest, Subscription)
 {
@@ -914,7 +915,10 @@ TEST_F(MamaSubscriptionTest, Subscription)
             MamaQueue *queue = Mama::getDefaultEventQueue(m_bridge);
 
             // Create the subscription
-            subscription->create(m_transport, queue, testCallback, getSource(), "IBM");
+            subscription->create(m_transport, queue, testCallback, getSource(), getSymbol());
+
+            // check if transport got stored correctly
+            ASSERT_TRUE(m_transport == subscription->getTransport());
 
             // Process messages until the first message is received
             Mama::start(m_bridge);
@@ -932,6 +936,8 @@ TEST_F(MamaSubscriptionTest, Subscription)
         delete testCallback;
     }
 }
+
+#if 0
 
 TEST_F(MamaSubscriptionTest, Subscription)
 {


### PR DESCRIPTION
# Initialize MamaBasicSubscription::mTransport in MamaSubscription::setup
## Summary
Initialize MamaBasicSubscription::mTransport in MamaSubscription::setup (overload taking MamaTransport as a parameter)

## Areas Affected
*Place an 'x' within the braces to check the box*
- [ ] MAMAC
- [X] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [X] Unit Tests
- [ ] Examples

## Details
If MamaSubscription instance was initialized with create method (overloaded version taking MamaTransport as a parameter) mTransport member is not set and remains NULL because MamaBasicSubscription::createBasic is not called.  To resolve it we can add the initialization into MamaSubscription::setup method.

## Testing
Test case MamaSubscriptionTest:Subscription is enhanced to check for correct initialization of mTransport.  