### PR TITLE
PLAT 1371

### DIFF
--- a/common/c_cpp/src/c/linux/machine.c
+++ b/common/c_cpp/src/c/linux/machine.c
@@ -38,7 +38,7 @@
 /* Macros for extract VSIZE and RSS from /proc/pid/stats files */
 #define bytetok(x)      (((x) + 512) >> 10)
 
-#define MAXPROCSARRAY 1000     /* need to keep track of processes */
+#define MAXPROCSARRAY 32000     /* need to keep track of processes */
 
 extern int useLWP;
 static int numProc = 0;


### PR DESCRIPTION
 # PLAT-1371
## Summary
This PR raises MAXPROXSARRAY to 32k to ensure that a machine running many processes will not core

## Areas Affected
*Place an 'x' within the braces to check the box*
- [X] Common
- [ ] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples