### PR TITLE
Initialize MamaBasicSubscription::mTransport in MamaSubscription::setup

### DIFF
--- a/mama/c_cpp/src/cpp/MamaSubscription.cpp
+++ b/mama/c_cpp/src/cpp/MamaSubscription.cpp
@@ -505,6 +505,7 @@ namespace Wombat
         // Save the callback in the member variable
         mCallback = callback;
         mClosure  = closure;
+        mTransport = transport;
 
         // Save the queue so that calls to MamaBasicSubscription->getQueue () work
         mQueue = queue;

--- a/mama/c_cpp/src/gunittest/cpp/MamaSubscriptionTest.cpp
+++ b/mama/c_cpp/src/gunittest/cpp/MamaSubscriptionTest.cpp
@@ -899,6 +899,7 @@ TEST_F(MamaSubscriptionTest, BasicSubscriptionRecreateOnMsg)
 /* ************************************************************************* */
 /* Test Functions - Subscription */
 /* ************************************************************************* */
+#endif
 
 TEST_F(MamaSubscriptionTest, Subscription)
 {
@@ -914,7 +915,10 @@ TEST_F(MamaSubscriptionTest, Subscription)
             MamaQueue *queue = Mama::getDefaultEventQueue(m_bridge);
 
             // Create the subscription
-            subscription->create(m_transport, queue, testCallback, getSource(), "IBM");
+            subscription->create(m_transport, queue, testCallback, getSource(), getSymbol());
+
+            // check if transport got stored correctly
+            ASSERT_TRUE(m_transport == subscription->getTransport());
 
             // Process messages until the first message is received
             Mama::start(m_bridge);
@@ -932,6 +936,8 @@ TEST_F(MamaSubscriptionTest, Subscription)
         delete testCallback;
     }
 }
+
+#if 0
 
 TEST_F(MamaSubscriptionTest, Subscription)
 {

--- a/mama/c_cpp/src/gunittest/cpp/MamaSubscriptionTest.cpp
+++ b/mama/c_cpp/src/gunittest/cpp/MamaSubscriptionTest.cpp
@@ -242,14 +242,14 @@ public:
 /* Private Classes - Subscription */
 /* ************************************************************************* */
 
-class TestCallback : public MamaSubscriptionCallback
+class TestSubscriptionCalback : public MamaSubscriptionCallback
 {
     // Private member variables
     mamaBridge m_bridge;
 
 public:
     
-    TestCallback(mamaBridge bridge)
+    TestSubscriptionCalback(mamaBridge bridge)
     {
         m_bridge = bridge;
     }
@@ -264,6 +264,8 @@ public:
         const MamaStatus&  status,
         const char*        symbol)
      {
+         // Stop on error
+         Mama::stop(m_bridge);
      }
 
      virtual void onGap (
@@ -304,7 +306,7 @@ class TestCallback_RecreateOnMsg : public MamaSubscriptionCallback
 {
     // Private member variables
     mamaBridge m_bridge;
-    TestCallback *m_testCallback;
+    TestSubscriptionCalback *m_testCallback;
     MamaTransport *m_transport;
 
 public:
@@ -313,7 +315,7 @@ public:
      {
          m_bridge = bridge;
          m_transport = transport;
-         m_testCallback = new TestCallback(bridge);
+         m_testCallback = new TestSubscriptionCalback(bridge);
      }
 
      virtual ~TestCallback_RecreateOnMsg(void)
@@ -334,6 +336,7 @@ public:
         const MamaStatus&  status,
         const char*        symbol)
      {
+		 recreateSubscription(subscription);
      }
 
      virtual void onGap (
@@ -362,8 +365,14 @@ public:
      }
 
      virtual void onMsg (
-        MamaSubscription*  subscription, 
+        MamaSubscription*  subscription,
         MamaMsg&     msg)
+     {
+         recreateSubscription(subscription);
+     }
+
+     virtual void recreateSubscription(
+         MamaSubscription*  subscription)
      {
          // Destroy the subscription
          subscription->destroy();
@@ -399,7 +408,7 @@ class TestCallback_RecreateOnDestroy : public MamaSubscriptionCallback
 {
     // Private member variables
     mamaBridge m_bridge;
-    TestCallback *m_testCallback;
+    TestSubscriptionCalback *m_testCallback;
     MamaTransport *m_transport;
 
 public:
@@ -408,7 +417,7 @@ public:
      {
          m_bridge = bridge;
          m_transport = transport;
-         m_testCallback = new TestCallback(bridge);
+         m_testCallback = new TestSubscriptionCalback(bridge);
      }
 
      virtual ~TestCallback_RecreateOnDestroy(void)
@@ -429,6 +438,8 @@ public:
         const MamaStatus&  status,
         const char*        symbol)
      {
+        // Destroy the subscription
+        subscription->destroy();
      }
 
      virtual void onGap (
@@ -904,7 +915,7 @@ TEST_F(MamaSubscriptionTest, BasicSubscriptionRecreateOnMsg)
 TEST_F(MamaSubscriptionTest, Subscription)
 {
     // Create a callback object
-    TestCallback *testCallback = new TestCallback(m_bridge);
+    TestSubscriptionCalback *testCallback = new TestSubscriptionCalback(m_bridge);
     if(NULL != testCallback)
     {
         // Allocate a subscription
@@ -937,41 +948,6 @@ TEST_F(MamaSubscriptionTest, Subscription)
     }
 }
 
-#if 0
-
-TEST_F(MamaSubscriptionTest, Subscription)
-{
-    // Create a callback object
-    TestCallback *testCallback = new TestCallback(m_bridge);
-    if(NULL != testCallback)
-    {
-        // Allocate a subscription
-        MamaSubscription *subscription = new MamaSubscription();
-        if(NULL != subscription)
-        {        
-            // Get the default queue
-            MamaQueue *queue = Mama::getDefaultEventQueue(m_bridge);
-
-            // Create the subscription
-            subscription->create(m_transport, queue, testCallback, getSource(), "IBM");
-
-            // Process messages until the first message is received
-            Mama::start(m_bridge);
-
-            // Destroy the subscription
-            subscription->destroy();            
-
-            // Process messages until the destroy is received
-            Mama::start(m_bridge);
-
-            // Delete the basic subscription
-            delete subscription;
-        }
-
-        delete testCallback;
-    }
-}
-
 TEST_F(MamaSubscriptionTest, Subscription_RecreateOnDestroy)
 {
     // Create a callback object
@@ -986,7 +962,7 @@ TEST_F(MamaSubscriptionTest, Subscription_RecreateOnDestroy)
             MamaQueue *queue = Mama::getDefaultEventQueue(m_bridge);
 
             // Create the subscription
-            subscription->create(m_transport, queue, testCallback, getSource(), "IBM");
+            subscription->create(m_transport, queue, testCallback, getSource(), getSymbol());
 
             // Process messages until the first message is received
             Mama::start(m_bridge);
@@ -1019,7 +995,7 @@ TEST_F(MamaSubscriptionTest, Subscription_RecreateOnMsg)
             MamaQueue *queue = Mama::getDefaultEventQueue(m_bridge);
 
             // Create the subscription
-            subscription->create(m_transport, queue, testCallback, getSource(), "IBM");
+            subscription->create(m_transport, queue, testCallback, getSource(), getSymbol());
 
             // Process messages until the first message is received
             Mama::start(m_bridge);
@@ -1037,6 +1013,8 @@ TEST_F(MamaSubscriptionTest, Subscription_RecreateOnMsg)
         delete testCallback;
     }
 }
+
+#if 0
 
 /* ************************************************************************* */
 /* Test Functions - Timer */


### PR DESCRIPTION
Initialize MamaBasicSubscription::mTransport in MamaSubscription::setup
## Summary
Initialize MamaBasicSubscription::mTransport in MamaSubscription::setup (overload taking MamaTransport as a parameter)
## Areas Affected
*Place an 'x' within the braces to check the box*
- [ ] MAMAC
- [X] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [X] Unit Tests
- [ ] Examples

## Details
If MamaSubscription instance was initialized with create method (overloaded version taking MamaTransport as a parameter) mTransport member is not set and remains NULL because MamaBasicSubscription::createBasic is not called. To resolve it we can add the initialization into MamaSubscription::setup method.

## Testing
Test case MamaSubscriptionTest:Subscription iss enhanced to check for correct initialization of mTransport.
Several test cases are improved to support a scenario when no data is returned by the subscriptions by properly implementing OnError callbacks.
TestCallback class is renamed to TestSubscriptionCallback class to avoid v-table conflicts with identically named class in MamaPublisherTest package.

