### PR TITLE
PLAT-1181: Implement MamaFieldCache in JNI

### DIFF
--- a/mama/jni/build.xml
+++ b/mama/jni/build.xml
@@ -148,6 +148,7 @@
     <!-- JUnit Tests -->
     <target name="junitdirs" description="Build junitdirs" if="withUnitTests">
        <mkdir dir="${build}/junittests"></mkdir>
+       <mkdir dir="${build}/junittests/fieldcache"></mkdir>
     </target>   
     <target name="compile.junittests" depends="dist.base, junitdirs" if="withUnitTests">
         <!-- JUnit jar must already be on the classpath -->

--- a/mama/jni/src/main/java/com/wombat/mama/MamaFieldCache.java
+++ b/mama/jni/src/main/java/com/wombat/mama/MamaFieldCache.java
@@ -1,0 +1,1321 @@
+//--------------------------------------------------------------------------
+// Copyright (c) 1999-2006 Wombat Financial Software Inc., of Incline
+// Village, NV.  All rights reserved.
+//
+// This software and documentation constitute an unpublished work and
+// contain valuable trade secrets and proprietary information belonging
+// to Wombat.  None of this material may be copied, duplicated or
+// disclosed without the express written permission of Wombat.
+//
+// WOMBAT EXPRESSLY DISCLAIMS ANY AND ALL WARRANTIES CONCERNING THIS
+// SOFTWARE AND DOCUMENTATION, INCLUDING ANY WARRANTIES OF
+// MERCHANTABILITY AND/OR FITNESS FOR ANY PARTICULAR PURPOSE, AND
+// WARRANTIES OF PERFORMANCE, AND ANY WARRANTY THAT MIGHT OTHERWISE ARISE
+// FROM COURSE OF DEALING OR USAGE OF TRADE. NO WARRANTY IS EITHER
+// EXPRESS OR IMPLIED WITH RESPECT TO THE USE OF THE SOFTWARE OR
+// DOCUMENTATION.
+//
+// Under no circumstances shall Wombat be liable for incidental, special,
+// indirect, direct or consequential damages or loss of profits,
+// interruption of business, or related expenses which may arise from use
+// of software or documentation, including but not limited to those
+// resulting from defects in software and/or documentation, or loss or
+// inaccuracy of data of any kind.
+//
+//----------------------------------------------------------------------------
+
+package com.wombat.mama;
+
+import java.util.ArrayList;
+import com.wombat.common.WombatException;
+
+public class MamaFieldCache extends MamaFieldCacheFieldList
+{
+    /* If set then field names will be used when calling getDeltaMsg or getFullMsg. This
+     * flag will be set to false by default.
+     */
+    private boolean mUseFieldNames;
+        
+    private boolean mTrackModState;
+    private static boolean mOverrideDescTrackModState = true; 
+
+    private FieldCacheMsgIterator complexIter = new FieldCacheMsgIterator();
+    private FieldCacheBasicMsgIterator basicIter = new FieldCacheBasicMsgIterator();
+
+    
+    public MamaFieldCache()
+    {
+        mUseFieldNames = false;
+        mTrackModState = false;
+    }
+    
+    /*
+     *  Description :   This function will return an array that contains all deltas
+     *                  since the last time this or getDeltaMsg was called.
+     *  Returns     :   The array of cache fields.
+     */
+    public MamaFieldCacheReadOnlyField[] getFastReadOnlyDeltaArray()
+    {
+        // Obtain the field list from the base class
+        ArrayList fieldList = super.getArrayList();
+
+        // Create a new return array list, the field list is the maximum size
+        ArrayList returnList = new ArrayList(fieldList.size());
+
+        // Enumerate the entire array
+        for(int count=0; count<fieldList.size(); count++)
+        {
+            // Get the next field in the array
+            MamaFieldCacheField nextField = (MamaFieldCacheField)fieldList.get(count);
+
+            // The field should only be added if it has changed
+            if(nextField.getModState() != MamaFieldCacheField.MOD_STATE_NOT_MODIFIED)
+            {
+                // Add this field to the return array
+                returnList.add((MamaFieldCacheReadOnlyField)nextField);
+
+                // Clear the modified state for the field
+                nextField.clearModState();
+            }
+        }
+
+        // Create the return array
+        MamaFieldCacheReadOnlyField[] ret = new MamaFieldCacheReadOnlyField[returnList.size()];
+
+        /* Obtain the array from the array list. */
+        returnList.toArray(ret);
+
+        return ret;
+    }
+
+    /*
+     *  Description :   This function will fill an array all of the fields contained
+     *                  in the cache.
+     *  Returns     :   The array of cache fields.
+     */
+    public MamaFieldCacheReadOnlyField[] getFastReadOnlyFullArray()
+    {
+        // Obtain the field list from the base class
+        ArrayList fieldList = super.getArrayList();
+
+        // Create the return array
+        MamaFieldCacheReadOnlyField[] ret = new MamaFieldCacheReadOnlyField[fieldList.size()];
+
+        /* Obtain the array from the array list. */
+        fieldList.toArray(ret);
+
+        return ret;
+    }
+    
+    /*
+     *  Description :   This function will create a message that contains all deltas
+     *                  since the last time it was called.
+     *                  Note that field names will be included if the mUseFieldNames flag is
+     *                  set, control this flag using the setUseFieldNames function.
+     *  Arguments   :   message        [I] The message to populate with fields.
+     */
+    public void getDeltaMsg(MamaMsg message)
+    {
+        // Obtain the field list from the base class
+        ArrayList fieldList = super.getArrayList();
+
+        // Enumerate the entire array
+        for(int count=0; count<fieldList.size(); count++)
+        {
+            // Get the next field in the array
+            MamaFieldCacheField nextField = (MamaFieldCacheField)fieldList.get(count);
+
+            // The field should only be added if it has changed
+            if(nextField.getModState() != MamaFieldCacheField.MOD_STATE_NOT_MODIFIED)
+            {
+                // Add this field to the message
+                nextField.addToMessage(mUseFieldNames, message);
+
+                // Clear the modified state for the field
+                nextField.clearModState();
+            }
+        }
+    }
+
+    /*
+     *  Description :   This function will fill a message with all of the fields contained
+     *                  in the cache.
+     *                  Note that field names will be included if the mUseFieldNames flag is
+     *                  set, control this flag using the setUseFieldNames function.
+     *  Arguments   :   message        [I] The message to populate with fields.
+     */
+    public void getFullMsg(MamaMsg message)
+    {
+        // Obtain the field list from the base class
+        ArrayList fieldList = super.getArrayList();
+        
+        // Enumerate the entire array
+        for(int count=0; count<fieldList.size(); count++)
+        {
+            // Get the next field in the array
+            MamaFieldCacheField nextField = (MamaFieldCacheField)fieldList.get(count);
+
+            // Add this field to the message
+            nextField.addToMessage(mUseFieldNames, message);
+        }
+    }
+   
+    /*
+     *  Description :   Returns the flag indicating whether field names will be used when calling
+     *                  getDeltaMsg and getFullMsg.
+     *  Returns     :   The flag as a bool.
+     */    
+    public boolean getUseFieldNames()
+    {
+        return mUseFieldNames;
+    }
+
+    /*
+     *  Description :   Sets the flag indicating whether field names will be used when calling
+     *                  getDeltaMsg and getFullMsg.
+     *  Arguments   :   useFieldNames [I] The flag as a bool.
+     */    
+    public void setUseFieldNames(boolean useFieldNames)
+    {
+        mUseFieldNames = useFieldNames;
+    }
+
+    class FieldCacheBasicMsgIterator implements MamaMsgFieldIterator
+    {
+        private MamaFieldCacheFieldList mDelta;
+        private boolean fieldHasName;
+        
+        public FieldCacheBasicMsgIterator()
+        {
+            mDelta = null;
+            fieldHasName = true;
+        }
+        
+        public FieldCacheBasicMsgIterator(MamaFieldCacheFieldList delta)
+        {
+            mDelta = delta;
+            fieldHasName = true;
+        }
+        
+        public void setDelta(MamaFieldCacheFieldList delta)
+        {
+            mDelta = delta;
+        }
+                
+        public void onField
+          (MamaMsg msg, MamaMsgField field, MamaDictionary dict, Object closure)
+        {        
+            short type  = MamaFieldDescriptor.UNKNOWN;
+            String name = null;
+            int fid     = 0;
+           
+            type = field.getType ();
+            fid  = field.getFid ();
+            
+            try 
+            {
+                if (fieldHasName)
+                {
+                    name = field.getName ();
+                }    
+                    
+            }
+            catch (WombatException exception)
+            {
+                // One possibility of this exception is trying to call getName on
+                // non-basic messages.
+                fieldHasName = false;
+                //return;
+            }
+            
+            MamaFieldCache cache = (MamaFieldCache)closure;
+            switch(type)
+            {
+                case MamaFieldDescriptor.MSG:
+                    break;
+                    
+                case MamaFieldDescriptor.OPAQUE:
+                    break;
+                    
+                case MamaFieldDescriptor.STRING:
+                    MamaFieldCacheString cachedStringField = 
+                        (MamaFieldCacheString)cache.findOrAddString (fid,name);
+                    if (cachedStringField != null)
+                    {
+                        cachedStringField.set(field.getString());
+                        if (mDelta!=null && cachedStringField.isModified())
+                            mDelta.add (cachedStringField);
+                    }
+                    break;
+                
+                case MamaFieldDescriptor.BOOL:
+                    MamaFieldCacheBool cachedBoolField =  
+                            (MamaFieldCacheBool)cache.findOrAddBool (fid,name);
+                    if (cachedBoolField != null)
+                    {
+                        cachedBoolField.set(field.getBoolean());
+                        if (mDelta!=null && cachedBoolField.isModified())
+                            mDelta.add (cachedBoolField);
+                    }
+                    break;
+                    
+                case MamaFieldDescriptor.CHAR:
+                    MamaFieldCacheChar  cachedCharField = 
+                           (MamaFieldCacheChar)cache.findOrAddChar (fid, name);
+                    if (cachedCharField != null)
+                    {
+                        cachedCharField.set (field.getChar());
+                        if (mDelta!=null && cachedCharField.isModified())
+                            mDelta.add (cachedCharField);
+                    }   
+                    break;
+                    
+                case MamaFieldDescriptor.I8:                
+                    MamaFieldCacheInt8  cachedInt8Field = 
+                           (MamaFieldCacheInt8)cache.findOrAddInt8 (fid, name);
+                    if (cachedInt8Field != null)
+                    {                        
+                        cachedInt8Field.set (field.getI8());
+                        if (mDelta !=null && cachedInt8Field.isModified())
+                            mDelta.add (cachedInt8Field);            
+                    }
+                    break; 
+                    
+                case MamaFieldDescriptor.U8:                   
+                    MamaFieldCacheUint8  cachedUint8Field = 
+                         (MamaFieldCacheUint8)cache.findOrAddUint8 (fid, name);                    
+                    if (cachedUint8Field != null)
+                    {                     
+                        cachedUint8Field.set (field.getU8());                                                                     
+                        if (mDelta !=null && cachedUint8Field.isModified())
+                            mDelta.add (cachedUint8Field);            
+                    }                    
+                    break;   
+                    
+                case MamaFieldDescriptor.I16:
+                    MamaFieldCacheInt16  cachedInt16Field = 
+                          (MamaFieldCacheInt16)cache.findOrAddInt16 (fid, name);
+                    if (cachedInt16Field != null)
+                    {                        
+                        cachedInt16Field.set (field.getI16());
+                        if (mDelta !=null && cachedInt16Field.isModified())
+                            mDelta.add (cachedInt16Field);            
+                    }
+                    break;
+                    
+                case MamaFieldDescriptor.U16:
+                    MamaFieldCacheUint16  cachedUint16Field = 
+                       (MamaFieldCacheUint16)cache.findOrAddUint16 (fid, name);
+                    if (cachedUint16Field != null)
+                    {                        
+                        cachedUint16Field.set (field.getU16());
+                        if (mDelta !=null && cachedUint16Field.isModified())
+                            mDelta.add (cachedUint16Field);            
+                    }
+                    break;
+                    
+                case MamaFieldDescriptor.I32:
+                    MamaFieldCacheInt32  cachedInt32Field = 
+                         (MamaFieldCacheInt32)cache.findOrAddInt32 (fid, name);
+                    if (cachedInt32Field != null)
+                    {
+                        cachedInt32Field.set (field.getI32());
+                        if (mDelta !=null && cachedInt32Field.isModified())
+                            mDelta.add (cachedInt32Field);            
+                    }
+                    break;
+                    
+                case MamaFieldDescriptor.U32:
+                    MamaFieldCacheUint32  cachedUint32Field = 
+                       (MamaFieldCacheUint32)cache.findOrAddUint32 (fid, name);
+                    if (cachedUint32Field != null)
+                    {                        
+                        cachedUint32Field.set (field.getU32());
+                        if (mDelta !=null && cachedUint32Field.isModified())
+                            mDelta.add (cachedUint32Field);            
+                    }
+                    break;
+                    
+                case MamaFieldDescriptor.I64:
+                    MamaFieldCacheInt64  cachedInt64Field = 
+                         (MamaFieldCacheInt64)cache.findOrAddInt64 (fid, name);
+                    if (cachedInt64Field != null)
+                    {
+                        cachedInt64Field.set (field.getI64());
+                        if (mDelta !=null && cachedInt64Field.isModified())
+                            mDelta.add (cachedInt64Field);            
+                    }
+                    break;
+                    
+                case MamaFieldDescriptor.U64:                    
+                    MamaFieldCacheUint64  cachedUint64Field = 
+                       (MamaFieldCacheUint64)cache.findOrAddUint64 (fid, name);
+                    if (cachedUint64Field != null)
+                    {
+                        cachedUint64Field.set (field.getU64());                        
+                        if (mDelta !=null && cachedUint64Field.isModified())
+                        {                            
+                            mDelta.add (cachedUint64Field);            
+                        }
+                    }
+                    break;
+                    
+                case MamaFieldDescriptor.F32:
+                    MamaFieldCacheFloat32  cachedFloat32Field = 
+                     (MamaFieldCacheFloat32)cache.findOrAddFloat32 (fid, name);
+                    if (cachedFloat32Field != null)
+                    {
+                        cachedFloat32Field.set (field.getF32());
+                        if (mDelta !=null && cachedFloat32Field.isModified())
+                            mDelta.add (cachedFloat32Field);            
+                    }
+                    break;
+                    
+                case MamaFieldDescriptor.F64:
+                    MamaFieldCacheFloat64  cachedFloat64Field = 
+                      (MamaFieldCacheFloat64)cache.findOrAddFloat64 (fid, name);
+                    if (cachedFloat64Field != null)
+                    {
+                        cachedFloat64Field.set (field.getF64());
+                        if (mDelta !=null && cachedFloat64Field.isModified())
+                            mDelta.add (cachedFloat64Field);            
+                    }
+                    break;
+                    
+                case MamaFieldDescriptor.TIME:
+                    MamaFieldCacheDateTime  cachedDateTimeField = 
+                    (MamaFieldCacheDateTime)cache.findOrAddDateTime (fid, name);
+                    if (cachedDateTimeField != null)
+                    {
+                        cachedDateTimeField.set (field.getDateTime());
+                        if (mDelta !=null && cachedDateTimeField.isModified())
+                            mDelta.add (cachedDateTimeField);            
+                    }
+                    break;
+                        
+                case MamaFieldDescriptor.PRICE:
+                    MamaFieldCachePrice  cachedPriceField = 
+                         (MamaFieldCachePrice)cache.findOrAddPrice (fid, name);
+                    if (cachedPriceField != null)
+                    {
+                        cachedPriceField.set (field.getPrice());
+                        if (mDelta !=null && cachedPriceField.isModified())
+                            mDelta.add (cachedPriceField);            
+                    }
+                    break;
+                    
+                case MamaFieldDescriptor.I8ARRAY:            
+                case MamaFieldDescriptor.U8ARRAY:
+                case MamaFieldDescriptor.I16ARRAY:
+                case MamaFieldDescriptor.U16ARRAY:
+                case MamaFieldDescriptor.I32ARRAY:
+                case MamaFieldDescriptor.U32ARRAY:
+                case MamaFieldDescriptor.I64ARRAY:
+                case MamaFieldDescriptor.U64ARRAY:
+                case MamaFieldDescriptor.F32ARRAY:
+                case MamaFieldDescriptor.F64ARRAY:
+                case MamaFieldDescriptor.VECTOR_STRING:
+                case MamaFieldDescriptor.VECTOR_MSG:
+                case MamaFieldDescriptor.VECTOR_TIME:
+                case MamaFieldDescriptor.VECTOR_PRICE:
+                case MamaFieldDescriptor.COLLECTION:
+                case MamaFieldDescriptor.UNKNOWN:                        
+                    break;
+            }
+        }    
+    }
+
+    class FieldCacheMsgIterator implements MamaMsgFieldIterator
+    {
+        private MamaFieldCacheFieldList mDelta;
+
+        public FieldCacheMsgIterator()
+        {
+            mDelta = null;
+        }
+        
+        public FieldCacheMsgIterator(MamaFieldCacheFieldList delta)
+        {
+            mDelta = delta;
+        }
+        
+        public void setDelta(MamaFieldCacheFieldList delta)
+        {
+            mDelta = delta;
+        }
+        
+        public void onField
+          (MamaMsg msg, MamaMsgField field, MamaDictionary dict, Object closure)
+        {  
+            // get this NOW - we'll need it for sure, but only get the field name
+            // when you have to, ie, on initialization of the fieldCacheField.
+            int fid = field.getFid();
+
+            MamaFieldCache cache = (MamaFieldCache)closure;
+
+            switch(field.getType())
+            {
+                case MamaFieldDescriptor.MSG:
+                    break;
+
+                case MamaFieldDescriptor.OPAQUE:
+                    break;
+                    
+                case MamaFieldDescriptor.STRING: 
+                    MamaFieldCacheString cachedStringField = 
+                             (MamaFieldCacheString)cache.find(fid);
+
+                    if (cachedStringField == null)
+                    {
+                        cachedStringField = (MamaFieldCacheString)cache.
+                            findOrAddString(fid, field.getName());      
+                    }
+
+                    if (cachedStringField != null)
+                    {
+                        cachedStringField.set(field.getString());
+                        if (mDelta!=null && cachedStringField.isModified())
+                            mDelta.add(cachedStringField);
+                    }
+                    break;
+                
+                case MamaFieldDescriptor.BOOL:                
+                    MamaFieldCacheBool cachedBoolField =
+                            (MamaFieldCacheBool) cache.find(fid);
+                    if (cachedBoolField == null)
+                    {
+                        cachedBoolField = (MamaFieldCacheBool)cache.
+                            findOrAddBool (fid, field.getName());
+                    }
+                    if (cachedBoolField != null)
+                    {
+                        cachedBoolField.set(field.getBoolean());
+                        if (mDelta!=null && cachedBoolField.isModified())
+                            mDelta.add (cachedBoolField);
+                    }
+                    break;
+                    
+                case MamaFieldDescriptor.CHAR:                
+                    MamaFieldCacheChar  cachedCharField = (MamaFieldCacheChar) cache.find(fid);
+
+                    if (cachedCharField == null)
+                    {
+                            cachedCharField = (MamaFieldCacheChar)cache.
+                                findOrAddChar (fid, field.getName());
+                    }
+                    if (cachedCharField != null)
+                    {
+                        cachedCharField.set (field.getChar());
+                        if (mDelta!=null && cachedCharField.isModified())
+                            mDelta.add (cachedCharField);
+                    }
+                    break;
+                    
+                case MamaFieldDescriptor.I8:                         
+                    MamaFieldCacheInt8  cachedInt8Field = (MamaFieldCacheInt8) cache.find(fid);
+
+                    if (cachedInt8Field == null)
+                    {
+                        cachedInt8Field = (MamaFieldCacheInt8)cache.
+                                findOrAddInt8 (fid, field.getName());
+                    }
+                    if (cachedInt8Field != null)
+                    {
+                        cachedInt8Field.set (field.getI8());
+                        if (mDelta !=null && cachedInt8Field.isModified())
+                            mDelta.add (cachedInt8Field);            
+                    }
+                    break;
+                
+                 case MamaFieldDescriptor.U8:                      
+                    MamaFieldCacheUint8  cachedUint8Field = (MamaFieldCacheUint8) cache.find(fid);
+                    if (cachedUint8Field == null)
+                    {
+                       cachedUint8Field = (MamaFieldCacheUint8)cache.
+                           findOrAddUint8 (fid, field.getName());
+                    }
+                    if (cachedUint8Field != null)
+                    {
+                        cachedUint8Field.set (field.getU8());                        
+                        if (mDelta !=null && cachedUint8Field.isModified())
+                            mDelta.add (cachedUint8Field);            
+                    }
+                    break;   
+                    
+                case MamaFieldDescriptor.I16:                
+                    MamaFieldCacheInt16  cachedInt16Field = (MamaFieldCacheInt16) cache.find(fid);
+                    if (cachedInt16Field == null)
+                        cachedInt16Field = (MamaFieldCacheInt16)cache.findOrAddInt16 (fid, field.getName());
+                    if (cachedInt16Field != null)
+                    {
+                        cachedInt16Field.set (field.getI16());
+                        if (mDelta !=null && cachedInt16Field.isModified())
+                            mDelta.add (cachedInt16Field);            
+                    }
+                    break;
+                    
+                case MamaFieldDescriptor.U16:         
+                    MamaFieldCacheUint16  cachedUint16Field = (MamaFieldCacheUint16) cache.find(fid);
+                    if (cachedUint16Field == null)
+                        cachedUint16Field = (MamaFieldCacheUint16)cache.findOrAddUint16 (fid, field.getName());
+                    if (cachedUint16Field != null)
+                    {
+                        cachedUint16Field.set (field.getU16());
+                        if (mDelta !=null && cachedUint16Field.isModified())
+                            mDelta.add (cachedUint16Field);            
+                    }
+                    break;
+                    
+                case MamaFieldDescriptor.I32:
+                    MamaFieldCacheInt32  cachedInt32Field = (MamaFieldCacheInt32) cache.find(fid);
+                    if (cachedInt32Field == null)
+                        cachedInt32Field = (MamaFieldCacheInt32)cache.findOrAddInt32 (fid, field.getName());
+                    if (cachedInt32Field != null)
+                    {
+                        cachedInt32Field.set (field.getI32());
+                        if (mDelta !=null && cachedInt32Field.isModified())
+                            mDelta.add (cachedInt32Field);            
+                    }
+                    break;
+                    
+                case MamaFieldDescriptor.U32:
+                    MamaFieldCacheUint32  cachedUint32Field = (MamaFieldCacheUint32) cache.find(fid);
+                    if (cachedUint32Field == null)
+                        cachedUint32Field = (MamaFieldCacheUint32)cache.findOrAddUint32 (fid, field.getName());
+                    if (cachedUint32Field != null)
+                    {
+                        cachedUint32Field.set (field.getU32());
+                        if (mDelta !=null && cachedUint32Field.isModified())
+                            mDelta.add (cachedUint32Field);            
+                    }
+                    break;
+                    
+                case MamaFieldDescriptor.I64:
+                    MamaFieldCacheInt64  cachedInt64Field = (MamaFieldCacheInt64) cache.find(fid);
+                    if (cachedInt64Field == null)
+                        cachedInt64Field = (MamaFieldCacheInt64)cache.findOrAddInt64 (fid, field.getName());
+                    if (cachedInt64Field != null)
+                    {
+                        cachedInt64Field.set (field.getI64());
+                        if (mDelta !=null && cachedInt64Field.isModified())
+                            mDelta.add (cachedInt64Field);            
+                    }
+                    break;
+                    
+                case MamaFieldDescriptor.U64:
+                    MamaFieldCacheUint64  cachedUint64Field = (MamaFieldCacheUint64) cache.find(fid);
+                    if (cachedUint64Field == null)
+                        cachedUint64Field = (MamaFieldCacheUint64)cache.findOrAddUint64 (fid, field.getName());
+                    if (cachedUint64Field != null)
+                    {
+                        cachedUint64Field.set (field.getU64());
+                        if (mDelta !=null && cachedUint64Field.isModified())
+                            mDelta.add (cachedUint64Field);            
+                    }
+                    break;
+                    
+                case MamaFieldDescriptor.F32:                
+                    MamaFieldCacheFloat32  cachedFloat32Field = (MamaFieldCacheFloat32) cache.find(fid);
+                    if (cachedFloat32Field == null)
+                        cachedFloat32Field = (MamaFieldCacheFloat32)cache.findOrAddFloat32 (fid, field.getName());
+                    if (cachedFloat32Field != null)
+                    {
+                        cachedFloat32Field.set (field.getF32());
+                        if (mDelta !=null && cachedFloat32Field.isModified())
+                            mDelta.add (cachedFloat32Field);            
+                    }
+                    break;
+                    
+                case MamaFieldDescriptor.F64:               
+                    MamaFieldCacheFloat64  cachedFloat64Field = 
+                           (MamaFieldCacheFloat64)cache.findOrAddFloat64 (fid, field.getName());
+                    if (cachedFloat64Field != null)
+                    {
+                        cachedFloat64Field.set (field.getF64());
+                        if (mDelta !=null && cachedFloat64Field.isModified())
+                            mDelta.add (cachedFloat64Field);            
+                    }
+                    break;
+                    
+                case MamaFieldDescriptor.TIME:
+                    MamaFieldCacheDateTime cachedDateTimeField = (MamaFieldCacheDateTime) cache.find(fid);
+                    if (cachedDateTimeField == null)
+                         cachedDateTimeField = (MamaFieldCacheDateTime)cache.findOrAddDateTime (fid, field.getName());
+                    if (cachedDateTimeField != null)
+                    {
+                        cachedDateTimeField.set (field.getDateTime());
+                        if (mDelta !=null && cachedDateTimeField.isModified())
+                            mDelta.add (cachedDateTimeField);            
+                    }
+                    break;
+                        
+                case MamaFieldDescriptor.PRICE:                
+                    MamaFieldCachePrice  cachedPriceField = (MamaFieldCachePrice) cache.find(fid);
+                    if (cachedPriceField == null)
+                        cachedPriceField = (MamaFieldCachePrice)cache.findOrAddPrice (fid, field.getName());
+                    if (cachedPriceField != null)
+                    {
+                        cachedPriceField.set (field.getPrice());
+                        if (mDelta !=null && cachedPriceField.isModified())
+                            mDelta.add (cachedPriceField);            
+                    }
+                    break;
+                    
+                case MamaFieldDescriptor.I8ARRAY:            
+                case MamaFieldDescriptor.U8ARRAY:
+                case MamaFieldDescriptor.I16ARRAY:
+                case MamaFieldDescriptor.U16ARRAY:
+                case MamaFieldDescriptor.I32ARRAY:
+                case MamaFieldDescriptor.U32ARRAY:
+                case MamaFieldDescriptor.I64ARRAY:
+                case MamaFieldDescriptor.U64ARRAY:
+                case MamaFieldDescriptor.F32ARRAY:
+                case MamaFieldDescriptor.F64ARRAY:
+                case MamaFieldDescriptor.VECTOR_STRING:
+                case MamaFieldDescriptor.VECTOR_MSG:
+                case MamaFieldDescriptor.VECTOR_TIME:
+                case MamaFieldDescriptor.VECTOR_PRICE:
+                case MamaFieldDescriptor.COLLECTION:
+                case MamaFieldDescriptor.UNKNOWN:                        
+                    break; 
+                
+            }
+        }
+    }
+    
+    public void apply(MamaMsg msg,
+                      MamaDictionary dict,
+                      MamaFieldCacheFieldList delta)
+    {
+        if (delta!=null)
+            delta.clear();
+    
+        if (dict!=null)
+        {
+            complexIter.setDelta(delta);
+            msg.iterateFields (complexIter, dict, this);
+        }
+        else
+        {
+            basicIter.setDelta(delta);
+            msg.iterateFields (basicIter,null, this);
+        }
+
+    }
+    
+    public MamaFieldCacheField add(MamaFieldDescriptor desc)
+    {
+        switch (desc.getType())
+        {   
+            case MamaFieldDescriptor.STRING:
+                return findOrAddString(desc);
+                                   
+            case MamaFieldDescriptor.BOOL:
+                return findOrAddBool(desc);
+        
+            case MamaFieldDescriptor.CHAR:
+                return findOrAddChar(desc);
+        
+            case MamaFieldDescriptor.I8:
+                return findOrAddInt8(desc);
+        
+            case MamaFieldDescriptor.U8:
+                return findOrAddUint8(desc);
+        
+            case MamaFieldDescriptor.I16:
+                return findOrAddInt16(desc);
+        
+            case MamaFieldDescriptor.U16:
+                return findOrAddUint16(desc);
+        
+            case MamaFieldDescriptor.I32:
+                return findOrAddInt32(desc);
+        
+            case MamaFieldDescriptor.U32:
+                return findOrAddUint32(desc);
+        
+            case MamaFieldDescriptor.I64:
+                return findOrAddInt64(desc);
+        
+            case MamaFieldDescriptor.U64:
+                return findOrAddUint64(desc);
+        
+            case MamaFieldDescriptor.F32:
+                return findOrAddFloat32(desc);
+        
+            case MamaFieldDescriptor.F64:
+                return findOrAddFloat64(desc);
+        
+            case MamaFieldDescriptor.TIME:
+            case MamaFieldDescriptor.DATETIME:
+                return findOrAddDateTime(desc);
+        
+            case MamaFieldDescriptor.PRICE:
+                return findOrAddPrice(desc);
+            
+            case MamaFieldDescriptor.MSG:
+            case MamaFieldDescriptor.OPAQUE:
+            case MamaFieldDescriptor.I8ARRAY:
+            case MamaFieldDescriptor.U8ARRAY:
+            case MamaFieldDescriptor.I16ARRAY:
+            case MamaFieldDescriptor.U16ARRAY:
+            case MamaFieldDescriptor.I32ARRAY:
+            case MamaFieldDescriptor.U32ARRAY:
+            case MamaFieldDescriptor.I64ARRAY:
+            case MamaFieldDescriptor.U64ARRAY:
+            case MamaFieldDescriptor.F32ARRAY:
+            case MamaFieldDescriptor.F64ARRAY:
+            case MamaFieldDescriptor.VECTOR_STRING:
+            case MamaFieldDescriptor.VECTOR_MSG:
+            case MamaFieldDescriptor.VECTOR_TIME:
+            case MamaFieldDescriptor.VECTOR_PRICE:
+            case MamaFieldDescriptor.COLLECTION:
+            case MamaFieldDescriptor.UNKNOWN:
+            
+            return null;            
+        }
+
+        return null;
+    
+    }
+    
+    public MamaFieldCacheField findOrAdd(MamaFieldDescriptor desc)
+    {    
+        MamaFieldCacheField result = find(desc);
+        if (result == null)
+        {
+            result = add (desc);
+        }
+        return result;
+    }
+    
+    public MamaFieldCacheField findOrAddBool(MamaFieldDescriptor desc)
+    {
+        MamaFieldCacheField result = find(desc);
+        if (result == null)
+        {
+            result = new MamaFieldCacheBool(desc);
+            if (mOverrideDescTrackModState)
+            {
+                result.setTrackModState (mTrackModState);
+            }
+            add (result);
+        }
+        return (MamaFieldCacheBool)(result);
+    }
+    
+    public MamaFieldCacheChar findOrAddChar(MamaFieldDescriptor desc)
+    {
+        MamaFieldCacheField result = find(desc);
+        if (result == null)
+        {
+            result = new MamaFieldCacheChar(desc);
+            if (mOverrideDescTrackModState)
+            {
+                result.setTrackModState (mTrackModState);
+            }
+            add (result);
+        }
+        return (MamaFieldCacheChar)(result);
+    }
+    
+    public MamaFieldCacheUint8 findOrAddUint8(MamaFieldDescriptor desc)
+    {
+        MamaFieldCacheField result = find(desc);
+        if (result == null)
+        {
+            result = new MamaFieldCacheUint8(desc);
+            if (mOverrideDescTrackModState)
+            {
+                result.setTrackModState (mTrackModState);
+            }
+            add (result);
+        }
+        return (MamaFieldCacheUint8)(result);
+    }
+    
+    public MamaFieldCacheInt8 findOrAddInt8(MamaFieldDescriptor desc)
+    {
+       MamaFieldCacheField result = find(desc);
+        if (result == null)
+        {
+            result = new MamaFieldCacheInt8(desc);
+            if (mOverrideDescTrackModState)
+            {
+                result.setTrackModState (mTrackModState);
+            }
+            add (result);
+        }
+        return (MamaFieldCacheInt8)(result);
+    }
+    
+    public MamaFieldCacheUint16 findOrAddUint16(MamaFieldDescriptor desc)
+    {
+       MamaFieldCacheField result = find(desc);
+        if (result == null)
+        {
+            result = new MamaFieldCacheUint16(desc);
+            if (mOverrideDescTrackModState)
+            {
+                result.setTrackModState (mTrackModState);
+            }
+            add (result);
+        }
+        return (MamaFieldCacheUint16)(result);
+    }
+    
+    public MamaFieldCacheInt16 findOrAddInt16(MamaFieldDescriptor desc)
+    {
+       MamaFieldCacheField result = find(desc);
+        if (result == null)
+        {
+            result = new MamaFieldCacheInt16(desc);
+            if (mOverrideDescTrackModState)
+            {
+                result.setTrackModState (mTrackModState);
+            }
+            add (result);
+        }
+        return (MamaFieldCacheInt16)(result);
+    }
+    
+    public MamaFieldCacheUint32 findOrAddUint32(MamaFieldDescriptor desc)
+    {
+    
+       MamaFieldCacheField result = find(desc);
+        if (result == null)
+        {
+            result = new MamaFieldCacheUint32(desc);
+            if (mOverrideDescTrackModState)
+            {
+                result.setTrackModState (mTrackModState);
+            }
+            add (result);
+        }
+        return (MamaFieldCacheUint32)(result);
+    }
+    
+    public MamaFieldCacheInt32 findOrAddInt32(MamaFieldDescriptor desc)
+    {
+       MamaFieldCacheField result = find(desc);
+        if (result == null)
+        {
+            result = new MamaFieldCacheInt32(desc);
+            if (mOverrideDescTrackModState)
+            {
+                result.setTrackModState (mTrackModState);
+            }
+            add (result);
+        }
+        return (MamaFieldCacheInt32)(result);
+    }
+    
+    public MamaFieldCacheUint64 findOrAddUint64(MamaFieldDescriptor desc)
+    {
+       MamaFieldCacheField result = find(desc);
+        if (result == null)
+        {
+            result = new MamaFieldCacheUint64(desc);
+            if (mOverrideDescTrackModState)
+            {
+                result.setTrackModState (mTrackModState);
+            }
+            add (result);
+        }
+        return (MamaFieldCacheUint64)(result);
+    }
+    
+    public MamaFieldCacheInt64 findOrAddInt64(MamaFieldDescriptor desc)
+    {
+       MamaFieldCacheField result = find(desc);
+        if (result == null)
+        {
+            result = new MamaFieldCacheInt64(desc);
+            if (mOverrideDescTrackModState)
+            {
+                result.setTrackModState (mTrackModState);
+            }
+            add (result);
+        }
+        return (MamaFieldCacheInt64)(result);
+    }
+    
+    public MamaFieldCacheFloat32 findOrAddFloat32(MamaFieldDescriptor desc)
+    {
+       MamaFieldCacheField result = find(desc);
+        if (result == null)
+        {
+            result = new MamaFieldCacheFloat32(desc);
+            if (mOverrideDescTrackModState)
+            {
+                result.setTrackModState (mTrackModState);
+            }
+            add (result);
+        }
+        return (MamaFieldCacheFloat32)(result);
+    }
+    
+    public MamaFieldCacheFloat64 findOrAddFloat64(MamaFieldDescriptor desc)
+    {
+       MamaFieldCacheField result = find(desc);
+        if (result == null)
+        {
+            result = new MamaFieldCacheFloat64(desc);
+            if (mOverrideDescTrackModState)
+            {
+                result.setTrackModState (mTrackModState);
+            }
+            add (result);
+        }
+        return (MamaFieldCacheFloat64)(result);
+    }
+    
+    public MamaFieldCacheDateTime findOrAddDateTime(MamaFieldDescriptor desc)
+    {
+       MamaFieldCacheField result = find(desc);
+        if (result == null)
+        {
+            result = new MamaFieldCacheDateTime(desc);
+            if (mOverrideDescTrackModState)
+            {
+                result.setTrackModState (mTrackModState);
+            }
+            add (result);
+        }
+        return (MamaFieldCacheDateTime)(result);
+    }
+    
+    public MamaFieldCachePrice findOrAddPrice(MamaFieldDescriptor desc)
+    {
+       MamaFieldCacheField result = find(desc);
+        if (result == null)
+        {
+            result = new MamaFieldCachePrice(desc);
+            if (mOverrideDescTrackModState)
+            {
+                result.setTrackModState (mTrackModState);
+            }
+            add (result);
+        }
+        return (MamaFieldCachePrice)(result);
+    }   
+    
+    public MamaFieldCacheString findOrAddString(MamaFieldDescriptor desc)
+    {        
+        MamaFieldCacheField result = find (desc);
+        if (result == null)
+        {
+            result = new MamaFieldCacheString (desc);
+            if (mOverrideDescTrackModState)
+            {
+                result.setTrackModState (mTrackModState);
+            }
+            add (result);
+        }
+        return (MamaFieldCacheString)(result);
+    }
+    
+    //check type for "type" parameter
+    public MamaFieldCacheField add (int fid,short type,String name)
+    {
+        switch (type)
+        {
+        case MamaFieldDescriptor.MSG:
+           return null;
+
+        case MamaFieldDescriptor.OPAQUE:
+            return null;
+
+        case MamaFieldDescriptor.STRING:
+            return findOrAddString (fid, name);
+
+        case MamaFieldDescriptor.BOOL:
+            return findOrAddBool (fid, name);
+
+        case MamaFieldDescriptor.CHAR:
+            return findOrAddChar (fid, name);
+
+        case MamaFieldDescriptor.I8:
+            return findOrAddInt8 (fid, name);
+
+        case MamaFieldDescriptor.U8:
+            return findOrAddUint8 (fid, name);
+
+        case MamaFieldDescriptor.I16:
+            return findOrAddInt16 (fid, name);
+
+        case MamaFieldDescriptor.U16:
+            return findOrAddUint16 (fid, name);
+
+        case MamaFieldDescriptor.I32:
+            return findOrAddInt32 (fid, name);
+
+        case MamaFieldDescriptor.U32:
+            return findOrAddUint32 (fid, name);
+
+        case MamaFieldDescriptor.I64:
+            return findOrAddInt64 (fid, name);
+
+        case MamaFieldDescriptor.U64:
+            return findOrAddUint64 (fid, name);
+    
+        case MamaFieldDescriptor.F32:
+            return findOrAddFloat32 (fid, name);
+
+        case MamaFieldDescriptor.F64:
+            return findOrAddFloat64 (fid, name);
+
+        case MamaFieldDescriptor.TIME:
+            return findOrAddDateTime (fid, name);
+
+        case MamaFieldDescriptor.PRICE:
+            return findOrAddPrice (fid, name);
+       
+        case MamaFieldDescriptor.I8ARRAY:
+        case MamaFieldDescriptor.U8ARRAY:
+        case MamaFieldDescriptor.I16ARRAY:
+        case MamaFieldDescriptor.U16ARRAY:
+        case MamaFieldDescriptor.I32ARRAY:
+        case MamaFieldDescriptor.U32ARRAY:
+        case MamaFieldDescriptor.I64ARRAY:
+        case MamaFieldDescriptor.U64ARRAY:
+        case MamaFieldDescriptor.F32ARRAY:
+        case MamaFieldDescriptor.F64ARRAY:
+        case MamaFieldDescriptor.VECTOR_STRING:
+        case MamaFieldDescriptor.VECTOR_MSG:
+        case MamaFieldDescriptor.VECTOR_TIME:
+        case MamaFieldDescriptor.VECTOR_PRICE:
+        case MamaFieldDescriptor.COLLECTION:
+        case MamaFieldDescriptor.UNKNOWN:
+            return null;
+        }
+
+    return null;
+    }   
+
+    public MamaFieldCacheField findOrAdd (int fid,short type,String name)
+    {
+        MamaFieldCacheField result = find (fid);
+        if (result == null)
+        {
+            result = add (fid, type, name);
+        }
+        return result;
+    }
+    
+    public MamaFieldCacheField findOrAddBool(int fid, String name)
+    {        
+        MamaFieldCacheField result = find (fid);
+        if (result == null)
+        {
+            result = new MamaFieldCacheBool (fid, name, mTrackModState);
+            add (result);            
+        }
+        return (MamaFieldCacheBool)result;
+    }
+    
+    public MamaFieldCacheField findOrAddChar(int fid, String name)
+    {        
+        MamaFieldCacheField result = find (fid);
+        if (result == null)
+        {
+            result = new MamaFieldCacheChar (fid, name, mTrackModState);
+            add(result);
+        }
+        return (MamaFieldCacheChar)result;
+    }
+    
+    public MamaFieldCacheField findOrAddUint8(int fid, String name)
+    {        
+        MamaFieldCacheField result = find (fid);
+        if (result == null)
+        {
+            result = new MamaFieldCacheUint8 (fid, name, mTrackModState);
+            add(result);
+        }
+        return (MamaFieldCacheUint8)result;  
+    }
+    
+    public MamaFieldCacheField findOrAddInt8(int fid, String name)
+    {
+        MamaFieldCacheField result = find (fid);
+        if (result == null)
+        {
+            result = new MamaFieldCacheInt8 (fid, name, mTrackModState);
+            add(result);
+        }
+        return (MamaFieldCacheInt8)result;
+    }
+    
+    public MamaFieldCacheField findOrAddUint16(int fid, String name)
+    {
+        MamaFieldCacheField result = find (fid);
+        if (result == null)
+        {
+            result = new MamaFieldCacheUint16 (fid, name, mTrackModState);
+            add(result);
+        }
+        return (MamaFieldCacheUint16)result;
+    }
+    
+    public MamaFieldCacheField findOrAddInt16(int fid, String name)
+    {        
+        MamaFieldCacheField result = find (fid);
+        if (result == null)
+        {
+            result = new MamaFieldCacheInt16 (fid, name, mTrackModState);
+            add(result);
+        }
+        return (MamaFieldCacheInt16)result;
+    }
+    
+    public MamaFieldCacheField findOrAddUint32(int fid, String name)
+    {        
+        MamaFieldCacheField result = find (fid);
+        if (result == null)
+        {
+            result = new MamaFieldCacheUint32 (fid, name, mTrackModState);
+            add(result);
+        }
+        return (MamaFieldCacheUint32)result;
+    }
+    
+    public MamaFieldCacheField findOrAddInt32(int fid, String name)
+    {        
+        MamaFieldCacheField result = find (fid);
+        if (result == null)
+        {
+            result = new MamaFieldCacheInt32 (fid, name, mTrackModState);
+            add(result);
+        }
+        return (MamaFieldCacheInt32)result; 
+    }
+    
+    public MamaFieldCacheField findOrAddUint64(int fid, String name)
+    {        
+        MamaFieldCacheField result = find (fid);
+        if (result == null)
+        {
+            result = new MamaFieldCacheUint64 (fid, name, mTrackModState);
+            add(result);
+        }
+        return (MamaFieldCacheUint64)result; 
+    }
+    
+    public MamaFieldCacheField findOrAddInt64(int fid, String name)
+    {        
+        MamaFieldCacheField result = find (fid);
+        if (result == null)
+        {
+            result = new MamaFieldCacheInt64 (fid, name, mTrackModState);
+            add(result);
+        }
+        return (MamaFieldCacheInt64)result;   
+    }
+    
+    public MamaFieldCacheField findOrAddFloat32(int fid, String name)
+    {        
+        MamaFieldCacheField result = find (fid);
+        if (result == null)
+        {
+            result = new MamaFieldCacheFloat32 (fid, name, mTrackModState);
+            add(result);
+        }
+        return (MamaFieldCacheFloat32)result;
+    }
+    
+    public MamaFieldCacheField findOrAddFloat64(int fid, String name)
+    {        
+        MamaFieldCacheField result = find (fid);
+        if (result == null)
+        {
+            result = new MamaFieldCacheFloat64 (fid, name, mTrackModState);
+            add(result);
+        }
+        return (MamaFieldCacheFloat64)result;
+    }
+    
+    public MamaFieldCacheField findOrAddDateTime(int fid, String name)
+    {      
+        MamaFieldCacheField result = find (fid);
+        if (result == null)
+        {            
+            result = new MamaFieldCacheDateTime (fid, name, mTrackModState);
+            add(result);
+        }        
+        return (MamaFieldCacheDateTime)result;    
+    }
+    
+    public MamaFieldCacheField findOrAddPrice(int fid, String name)
+    {        
+        MamaFieldCacheField result = find (fid);
+        if (result == null)
+        {
+            result = new MamaFieldCachePrice (fid, name, mTrackModState);
+            add(result);
+        }
+        return (MamaFieldCachePrice)result;
+    }   
+    
+    public MamaFieldCacheField findOrAddString(int fid, String name)
+    {        
+        MamaFieldCacheField result = find (fid);
+        if (result==null)
+        {
+            result = new MamaFieldCacheString (fid, name, mTrackModState);
+            add(result);
+        }
+        return (MamaFieldCacheField)result;
+    }
+    /*
+    public MamaFieldCacheField findOrAddEnum(int fid, String name)
+    {
+        MamaFieldCacheField result = find(fid);
+        if (result==null)
+        {
+            result = new MamaFieldCacheUint8(fid,name,mTrackModState);            
+            add (result);
+        }
+        return (MamaFieldCacheUint8)(result);
+    }
+    
+    public MamaFieldCacheField findOrAddMultiEnum(int fid, String name)
+    {
+        MamaFieldCacheField result = find(desc);
+        if (result==null)
+        {
+            result = new MamaFieldCacheUint8(fid,name,mTrackModState);            
+            add (result);
+        }
+        return (MamaFieldCacheUint8)(result);
+    }*/
+    
+    public void lockFields()
+    {
+    }
+    
+    public void unlockFields()
+    {
+    
+    }
+    
+    public void setTrackModState(boolean state)
+    {
+        mTrackModState = state;
+    }
+    
+    public boolean getTrackModState()
+    {
+        return mTrackModState;
+    }    
+    
+    public void setOverrideDescriptorTrackModState(boolean state)
+    {
+        mOverrideDescTrackModState = state;
+    }
+    
+    public boolean getOverrideDescriptorTrackModState()
+    {
+        return  mOverrideDescTrackModState;
+    }
+}

--- a/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheBool.java
+++ b/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheBool.java
@@ -1,0 +1,149 @@
+//--------------------------------------------------------------------------
+// Copyright (c) 1999-2006 Wombat Financial Software Inc., of Incline
+// Village, NV.  All rights reserved.
+//
+// This software and documentation constitute an unpublished work and
+// contain valuable trade secrets and proprietary information belonging
+// to Wombat.  None of this material may be copied, duplicated or
+// disclosed without the express written permission of Wombat.
+//
+// WOMBAT EXPRESSLY DISCLAIMS ANY AND ALL WARRANTIES CONCERNING THIS
+// SOFTWARE AND DOCUMENTATION, INCLUDING ANY WARRANTIES OF
+// MERCHANTABILITY AND/OR FITNESS FOR ANY PARTICULAR PURPOSE, AND
+// WARRANTIES OF PERFORMANCE, AND ANY WARRANTY THAT MIGHT OTHERWISE ARISE
+// FROM COURSE OF DEALING OR USAGE OF TRADE. NO WARRANTY IS EITHER
+// EXPRESS OR IMPLIED WITH RESPECT TO THE USE OF THE SOFTWARE OR
+// DOCUMENTATION.
+//
+// Under no circumstances shall Wombat be liable for incidental, special,
+// indirect, direct or consequential damages or loss of profits,
+// interruption of business, or related expenses which may arise from use
+// of software or documentation, including but not limited to those
+// resulting from defects in software and/or documentation, or loss or
+// inaccuracy of data of any kind.
+//
+//----------------------------------------------------------------------------
+
+package com.wombat.mama;
+
+public class MamaFieldCacheBool extends MamaFieldCacheField
+{
+    private boolean mValue;
+    
+    /**
+     * Constructor.  Use one of the create() methods to actually
+     * initialize the field.
+     */
+     
+    public MamaFieldCacheBool (MamaFieldDescriptor desc)
+    {
+        super(desc,MamaFieldDescriptor.BOOL);
+        mValue = false;
+    }
+    
+    /**
+     * Constructor.
+     */
+     
+    public MamaFieldCacheBool (int fid, String name, boolean trackModState)
+    {
+        super(fid,MamaFieldDescriptor.BOOL,name,trackModState);
+        mValue = false;
+    }
+
+    /*  Description :   This function will add the contents of the cache field
+     *                  to the supplied message.
+     *  Arguments   :   fieldName   [I] True to add the field name to the message.
+     *                  message     [I] The message where the field will be added.
+     */
+    public void addToMessage(boolean fieldName, MamaMsg message)
+    {
+        // Check to see if field names should be added
+        String name = null;
+        if (fieldName)
+        {
+            // Get the field name from the descriptor
+            name = mDesc.getName();
+        }
+
+        // Add the value
+        message.addBool(name, mDesc.getFid (), mValue);
+    }
+
+    public MamaFieldCacheField copy ()
+    {
+        MamaFieldCacheBool result = new MamaFieldCacheBool (
+            mDesc.getFid (),
+            mDesc.getName (),
+            mTrackModState);
+        result.mValue = mValue;
+        return result;
+    }
+
+    /**
+     * Apply the MamaMsgField to the cached field.
+     */
+     
+    public void apply(MamaMsgField msgField)
+    {
+        mValue = msgField.getBoolean ();
+    }
+
+    /**
+     * Apply the MamaFieldCacheField.
+     */
+    public void apply (MamaFieldCacheField value)
+    {
+        mValue = ((MamaFieldCacheBool)value).mValue;
+    }
+
+    /**
+     * Explicitly set the cached value.
+     */
+     
+    public void set (boolean value)
+    {
+        if (mTrackModState)
+        {
+            if (mValue == value)
+            {
+                if (isModified())
+                    setModState (MamaFieldCacheField.MOD_STATE_TOUCHED);
+                return;
+            }
+            else
+            {
+                setModState (MamaFieldCacheField.MOD_STATE_MODIFIED);
+                // Drop through to assignment.               
+            }            
+        }
+        mValue = value;
+    }
+    
+    /**
+     * Check whether the field value is equal.
+     */
+     
+    public boolean isEqual (boolean value)
+    {
+        return value == mValue;      
+    }
+    
+    /**
+     * Return the cached value.
+     */
+     
+    public boolean get ()
+    {
+        return  mValue;
+    }
+    
+    /**
+     * Return a string representation of the value
+     */
+     
+    public String getAsString()
+    {
+        return new Boolean(mValue).toString();        
+    }
+}

--- a/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheChar.java
+++ b/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheChar.java
@@ -1,0 +1,155 @@
+//--------------------------------------------------------------------------
+// Copyright (c) 1999-2006 Wombat Financial Software Inc., of Incline
+// Village, NV.  All rights reserved.
+//
+// This software and documentation constitute an unpublished work and
+// contain valuable trade secrets and proprietary information belonging
+// to Wombat.  None of this material may be copied, duplicated or
+// disclosed without the express written permission of Wombat.
+//
+// WOMBAT EXPRESSLY DISCLAIMS ANY AND ALL WARRANTIES CONCERNING THIS
+// SOFTWARE AND DOCUMENTATION, INCLUDING ANY WARRANTIES OF
+// MERCHANTABILITY AND/OR FITNESS FOR ANY PARTICULAR PURPOSE, AND
+// WARRANTIES OF PERFORMANCE, AND ANY WARRANTY THAT MIGHT OTHERWISE ARISE
+// FROM COURSE OF DEALING OR USAGE OF TRADE. NO WARRANTY IS EITHER
+// EXPRESS OR IMPLIED WITH RESPECT TO THE USE OF THE SOFTWARE OR
+// DOCUMENTATION.
+//
+// Under no circumstances shall Wombat be liable for incidental, special,
+// indirect, direct or consequential damages or loss of profits,
+// interruption of business, or related expenses which may arise from use
+// of software or documentation, including but not limited to those
+// resulting from defects in software and/or documentation, or loss or
+// inaccuracy of data of any kind.
+//
+//----------------------------------------------------------------------------
+
+package com.wombat.mama;
+
+public class MamaFieldCacheChar extends MamaFieldCacheField
+{
+    private char mValue;
+    
+    /**
+     * Constructor.  Use one of the create() methods to actually
+     * initialize the field.
+     */
+     
+    public MamaFieldCacheChar (MamaFieldDescriptor desc)
+    {
+        super(desc,MamaFieldDescriptor.CHAR);
+        mValue = '\0';
+    }
+    
+    /**
+     * Constructor.
+     */
+     
+    public MamaFieldCacheChar (int fid, String name, boolean trackModState)
+    {
+        super(fid,MamaFieldDescriptor.CHAR,name,trackModState);
+        mValue = '\0';
+    }
+
+    /*  Description :   This function will add the contents of the cache field
+     *                  to the supplied message.
+     *  Arguments   :   fieldName   [I] True to add the field name to the message.
+     *                  message     [I] The message where the field will be added.
+     */
+    public void addToMessage(boolean fieldName, MamaMsg message)
+    {
+        // Check to see if field names should be added
+        String name = null;
+        if (fieldName)
+        {
+            // Get the field name from the descriptor
+            name = mDesc.getName();
+        }
+
+        // Add the value
+        message.addChar(name, mDesc.getFid (), mValue);
+    }
+
+    public MamaFieldCacheField copy ()
+    {
+        MamaFieldCacheChar result = new MamaFieldCacheChar (
+            mDesc.getFid (),
+            mDesc.getName (),
+            mTrackModState);
+        result.mValue = mValue;
+        return result;
+    }
+
+    /**
+     * Apply the MamaMsgField to the cached field.
+     */
+     
+    public void apply(MamaMsgField msgField)
+    {
+        mValue = msgField.getChar ();
+    }
+    
+    /**
+     * Explicitly set the cached value.
+     */
+    
+    public void set (char value)
+    {
+        if (mTrackModState)
+        {
+            if (mValue == value)
+            {
+                if (isModified())
+                    setModState (MamaFieldCacheField.MOD_STATE_TOUCHED);
+                return;
+            }
+            else
+            {
+                setModState (MamaFieldCacheField.MOD_STATE_MODIFIED);
+                // Drop through to assignment.               
+            }            
+        }
+        mValue = value;
+    }
+    
+    /**
+     * Check whether the field value is equal.
+     */
+     
+    public boolean isEqual (char value)
+    {     
+        return value == mValue;      
+    }
+    
+    /**
+     * Return the cached value.
+     */
+     
+    public char get ()
+    {
+        return (mValue != '\0') ? mValue : '\0';
+    }
+    
+    /**
+     * Copy the cached value into the result.
+     */
+    
+    public void get (char result)
+    {
+        result = mValue;
+    }
+   
+    /**
+     * Return a string representation of the value
+     */
+     
+    public String getAsString()
+    {
+        return (mValue != '\0') ? new Character(mValue).toString() : "\0";    
+    }
+
+    public void apply (MamaFieldCacheField value)
+    {
+        mValue = ((MamaFieldCacheChar)value).mValue;
+    }
+}

--- a/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheDateTime.java
+++ b/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheDateTime.java
@@ -1,0 +1,184 @@
+//--------------------------------------------------------------------------
+// Copyright (c) 1999-2006 Wombat Financial Software Inc., of Incline
+// Village, NV.  All rights reserved.
+//
+// This software and documentation constitute an unpublished work and
+// contain valuable trade secrets and proprietary information belonging
+// to Wombat.  None of this material may be copied, duplicated or
+// disclosed without the express written permission of Wombat.
+//
+// WOMBAT EXPRESSLY DISCLAIMS ANY AND ALL WARRANTIES CONCERNING THIS
+// SOFTWARE AND DOCUMENTATION, INCLUDING ANY WARRANTIES OF
+// MERCHANTABILITY AND/OR FITNESS FOR ANY PARTICULAR PURPOSE, AND
+// WARRANTIES OF PERFORMANCE, AND ANY WARRANTY THAT MIGHT OTHERWISE ARISE
+// FROM COURSE OF DEALING OR USAGE OF TRADE. NO WARRANTY IS EITHER
+// EXPRESS OR IMPLIED WITH RESPECT TO THE USE OF THE SOFTWARE OR
+// DOCUMENTATION.
+//
+// Under no circumstances shall Wombat be liable for incidental, special,
+// indirect, direct or consequential damages or loss of profits,
+// interruption of business, or related expenses which may arise from use
+// of software or documentation, including but not limited to those
+// resulting from defects in software and/or documentation, or loss or
+// inaccuracy of data of any kind.
+//
+//----------------------------------------------------------------------------
+
+
+package com.wombat.mama;
+
+public class MamaFieldCacheDateTime extends MamaFieldCacheField
+{
+    private MamaDateTime mValue;
+
+    /**
+     * Constructor.  Use one of the create() methods to actually
+     * initialize the field.
+     */
+
+    public MamaFieldCacheDateTime (MamaFieldDescriptor desc)
+    {
+        super (desc,MamaFieldDescriptor.DATETIME);
+        mValue = null;
+    }
+
+    /**
+     * Constructor.
+     */
+
+    public MamaFieldCacheDateTime (int fid, String name, boolean trackModState)
+    {
+        super (fid,MamaFieldDescriptor.DATETIME,name,trackModState);
+        mValue = null;
+    }
+    
+    /*  Description :   This function will add the contents of the cache field
+     *                  to the supplied message.
+     *  Arguments   :   fieldName   [I] True to add the field name to the message.
+     *                  message     [I] The message where the field will be added.
+     */
+    public void addToMessage(boolean fieldName, MamaMsg message)
+    {
+        // Check to see if field names should be added
+        String name = null;
+        if (fieldName)
+        {
+            // Get the field name from the descriptor
+            name = mDesc.getName();
+        }
+
+        // Add the value
+        message.addDateTime(name, mDesc.getFid (), mValue);
+    }
+
+    public MamaFieldCacheField copy ()
+    {
+        MamaFieldCacheDateTime result = new MamaFieldCacheDateTime (
+            mDesc.getFid (),
+            mDesc.getName (),
+            mTrackModState);
+        result.mValue = new MamaDateTime (mValue);
+        return result;
+
+    }
+
+    /**
+     * Apply the MamaMsgField to the cached field.
+     */
+
+    public void apply(MamaMsgField msgField)
+    {
+        mValue = msgField.getDateTime ();
+    }
+
+    /**
+     * Explicitly set the cached value.
+     */
+
+    public void set (MamaDateTime value)
+    {
+        if (mTrackModState)
+        {
+            if (mValue == value)
+            {
+                if (isModified())
+                    setModState (MamaFieldCacheField.MOD_STATE_TOUCHED);
+                return;
+            }
+            else
+            {
+                setModState (MamaFieldCacheField.MOD_STATE_MODIFIED);
+                // Drop through to assignment.
+            }
+        }
+        if (value == null)
+            mValue = null;
+        else
+        {
+            if (mValue == null)
+                mValue = new MamaDateTime (value);
+            else
+                mValue.copy(value);
+        }
+    }
+
+    /**
+     * Check whether the field value is equal.
+     */
+
+    public boolean isEqual (MamaDateTime value)
+    {
+        if (mValue == null)
+        {
+            return (value == null);
+        }
+        else
+        {
+            return mValue.equals(value);
+        }
+    }
+
+    /**
+     * Return the cached value.
+     */
+
+    public MamaDateTime get ()
+    {
+        return (mValue != null) ? mValue : null;
+    }
+
+    /**
+     * Copy the cached value into the result.
+     */
+
+    public void get (MamaDateTime result)
+    {
+        result = mValue;
+    }
+
+    /**
+     * Return a string representation of the value
+     */
+
+    public String getAsString()
+    {
+        return (mValue != null) ? mValue.toString() : "null";
+    }
+
+    public void apply (MamaFieldCacheField value)
+    {
+        if (value == null)
+            throw new MamaException("MamaFieldCacheDateTime.apply() cannot be called with a null value");
+
+        if (((MamaFieldCacheDateTime)value).get() == null)
+        {
+            mValue = null;
+            return;
+        }
+
+        if (mValue == null)
+            mValue = new MamaDateTime(((MamaFieldCacheDateTime)value).mValue);
+        else
+            mValue.copy (((MamaFieldCacheDateTime)value).mValue);
+    }
+}

--- a/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheEnum.java
+++ b/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheEnum.java
@@ -1,0 +1,156 @@
+//--------------------------------------------------------------------------
+// Copyright (c) 1999-2006 Wombat Financial Software Inc., of Incline
+// Village, NV.  All rights reserved.
+//
+// This software and documentation constitute an unpublished work and
+// contain valuable trade secrets and proprietary information belonging
+// to Wombat.  None of this material may be copied, duplicated or
+// disclosed without the express written permission of Wombat.
+//
+// WOMBAT EXPRESSLY DISCLAIMS ANY AND ALL WARRANTIES CONCERNING THIS
+// SOFTWARE AND DOCUMENTATION, INCLUDING ANY WARRANTIES OF
+// MERCHANTABILITY AND/OR FITNESS FOR ANY PARTICULAR PURPOSE, AND
+// WARRANTIES OF PERFORMANCE, AND ANY WARRANTY THAT MIGHT OTHERWISE ARISE
+// FROM COURSE OF DEALING OR USAGE OF TRADE. NO WARRANTY IS EITHER
+// EXPRESS OR IMPLIED WITH RESPECT TO THE USE OF THE SOFTWARE OR
+// DOCUMENTATION.
+//
+// Under no circumstances shall Wombat be liable for incidental, special,
+// indirect, direct or consequential damages or loss of profits,
+// interruption of business, or related expenses which may arise from use
+// of software or documentation, including but not limited to those
+// resulting from defects in software and/or documentation, or loss or
+// inaccuracy of data of any kind.
+//
+//----------------------------------------------------------------------------
+
+
+package com.wombat.mama;
+
+public class MamaFieldCacheEnum extends MamaFieldCacheField
+{
+    private int mValue;
+    
+    /**
+     * Constructor.  Use one of the create() methods to actually
+     * initialize the field.
+     */
+     
+    public MamaFieldCacheEnum (MamaFieldDescriptor desc)
+    {
+        super(desc,MamaFieldDescriptor.U16);
+        mValue = 0;
+    }
+    
+    /**
+     * Constructor.
+     */
+     
+    public MamaFieldCacheEnum (int fid, String name, boolean trackModState)
+    {
+        super(fid,MamaFieldDescriptor.U16,name,trackModState);
+        mValue = 0;
+    }
+
+    /*  Description :   This function will add the contents of the cache field
+     *                  to the supplied message.
+     *  Arguments   :   fieldName   [I] True to add the field name to the message.
+     *                  message     [I] The message where the field will be added.
+     */
+    public void addToMessage(boolean fieldName, MamaMsg message)
+    {
+        // Check to see if field names should be added
+        String name = null;
+        if (fieldName)
+        {
+            // Get the field name from the descriptor
+            name = mDesc.getName();
+        }
+
+        // Add the value
+        message.addI32(name, mDesc.getFid (), mValue);
+    }
+
+    public MamaFieldCacheField copy ()
+    {
+        MamaFieldCacheEnum result = new MamaFieldCacheEnum (
+            mDesc.getFid (),
+            mDesc.getName (),
+            mTrackModState);
+        result.mValue = mValue;
+        return result;
+    }
+
+    /**
+     * Apply the MamaMsgField to the cached field.
+     */
+     
+    public void apply(MamaMsgField msgField)
+    {
+        mValue = msgField.getU16 ();
+    }
+    
+    /**
+     * Explicitly set the cached value.
+     */
+    
+    public void set (int value)
+    {
+        if (mTrackModState)
+        {
+            if (mValue == value)
+            {
+                if (isModified())
+                    setModState (MamaFieldCacheField.MOD_STATE_TOUCHED);
+                return;
+            }
+            else
+            {
+                setModState (MamaFieldCacheField.MOD_STATE_MODIFIED);
+                // Drop through to assignment.               
+            }            
+        }
+        mValue = value;
+    }
+    
+    /**
+     * Check whether the field value is equal.
+     */
+     
+    public boolean isEqual (int value)
+    {     
+        return value == mValue;      
+    }
+    
+    /**
+     * Return the cached value.
+     */
+     
+    public int get ()
+    {
+        return mValue;
+    }
+    
+    /**
+     * Copy the cached value into the result.
+     */
+    
+    public void get (int result)
+    {
+        result = mValue;
+    }
+   
+    /**
+     * Return a string representation of the value
+     */
+     
+    public String getAsString ()
+    {
+        return new Integer(mValue).toString();    
+    }
+
+    public void apply (MamaFieldCacheField value)
+    {
+        mValue = ((MamaFieldCacheEnum)value).mValue;
+    }
+}

--- a/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheField.java
+++ b/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheField.java
@@ -1,0 +1,202 @@
+//--------------------------------------------------------------------------
+// Copyright (c) 1999-2006 Wombat Financial Software Inc., of Incline
+// Village, NV.  All rights reserved.
+//
+// This software and documentation constitute an unpublished work and
+// contain valuable trade secrets and proprietary information belonging
+// to Wombat.  None of this material may be copied, duplicated or
+// disclosed without the express written permission of Wombat.
+//
+// WOMBAT EXPRESSLY DISCLAIMS ANY AND ALL WARRANTIES CONCERNING THIS
+// SOFTWARE AND DOCUMENTATION, INCLUDING ANY WARRANTIES OF
+// MERCHANTABILITY AND/OR FITNESS FOR ANY PARTICULAR PURPOSE, AND
+// WARRANTIES OF PERFORMANCE, AND ANY WARRANTY THAT MIGHT OTHERWISE ARISE
+// FROM COURSE OF DEALING OR USAGE OF TRADE. NO WARRANTY IS EITHER
+// EXPRESS OR IMPLIED WITH RESPECT TO THE USE OF THE SOFTWARE OR
+// DOCUMENTATION.
+//
+// Under no circumstances shall Wombat be liable for incidental, special,
+// indirect, direct or consequential damages or loss of profits,
+// interruption of business, or related expenses which may arise from use
+// of software or documentation, including but not limited to those
+// resulting from defects in software and/or documentation, or loss or
+// inaccuracy of data of any kind.
+//
+//----------------------------------------------------------------------------
+
+
+package com.wombat.mama;
+
+public abstract class MamaFieldCacheField implements MamaFieldCacheReadOnlyField
+{
+    public static final short MOD_STATE_NOT_MODIFIED = 1;
+    public static final short MOD_STATE_MODIFIED = 2;
+    public static final short MOD_STATE_TOUCHED = 3;
+
+    protected short               mType;
+    protected MamaFieldDescriptor mDesc;
+    protected short               mModState;
+    protected boolean             mTrackModState;
+    protected boolean             mLocalDescriptorCopy;
+
+    /**
+     * Constructor.  Use one of the create() methods to actually
+     * initialize the field.
+     */
+     
+    public MamaFieldCacheField(MamaFieldDescriptor desc,
+                               short type)
+    {
+        mDesc = desc;
+        mModState = MamaFieldCacheField.MOD_STATE_MODIFIED;
+            
+        mTrackModState = false;
+        mLocalDescriptorCopy = false;
+        
+        if ((desc!=null) && (type == MamaFieldDescriptor.UNKNOWN))
+            mType = desc.getType();
+        else
+            mType = type;
+        if (mDesc!=null)
+            mTrackModState = mDesc.getTrackModState();
+    }
+    
+    /**
+     * Constructor. Also create a local copy of field descriptor based on
+     * supplied info.
+     */
+     
+    public MamaFieldCacheField (int      fid,
+                                short    type,
+                                String   name,
+                                boolean  trackModState)
+    {
+        this(new MamaFieldDescriptor (fid, type, name,null), type);
+        mTrackModState = trackModState;
+        mLocalDescriptorCopy = true;        
+    }
+
+    /**
+     * Make a copy of this field.
+     *
+     * @return the copy
+     */
+    public abstract MamaFieldCacheField copy ();
+
+    /*  Description :   This function will add the contents of the cache field
+     *                  to the supplied message.
+     *  Arguments   :   fieldName   [I] True to add the field name to the message.
+     *                  message     [I] The message where the field will be added.
+     */
+    public abstract void addToMessage(boolean fieldName, MamaMsg message);
+
+    /**
+     * Apply the MamaMsgField to the cached field.
+     */
+     
+    public abstract void apply (MamaMsgField msgField);
+
+    /**
+     * Create a string value of the field in the buffer provided.
+     */
+     
+    public abstract String getAsString ();
+
+    /**
+     * Set the MamaFieldDescriptor for this field.  This is an unusual
+     * thing to want to do to an existing field but it can help with
+     * performance for specialized tasks.
+     */
+        
+    public void setDescriptor (MamaFieldDescriptor desc)
+    {
+        if (mDesc!=null)
+            mTrackModState = mDesc.getTrackModState();
+        mDesc = desc; 
+    }
+
+    /**
+     * Return the MamaFieldDescriptor for this field (or NULL).
+     */
+    public MamaFieldDescriptor getDescriptor() { return mDesc; }
+
+    /**
+     * Return the actual field type for this field.  It is possible to
+     * create fields that actually differ from the type specified in
+     * the dictionary field descriptor.
+     */
+    public short getType() { return mType; }
+
+
+    /**
+     * Set the whether track modification state for the field
+     */
+    public void setTrackModState (boolean state)
+    {
+        mTrackModState = state;
+    }
+
+    /**
+     * Get the track modification state for the field
+     */
+    public boolean getTrackModState ()
+    {
+        return mTrackModState;
+    }
+
+
+    /**
+     * Set the modification state for the field.
+     */
+   public void setModState (short  state) 
+    { 
+        if (mTrackModState)
+            mModState = state; 
+    }
+
+    /**
+     * Clear the modification state for the field (i.e., set to
+     * MOD_STATE_NOT_MODIFIED).
+     */
+    public void clearModState () 
+    { 
+        if (mTrackModState)
+            mModState = MamaFieldCacheField.MOD_STATE_NOT_MODIFIED; 
+    }
+
+    /**
+     * Get the modification state for the field.
+     */
+    public short getModState ()  { return mModState; }
+
+    /**
+     * Return whether the field is unmodified.
+     */
+    public boolean isUnmodified () { return mModState == MamaFieldCacheField.MOD_STATE_NOT_MODIFIED; }
+
+    /**
+     * Return whether the field is modified.
+     */
+    public boolean isModified ()  { return mModState == MamaFieldCacheField.MOD_STATE_MODIFIED; }
+
+    /**
+     * Return whether the field is modified.
+     */
+    public boolean isTouched () { return mModState == MamaFieldCacheField.MOD_STATE_TOUCHED; }
+
+    /**
+     * Explicitly "touch" the cached value.  To touch the cached value
+     * means to mark it as modified (or touched, actually) without
+     * actually bothering to check/update the current value.
+     */
+    public void  touch () 
+    {
+        if (mTrackModState)
+        {
+            if (!isModified())
+                setModState (MamaFieldCacheField.MOD_STATE_TOUCHED);
+        }
+    }
+
+    public abstract void apply (MamaFieldCacheField value);
+}

--- a/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheFieldList.java
+++ b/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheFieldList.java
@@ -1,0 +1,127 @@
+//--------------------------------------------------------------------------
+// Copyright (c) 1999-2006 Wombat Financial Software Inc., of Incline
+// Village, NV.  All rights reserved.
+//
+// This software and documentation constitute an unpublished work and
+// contain valuable trade secrets and proprietary information belonging
+// to Wombat.  None of this material may be copied, duplicated or
+// disclosed without the express written permission of Wombat.
+//
+// WOMBAT EXPRESSLY DISCLAIMS ANY AND ALL WARRANTIES CONCERNING THIS
+// SOFTWARE AND DOCUMENTATION, INCLUDING ANY WARRANTIES OF
+// MERCHANTABILITY AND/OR FITNESS FOR ANY PARTICULAR PURPOSE, AND
+// WARRANTIES OF PERFORMANCE, AND ANY WARRANTY THAT MIGHT OTHERWISE ARISE
+// FROM COURSE OF DEALING OR USAGE OF TRADE. NO WARRANTY IS EITHER
+// EXPRESS OR IMPLIED WITH RESPECT TO THE USE OF THE SOFTWARE OR
+// DOCUMENTATION.
+//
+// Under no circumstances shall Wombat be liable for incidental, special,
+// indirect, direct or consequential damages or loss of profits,
+// interruption of business, or related expenses which may arise from use
+// of software or documentation, including but not limited to those
+// resulting from defects in software and/or documentation, or loss or
+// inaccuracy of data of any kind.
+//
+//----------------------------------------------------------------------------
+
+package com.wombat.mama;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+
+public class MamaFieldCacheFieldList
+{
+    private ArrayList mFields;
+
+    public MamaFieldCacheFieldList()
+    {
+        mFields = new ArrayList(128);
+    }
+    
+    public void clear()
+    {
+        mFields.clear();
+    }
+    
+    public void clearAndDelete()
+    {
+        mFields.clear();
+    }
+    
+    public void add(MamaFieldCacheField  field)
+    {
+        if (field!=null)
+        {
+            MamaFieldDescriptor desc = field.getDescriptor();
+            if (desc!=null)
+            {
+                mFields.add(field);
+            }
+        }
+    }
+    
+    public void addIfModified(MamaFieldCacheField field)
+    {
+        if ((field!=null) && !field.isUnmodified())
+        {
+            MamaFieldDescriptor desc = field.getDescriptor();
+            if (desc!=null)
+            {
+                mFields.add(field);
+            }
+        }
+    }
+
+    public MamaFieldCacheField find(String name)
+    {
+        if (name == null)
+            return null;
+
+        for (int i=0; i<mFields.size(); i++)
+        {
+            MamaFieldCacheField field = (MamaFieldCacheField)mFields.get(i);
+            if (name.equals(field.getDescriptor().getName()))
+                return field;
+        }
+
+        return null;
+    }
+
+    public MamaFieldCacheField find(int fid)
+    {
+        for (int i=0; i<mFields.size(); i++)
+        {
+            MamaFieldCacheField field = (MamaFieldCacheField)mFields.get(i);
+            if (fid == field.getDescriptor().getFid())
+                return field;
+        }
+
+        return null;
+
+    }
+
+    public MamaFieldCacheField find(MamaFieldDescriptor desc)
+    {
+        return find(desc.getFid());
+    }
+
+    public int size()
+    {
+        return mFields.size();
+    }
+    
+    public boolean empty()
+    {
+        return mFields.isEmpty();
+    }
+    
+    public Iterator getIterator()
+    {
+        return mFields.iterator();
+    }
+
+    protected ArrayList getArrayList()
+    {
+        return mFields;
+    }
+}

--- a/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheFloat32.java
+++ b/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheFloat32.java
@@ -1,0 +1,156 @@
+//--------------------------------------------------------------------------
+// Copyright (c) 1999-2006 Wombat Financial Software Inc., of Incline
+// Village, NV.  All rights reserved.
+//
+// This software and documentation constitute an unpublished work and
+// contain valuable trade secrets and proprietary information belonging
+// to Wombat.  None of this material may be copied, duplicated or
+// disclosed without the express written permission of Wombat.
+//
+// WOMBAT EXPRESSLY DISCLAIMS ANY AND ALL WARRANTIES CONCERNING THIS
+// SOFTWARE AND DOCUMENTATION, INCLUDING ANY WARRANTIES OF
+// MERCHANTABILITY AND/OR FITNESS FOR ANY PARTICULAR PURPOSE, AND
+// WARRANTIES OF PERFORMANCE, AND ANY WARRANTY THAT MIGHT OTHERWISE ARISE
+// FROM COURSE OF DEALING OR USAGE OF TRADE. NO WARRANTY IS EITHER
+// EXPRESS OR IMPLIED WITH RESPECT TO THE USE OF THE SOFTWARE OR
+// DOCUMENTATION.
+//
+// Under no circumstances shall Wombat be liable for incidental, special,
+// indirect, direct or consequential damages or loss of profits,
+// interruption of business, or related expenses which may arise from use
+// of software or documentation, including but not limited to those
+// resulting from defects in software and/or documentation, or loss or
+// inaccuracy of data of any kind.
+//
+//----------------------------------------------------------------------------
+
+
+package com.wombat.mama;
+
+public class MamaFieldCacheFloat32 extends MamaFieldCacheField
+{
+    private float mValue;
+    
+    /**
+     * Constructor.  Use one of the create() methods to actually
+     * initialize the field.
+     */
+     
+    public MamaFieldCacheFloat32 (MamaFieldDescriptor desc)
+    {
+        super(desc,MamaFieldDescriptor.F32);
+        mValue = 0;
+    }
+    
+    /**
+     * Constructor.
+     */
+     
+    public MamaFieldCacheFloat32 (int fid, String name, boolean trackModState)
+    {
+        super(fid,MamaFieldDescriptor.F32,name,trackModState);
+        mValue = 0;
+    }
+
+    /*  Description :   This function will add the contents of the cache field
+     *                  to the supplied message.
+     *  Arguments   :   fieldName   [I] True to add the field name to the message.
+     *                  message     [I] The message where the field will be added.
+     */
+    public void addToMessage(boolean fieldName, MamaMsg message)
+    {
+        // Check to see if field names should be added
+        String name = null;
+        if (fieldName)
+        {
+            // Get the field name from the descriptor
+            name = mDesc.getName();
+        }
+
+        // Add the value
+        message.addF32(name, mDesc.getFid (), mValue);
+    }
+
+    public MamaFieldCacheField copy ()
+    {
+        MamaFieldCacheFloat32 result = new MamaFieldCacheFloat32 (
+            mDesc.getFid (),
+            mDesc.getName (),
+            mTrackModState);
+        result.mValue = mValue;
+        return result;
+    }
+
+    /**
+     * Apply the MamaMsgField to the cached field.
+     */
+     
+    public void apply(MamaMsgField msgField)
+    {
+        mValue = msgField.getF32 ();
+    }
+    
+    /**
+     * Explicitly set the cached value.
+     */
+    
+    public void set (float value)
+    {
+        if (mTrackModState)
+        {
+            if (mValue == value)
+            {
+                if (isModified())
+                    setModState (MamaFieldCacheField.MOD_STATE_TOUCHED);
+                return;
+            }
+            else
+            {
+                setModState (MamaFieldCacheField.MOD_STATE_MODIFIED);
+                // Drop through to assignment.               
+            }            
+        }
+        mValue = value;
+    }
+    
+    /**
+     * Check whether the field value is equal.
+     */
+     
+    public boolean isEqual (float value)
+    {     
+        return value == mValue;      
+    }
+    
+    /**
+     * Return the cached value.
+     */
+     
+    public float get ()
+    {
+        return mValue;
+    }
+    
+    /**
+     * Copy the cached value into the result.
+     */
+    
+    public void get (float result)
+    {
+        result = mValue;
+    }
+   
+    /**
+     * Return a string representation of the value
+     */
+     
+    public String getAsString ()
+    {
+        return new Float(mValue).toString();    
+    }
+
+    public void apply (MamaFieldCacheField value)
+    {
+        mValue = ((MamaFieldCacheFloat32)value).mValue;
+    }
+}

--- a/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheFloat64.java
+++ b/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheFloat64.java
@@ -1,0 +1,156 @@
+//--------------------------------------------------------------------------
+// Copyright (c) 1999-2006 Wombat Financial Software Inc., of Incline
+// Village, NV.  All rights reserved.
+//
+// This software and documentation constitute an unpublished work and
+// contain valuable trade secrets and proprietary information belonging
+// to Wombat.  None of this material may be copied, duplicated or
+// disclosed without the express written permission of Wombat.
+//
+// WOMBAT EXPRESSLY DISCLAIMS ANY AND ALL WARRANTIES CONCERNING THIS
+// SOFTWARE AND DOCUMENTATION, INCLUDING ANY WARRANTIES OF
+// MERCHANTABILITY AND/OR FITNESS FOR ANY PARTICULAR PURPOSE, AND
+// WARRANTIES OF PERFORMANCE, AND ANY WARRANTY THAT MIGHT OTHERWISE ARISE
+// FROM COURSE OF DEALING OR USAGE OF TRADE. NO WARRANTY IS EITHER
+// EXPRESS OR IMPLIED WITH RESPECT TO THE USE OF THE SOFTWARE OR
+// DOCUMENTATION.
+//
+// Under no circumstances shall Wombat be liable for incidental, special,
+// indirect, direct or consequential damages or loss of profits,
+// interruption of business, or related expenses which may arise from use
+// of software or documentation, including but not limited to those
+// resulting from defects in software and/or documentation, or loss or
+// inaccuracy of data of any kind.
+//
+//----------------------------------------------------------------------------
+
+
+package com.wombat.mama;
+
+public class MamaFieldCacheFloat64 extends MamaFieldCacheField
+{
+    private double mValue;
+    
+    /**
+     * Constructor.  Use one of the create() methods to actually
+     * initialize the field.
+     */
+     
+    public MamaFieldCacheFloat64 (MamaFieldDescriptor desc)
+    {
+        super(desc,MamaFieldDescriptor.F64);
+        mValue = 0.0;
+    }
+    
+    /**
+     * Constructor.
+     */
+     
+    public MamaFieldCacheFloat64 (int fid, String name, boolean trackModState)
+    {
+        super(fid,MamaFieldDescriptor.F64,name,trackModState);
+        mValue = 0.0;
+    }
+
+    /*  Description :   This function will add the contents of the cache field
+     *                  to the supplied message.
+     *  Arguments   :   fieldName   [I] True to add the field name to the message.
+     *                  message     [I] The message where the field will be added.
+     */
+    public void addToMessage(boolean fieldName, MamaMsg message)
+    {
+        // Check to see if field names should be added
+        String name = null;
+        if (fieldName)
+        {
+            // Get the field name from the descriptor
+            name = mDesc.getName();
+        }
+
+        // Add the value
+        message.addF64(name, mDesc.getFid (), mValue);
+    }
+
+    public MamaFieldCacheField copy ()
+    {
+        MamaFieldCacheFloat64 result = new MamaFieldCacheFloat64 (
+            mDesc.getFid (),
+            mDesc.getName (),
+            mTrackModState);
+        result.mValue = mValue;
+        return result;
+    }
+
+    /**
+     * Apply the MamaMsgField to the cached field.
+     */
+     
+    public void apply(MamaMsgField msgField)
+    {
+        mValue = msgField.getF64 ();
+    }
+    
+    /**
+     * Explicitly set the cached value.
+     */
+    
+    public void set (double value)
+    {
+        if (mTrackModState)
+        {
+            if (mValue == value)
+            {
+                if (isModified())
+                    setModState (MamaFieldCacheField.MOD_STATE_TOUCHED);
+                return;
+            }
+            else
+            {
+                setModState (MamaFieldCacheField.MOD_STATE_MODIFIED);
+                // Drop through to assignment.               
+            }            
+        }
+        mValue = value;
+    }
+    
+    /**
+     * Check whether the field value is equal.
+     */
+     
+    public boolean isEqual (double value)
+    {     
+        return value == mValue;      
+    }
+    
+    /**
+     * Return the cached value.
+     */
+     
+    public double get ()
+    {
+        return mValue;
+    }
+    
+    /**
+     * Copy the cached value into the result.
+     */
+    
+    public void get (double result)
+    {
+        result = mValue;
+    }
+   
+    /**
+     * Return a string representation of the value
+     */
+     
+    public String getAsString ()
+    {
+        return new Double(mValue).toString();    
+    }
+
+    public void apply (MamaFieldCacheField value)
+    {
+        mValue = ((MamaFieldCacheFloat64)value).mValue;
+    }
+}

--- a/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheInt16.java
+++ b/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheInt16.java
@@ -1,0 +1,156 @@
+//--------------------------------------------------------------------------
+// Copyright (c) 1999-2006 Wombat Financial Software Inc., of Incline
+// Village, NV.  All rights reserved.
+//
+// This software and documentation constitute an unpublished work and
+// contain valuable trade secrets and proprietary information belonging
+// to Wombat.  None of this material may be copied, duplicated or
+// disclosed without the express written permission of Wombat.
+//
+// WOMBAT EXPRESSLY DISCLAIMS ANY AND ALL WARRANTIES CONCERNING THIS
+// SOFTWARE AND DOCUMENTATION, INCLUDING ANY WARRANTIES OF
+// MERCHANTABILITY AND/OR FITNESS FOR ANY PARTICULAR PURPOSE, AND
+// WARRANTIES OF PERFORMANCE, AND ANY WARRANTY THAT MIGHT OTHERWISE ARISE
+// FROM COURSE OF DEALING OR USAGE OF TRADE. NO WARRANTY IS EITHER
+// EXPRESS OR IMPLIED WITH RESPECT TO THE USE OF THE SOFTWARE OR
+// DOCUMENTATION.
+//
+// Under no circumstances shall Wombat be liable for incidental, special,
+// indirect, direct or consequential damages or loss of profits,
+// interruption of business, or related expenses which may arise from use
+// of software or documentation, including but not limited to those
+// resulting from defects in software and/or documentation, or loss or
+// inaccuracy of data of any kind.
+//
+//----------------------------------------------------------------------------
+
+
+package com.wombat.mama;
+
+public class MamaFieldCacheInt16 extends MamaFieldCacheField
+{
+    private short mValue;
+    
+    /**
+     * Constructor.  Use one of the create() methods to actually
+     * initialize the field.
+     */
+     
+    public MamaFieldCacheInt16 (MamaFieldDescriptor desc)
+    {
+        super(desc,MamaFieldDescriptor.I16);
+        mValue = 0;
+    }
+    
+    /**
+     * Constructor.
+     */
+     
+    public MamaFieldCacheInt16 (int fid, String name, boolean trackModState)
+    {
+        super(fid,MamaFieldDescriptor.I16,name,trackModState);
+        mValue = 0;
+    }
+
+    /*  Description :   This function will add the contents of the cache field
+     *                  to the supplied message.
+     *  Arguments   :   fieldName   [I] True to add the field name to the message.
+     *                  message     [I] The message where the field will be added.
+     */
+    public void addToMessage(boolean fieldName, MamaMsg message)
+    {
+        // Check to see if field names should be added
+        String name = null;
+        if (fieldName)
+        {
+            // Get the field name from the descriptor
+            name = mDesc.getName();
+        }
+
+        // Add the value
+        message.addI16(name, mDesc.getFid (), mValue);
+    }
+
+    public MamaFieldCacheField copy ()
+    {
+        MamaFieldCacheInt16 result = new MamaFieldCacheInt16 (
+            mDesc.getFid (),
+            mDesc.getName (),
+            mTrackModState);
+        result.mValue = mValue;
+        return result;
+    }
+
+    /**
+     * Apply the MamaMsgField to the cached field.
+     */
+     
+    public void apply(MamaMsgField msgField)
+    {
+        mValue = msgField.getI16 ();
+    }
+    
+    /**
+     * Explicitly set the cached value.
+     */
+    
+    public void set (short value)
+    {
+        if (mTrackModState)
+        {
+            if (mValue == value)
+            {
+                if (isModified())
+                    setModState (MamaFieldCacheField.MOD_STATE_TOUCHED);
+                return;
+            }
+            else
+            {
+                setModState (MamaFieldCacheField.MOD_STATE_MODIFIED);
+                // Drop through to assignment.               
+            }            
+        }
+        mValue = value;
+    }
+    
+    /**
+     * Check whether the field value is equal.
+     */
+     
+    public boolean isEqual (short value)
+    {     
+        return value == mValue;      
+    }
+    
+    /**
+     * Return the cached value.
+     */
+     
+    public short get ()
+    {
+        return mValue;
+    }
+    
+    /**
+     * Copy the cached value into the result.
+     */
+    
+    public void get (short result)
+    {
+        result = mValue;
+    }
+   
+    /**
+     * Return a string representation of the value
+     */
+     
+    public String getAsString ()
+    {
+        return new Short(mValue).toString();    
+    }
+
+    public void apply (MamaFieldCacheField value)
+    {
+        mValue = ((MamaFieldCacheInt16)value).mValue;
+    }
+}

--- a/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheInt32.java
+++ b/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheInt32.java
@@ -1,0 +1,156 @@
+//--------------------------------------------------------------------------
+// Copyright (c) 1999-2006 Wombat Financial Software Inc., of Incline
+// Village, NV.  All rights reserved.
+//
+// This software and documentation constitute an unpublished work and
+// contain valuable trade secrets and proprietary information belonging
+// to Wombat.  None of this material may be copied, duplicated or
+// disclosed without the express written permission of Wombat.
+//
+// WOMBAT EXPRESSLY DISCLAIMS ANY AND ALL WARRANTIES CONCERNING THIS
+// SOFTWARE AND DOCUMENTATION, INCLUDING ANY WARRANTIES OF
+// MERCHANTABILITY AND/OR FITNESS FOR ANY PARTICULAR PURPOSE, AND
+// WARRANTIES OF PERFORMANCE, AND ANY WARRANTY THAT MIGHT OTHERWISE ARISE
+// FROM COURSE OF DEALING OR USAGE OF TRADE. NO WARRANTY IS EITHER
+// EXPRESS OR IMPLIED WITH RESPECT TO THE USE OF THE SOFTWARE OR
+// DOCUMENTATION.
+//
+// Under no circumstances shall Wombat be liable for incidental, special,
+// indirect, direct or consequential damages or loss of profits,
+// interruption of business, or related expenses which may arise from use
+// of software or documentation, including but not limited to those
+// resulting from defects in software and/or documentation, or loss or
+// inaccuracy of data of any kind.
+//
+//----------------------------------------------------------------------------
+
+
+package com.wombat.mama;
+
+public class MamaFieldCacheInt32 extends MamaFieldCacheField
+{
+    private int mValue;
+    
+    /**
+     * Constructor.  Use one of the create() methods to actually
+     * initialize the field.
+     */
+     
+    public MamaFieldCacheInt32 (MamaFieldDescriptor desc)
+    {
+        super(desc,MamaFieldDescriptor.I32);
+        mValue = 0;
+    }
+    
+    /**
+     * Constructor.
+     */
+     
+    public MamaFieldCacheInt32 (int fid, String name, boolean trackModState)
+    {
+        super(fid,MamaFieldDescriptor.I32,name,trackModState);
+        mValue = 0;
+    }
+
+    /*  Description :   This function will add the contents of the cache field
+     *                  to the supplied message.
+     *  Arguments   :   fieldName   [I] True to add the field name to the message.
+     *                  message     [I] The message where the field will be added.
+     */
+    public void addToMessage(boolean fieldName, MamaMsg message)
+    {
+        // Check to see if field names should be added
+        String name = null;
+        if (fieldName)
+        {
+            // Get the field name from the descriptor
+            name = mDesc.getName();
+        }
+
+        // Add the value
+        message.addI32(name, mDesc.getFid (), mValue);
+    }
+
+    public MamaFieldCacheField copy ()
+    {
+        MamaFieldCacheInt32 result = new MamaFieldCacheInt32 (
+            mDesc.getFid (),
+            mDesc.getName (),
+            mTrackModState);
+        result.mValue = mValue;
+        return result;
+    }
+
+    /**
+     * Apply the MamaMsgField to the cached field.
+     */
+     
+    public void apply(MamaMsgField msgField)
+    {
+        mValue = msgField.getI32 ();
+    }
+    
+    /**
+     * Explicitly set the cached value.
+     */
+    
+    public void set (int value)
+    {
+        if (mTrackModState)
+        {
+            if (mValue == value)
+            {
+                if (isModified())
+                    setModState (MamaFieldCacheField.MOD_STATE_TOUCHED);
+                return;
+            }
+            else
+            {
+                setModState (MamaFieldCacheField.MOD_STATE_MODIFIED);
+                // Drop through to assignment.               
+            }            
+        }
+        mValue = value;
+    }
+    
+    /**
+     * Check whether the field value is equal.
+     */
+     
+    public boolean isEqual (int value)
+    {     
+        return value == mValue;      
+    }
+    
+    /**
+     * Return the cached value.
+     */
+     
+    public int get ()
+    {
+        return mValue;
+    }
+    
+    /**
+     * Copy the cached value into the result.
+     */
+    
+    public void get (int result)
+    {
+        result = mValue;
+    }
+   
+    /**
+     * Return a string representation of the value
+     */
+     
+    public String getAsString ()
+    {
+        return new Integer(mValue).toString();    
+    }
+
+    public void apply (MamaFieldCacheField value)
+    {
+        mValue = ((MamaFieldCacheInt32)value).mValue;
+    }
+}

--- a/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheInt64.java
+++ b/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheInt64.java
@@ -1,0 +1,156 @@
+//--------------------------------------------------------------------------
+// Copyright (c) 1999-2006 Wombat Financial Software Inc., of Incline
+// Village, NV.  All rights reserved.
+//
+// This software and documentation constitute an unpublished work and
+// contain valuable trade secrets and proprietary information belonging
+// to Wombat.  None of this material may be copied, duplicated or
+// disclosed without the express written permission of Wombat.
+//
+// WOMBAT EXPRESSLY DISCLAIMS ANY AND ALL WARRANTIES CONCERNING THIS
+// SOFTWARE AND DOCUMENTATION, INCLUDING ANY WARRANTIES OF
+// MERCHANTABILITY AND/OR FITNESS FOR ANY PARTICULAR PURPOSE, AND
+// WARRANTIES OF PERFORMANCE, AND ANY WARRANTY THAT MIGHT OTHERWISE ARISE
+// FROM COURSE OF DEALING OR USAGE OF TRADE. NO WARRANTY IS EITHER
+// EXPRESS OR IMPLIED WITH RESPECT TO THE USE OF THE SOFTWARE OR
+// DOCUMENTATION.
+//
+// Under no circumstances shall Wombat be liable for incidental, special,
+// indirect, direct or consequential damages or loss of profits,
+// interruption of business, or related expenses which may arise from use
+// of software or documentation, including but not limited to those
+// resulting from defects in software and/or documentation, or loss or
+// inaccuracy of data of any kind.
+//
+//----------------------------------------------------------------------------
+
+
+package com.wombat.mama;
+
+public class MamaFieldCacheInt64 extends MamaFieldCacheField
+{
+    private long mValue;
+    
+    /**
+     * Constructor.  Use one of the create() methods to actually
+     * initialize the field.
+     */
+     
+    public MamaFieldCacheInt64 (MamaFieldDescriptor desc)
+    {
+        super(desc,MamaFieldDescriptor.I64);
+        mValue = 0;
+    }
+    
+    /**
+     * Constructor.
+     */
+     
+    public MamaFieldCacheInt64 (int fid, String name, boolean trackModState)
+    {
+        super(fid,MamaFieldDescriptor.I64,name,trackModState);
+        mValue = 0;
+    }
+
+    public MamaFieldCacheField copy ()
+    {
+        MamaFieldCacheInt64 result = new MamaFieldCacheInt64 (
+            mDesc.getFid (),
+            mDesc.getName (),
+            mTrackModState);
+        result.mValue = mValue;
+        return result;
+    }
+
+    /*  Description :   This function will add the contents of the cache field
+     *                  to the supplied message.
+     *  Arguments   :   fieldName   [I] True to add the field name to the message.
+     *                  message     [I] The message where the field will be added.
+     */
+    public void addToMessage(boolean fieldName, MamaMsg message)
+    {
+        // Check to see if field names should be added
+        String name = null;
+        if (fieldName)
+        {
+            // Get the field name from the descriptor
+            name = mDesc.getName();
+        }
+
+        // Add the value
+        message.addI64(name, mDesc.getFid (), mValue);
+    }
+
+    /**
+     * Apply the MamaMsgField to the cached field.
+     */
+     
+    public void apply(MamaMsgField msgField)
+    {
+        mValue = msgField.getI64 ();
+    }
+    
+    /**
+     * Explicitly set the cached value.
+     */
+    
+    public void set (long value)
+    {
+        if (mTrackModState)
+        {
+            if (mValue == value)
+            {
+                if (isModified())
+                    setModState (MamaFieldCacheField.MOD_STATE_TOUCHED);
+                return;
+            }
+            else
+            {
+                setModState (MamaFieldCacheField.MOD_STATE_MODIFIED);
+                // Drop through to assignment.               
+            }            
+        }
+        mValue = value;
+    }
+    
+    /**
+     * Check whether the field value is equal.
+     */
+     
+    public boolean isEqual (long value)
+    {     
+        return value == mValue;      
+    }
+    
+    /**
+     * Return the cached value.
+     */
+     
+    public long get ()
+    {
+        return mValue;
+    }
+    
+    /**
+     * Copy the cached value into the result.
+     */
+    
+    public void get (long result)
+    {
+        result = mValue;
+    }
+   
+    /**
+     * Return a string representation of the value
+     */
+     
+    public String getAsString ()
+    {
+        return new Long(mValue).toString();    
+    }
+
+    public void apply (MamaFieldCacheField value)
+    {
+        mValue = ((MamaFieldCacheInt64)value).mValue;
+    }
+}

--- a/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheInt8.java
+++ b/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheInt8.java
@@ -1,0 +1,155 @@
+//--------------------------------------------------------------------------
+// Copyright (c) 1999-2006 Wombat Financial Software Inc., of Incline
+// Village, NV.  All rights reserved.
+//
+// This software and documentation constitute an unpublished work and
+// contain valuable trade secrets and proprietary information belonging
+// to Wombat.  None of this material may be copied, duplicated or
+// disclosed without the express written permission of Wombat.
+//
+// WOMBAT EXPRESSLY DISCLAIMS ANY AND ALL WARRANTIES CONCERNING THIS
+// SOFTWARE AND DOCUMENTATION, INCLUDING ANY WARRANTIES OF
+// MERCHANTABILITY AND/OR FITNESS FOR ANY PARTICULAR PURPOSE, AND
+// WARRANTIES OF PERFORMANCE, AND ANY WARRANTY THAT MIGHT OTHERWISE ARISE
+// FROM COURSE OF DEALING OR USAGE OF TRADE. NO WARRANTY IS EITHER
+// EXPRESS OR IMPLIED WITH RESPECT TO THE USE OF THE SOFTWARE OR
+// DOCUMENTATION.
+//
+// Under no circumstances shall Wombat be liable for incidental, special,
+// indirect, direct or consequential damages or loss of profits,
+// interruption of business, or related expenses which may arise from use
+// of software or documentation, including but not limited to those
+// resulting from defects in software and/or documentation, or loss or
+// inaccuracy of data of any kind.
+//
+//----------------------------------------------------------------------------
+
+package com.wombat.mama;
+
+public class MamaFieldCacheInt8 extends MamaFieldCacheField
+{
+    private byte mValue;
+    
+    /**
+     * Constructor.  Use one of the create() methods to actually
+     * initialize the field.
+     */
+     
+    public MamaFieldCacheInt8 (MamaFieldDescriptor desc)
+    {
+        super(desc,MamaFieldDescriptor.I8);
+        mValue = 0;
+    }
+    
+    /**
+     * Constructor.
+     */
+     
+    public MamaFieldCacheInt8 (int fid, String name, boolean trackModState)
+    {
+        super(fid,MamaFieldDescriptor.I8,name,trackModState);       
+        mValue = 0;
+    }
+
+    /*  Description :   This function will add the contents of the cache field
+     *                  to the supplied message.
+     *  Arguments   :   fieldName   [I] True to add the field name to the message.
+     *                  message     [I] The message where the field will be added.
+     */
+    public void addToMessage(boolean fieldName, MamaMsg message)
+    {
+        // Check to see if field names should be added
+        String name = null;
+        if (fieldName)
+        {
+            // Get the field name from the descriptor
+            name = mDesc.getName();
+        }
+
+        // Add the value
+        message.addI8(name, mDesc.getFid (), mValue);
+    }
+
+    public MamaFieldCacheField copy ()
+    {
+        MamaFieldCacheInt8 result = new MamaFieldCacheInt8 (
+            mDesc.getFid (),
+            mDesc.getName (),
+            mTrackModState);
+        result.mValue = mValue;
+        return result;
+    }
+
+    /**
+     * Apply the MamaMsgField to the cached field.
+     */
+     
+    public void apply(MamaMsgField msgField)
+    {
+        mValue = msgField.getI8 ();
+    }
+    
+    /**
+     * Explicitly set the cached value.
+     */
+    
+    public void set (byte value)
+    {
+        if (mTrackModState)
+        {
+            if (mValue == value)
+            {
+                if (isModified())
+                    setModState (MamaFieldCacheField.MOD_STATE_TOUCHED);
+                return;
+            }
+            else
+            {
+                setModState (MamaFieldCacheField.MOD_STATE_MODIFIED);
+                // Drop through to assignment.               
+            }            
+        }
+        mValue = value;
+    }
+    
+    /**
+     * Check whether the field value is equal.
+     */
+     
+    public boolean isEqual (byte value)
+    {     
+        return value == mValue;      
+    }
+    
+    /**
+     * Return the cached value.
+     */
+     
+    public byte get ()
+    {
+        return mValue;
+    }
+    
+    /**
+     * Copy the cached value into the result.
+     */
+    
+    public void get (byte result)
+    {
+        result = mValue;
+    }
+   
+    /**
+     * Return a string representation of the value
+     */
+     
+    public String getAsString ()
+    {
+        return new Byte(mValue).toString();    
+    }
+
+    public void apply (MamaFieldCacheField value)
+    {
+        mValue = ((MamaFieldCacheInt8)value).mValue;
+    }
+}

--- a/mama/jni/src/main/java/com/wombat/mama/MamaFieldCachePrice.java
+++ b/mama/jni/src/main/java/com/wombat/mama/MamaFieldCachePrice.java
@@ -1,0 +1,183 @@
+//--------------------------------------------------------------------------
+// Copyright (c) 1999-2006 Wombat Financial Software Inc., of Incline
+// Village, NV.  All rights reserved.
+//
+// This software and documentation constitute an unpublished work and
+// contain valuable trade secrets and proprietary information belonging
+// to Wombat.  None of this material may be copied, duplicated or
+// disclosed without the express written permission of Wombat.
+//
+// WOMBAT EXPRESSLY DISCLAIMS ANY AND ALL WARRANTIES CONCERNING THIS
+// SOFTWARE AND DOCUMENTATION, INCLUDING ANY WARRANTIES OF
+// MERCHANTABILITY AND/OR FITNESS FOR ANY PARTICULAR PURPOSE, AND
+// WARRANTIES OF PERFORMANCE, AND ANY WARRANTY THAT MIGHT OTHERWISE ARISE
+// FROM COURSE OF DEALING OR USAGE OF TRADE. NO WARRANTY IS EITHER
+// EXPRESS OR IMPLIED WITH RESPECT TO THE USE OF THE SOFTWARE OR
+// DOCUMENTATION.
+//
+// Under no circumstances shall Wombat be liable for incidental, special,
+// indirect, direct or consequential damages or loss of profits,
+// interruption of business, or related expenses which may arise from use
+// of software or documentation, including but not limited to those
+// resulting from defects in software and/or documentation, or loss or
+// inaccuracy of data of any kind.
+//
+//----------------------------------------------------------------------------
+
+
+package com.wombat.mama;
+
+public class MamaFieldCachePrice extends MamaFieldCacheField
+{
+    private MamaPrice mValue;
+
+    /**
+     * Constructor.  Use one of the create() methods to actually
+     * initialize the field.
+     */
+
+    public MamaFieldCachePrice (MamaFieldDescriptor desc)
+    {
+        super (desc,MamaFieldDescriptor.PRICE);
+        mValue = null;
+    }
+
+    /**
+     * Constructor.
+     */
+
+    public MamaFieldCachePrice (int fid, String name, boolean trackModState)
+    {
+        super (fid,MamaFieldDescriptor.PRICE,name,trackModState);
+        mValue = null;
+    }
+
+    public MamaFieldCacheField copy ()
+    {
+        MamaFieldCachePrice result = new MamaFieldCachePrice (
+            mDesc.getFid (),
+            mDesc.getName (),
+            mTrackModState);
+        result.mValue = new MamaPrice (mValue);
+        return result;
+    }
+
+    /*  Description :   This function will add the contents of the cache field
+     *                  to the supplied message.
+     *  Arguments   :   fieldName   [I] True to add the field name to the message.
+     *                  message     [I] The message where the field will be added.
+     */
+    public void addToMessage(boolean fieldName, MamaMsg message)
+    {
+        // Check to see if field names should be added
+        String name = null;
+        if (fieldName)
+        {
+            // Get the field name from the descriptor
+            name = mDesc.getName();
+        }
+
+        // Add the value
+        message.addPrice(name, mDesc.getFid (), mValue);
+    }
+
+    /**
+     * Apply the MamaMsgField to the cached field.
+     */
+
+    public void apply(MamaMsgField msgField)
+    {
+        mValue = msgField.getPrice ();
+    }
+
+    /**
+     * Explicitly set the cached value.
+     */
+
+    public void set (MamaPrice value)
+    {
+        if (mTrackModState)
+        {
+            if (mValue == value)
+            {
+                if (!isModified())
+                     setModState (MamaFieldCacheField.MOD_STATE_TOUCHED);
+                return;
+            }
+            else
+            {
+                setModState (MamaFieldCacheField.MOD_STATE_MODIFIED);
+                // Drop through to assignment.
+            }
+        }
+        if (value == null)
+            mValue = null;
+        else
+        {
+            if (mValue == null)
+                mValue = new MamaPrice (value);
+            else
+                mValue.copy(value);
+        }
+    }
+
+    /**
+     * Check whether the field value is equal.
+     */
+
+    public boolean isEqual (MamaPrice value)
+    {
+        if (mValue == null)
+        {
+            return (value == null);
+        }
+        else
+        {
+            return  mValue.equals(value);
+        }
+    }
+
+    /**
+     * Return the cached value.
+     */
+
+    public MamaPrice get ()
+    {
+        return (mValue != null) ? mValue : null;
+    }
+
+    /**
+     * Copy the cached value into the result.
+     */
+
+    public void get (MamaPrice result)
+    {
+        result = mValue;
+    }
+
+    /**
+     * Return a string representation of the value
+     */
+
+    public String getAsString ()
+    {
+        return (mValue != null) ? mValue.toString() : "null";
+    }
+
+    public void apply (MamaFieldCacheField value)
+    {
+        if (value == null)
+            throw new MamaException("MamaFieldCachePrice.apply() cannot be called with a null value");
+
+        if (((MamaFieldCachePrice)value).get() == null)
+        {
+            mValue = null;
+            return;
+        }
+
+        if (mValue == null)
+            mValue = new MamaPrice(((MamaFieldCachePrice)value).mValue);
+        else
+            mValue. copy (((MamaFieldCachePrice)value).mValue);
+    }
+}

--- a/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheProperties.java
+++ b/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheProperties.java
@@ -1,0 +1,477 @@
+//----------------------------------------------------------------------------
+//
+// $Id$
+//
+// Copyright (c) 1999-2006 Wombat Financial Software Inc., of Incline
+// Village, NV.  All rights reserved.
+//
+// This software and documentation constitute an unpublished work and
+// contain valuable trade secrets and proprietary information belonging
+// to Wombat.  None of this material may be copied, duplicated or
+// disclosed without the express written permission of Wombat.
+//
+// WOMBAT EXPRESSLY DISCLAIMS ANY AND ALL WARRANTIES CONCERNING THIS
+// SOFTWARE AND DOCUMENTATION, INCLUDING ANY WARRANTIES OF
+// MERCHANTABILITY AND/OR FITNESS FOR ANY PARTICULAR PURPOSE, AND
+// WARRANTIES OF PERFORMANCE, AND ANY WARRANTY THAT MIGHT OTHERWISE ARISE
+// FROM COURSE OF DEALING OR USAGE OF TRADE. NO WARRANTY IS EITHER
+// EXPRESS OR IMPLIED WITH RESPECT TO THE USE OF THE SOFTWARE OR
+// DOCUMENTATION.
+//
+// Under no circumstances shall Wombat be liable for incidental, special,
+// indirect, direct or consequential damages or loss of profits,
+// interruption of business, or related expenses which may arise from use
+// of software or documentation, including but not limited to those
+// resulting from defects in software and/or documentation, or loss or
+// inaccuracy of data of any kind.
+//
+//----------------------------------------------------------------------------
+package com.wombat.mama;
+
+import java.util.Iterator;
+import java.util.HashMap;
+import java.util.NoSuchElementException;
+import java.util.logging.Logger;
+import java.util.logging.Level;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+
+/**
+ * The MamaFieldCacheProperties class is used for MamdaOrderBookProperties.
+ *
+ * This class maintains a collection of MamaFieldCacheField objects mapped to
+ * fids. A field will only be added to or updated in the cache if its fid
+ * matches a fid previously registed with the <code>registerField</code> method.
+ *
+ */
+public class MamaFieldCacheProperties
+{
+    private static Logger mLogger =
+                   Logger.getLogger("com.wombat.mama.MamaFieldCacheProperties");
+
+    private HashMap mFields;
+    // The serial number avoids iterating on clear!
+    private long    mSerial = 1;
+    // For efficient lookups.
+    private MamaInteger mTmpInt = new MamaInteger ();
+
+
+    public MamaFieldCacheProperties (int hashSize)
+    {
+        mFields = new HashMap (hashSize);
+    }
+
+    public MamaFieldCacheProperties ()
+    {
+        mFields = new HashMap(10);
+    }
+
+    public MamaFieldCacheProperties (MamaFieldCacheProperties source)
+    {
+        mSerial = source.mSerial;
+        for (Iterator i = mFields.keySet ().iterator (); i.hasNext ();)
+        {
+            MamaInteger key =  (MamaInteger) i.next ();
+            Entry e = new Entry ((Entry)mFields.get (key) );
+            mFields.put (key, e);
+        }
+    }
+
+    /**
+     * This method clears the fields but does not unregister the properteis.
+     */
+    public void clear()
+    {
+        mSerial += 2; // Will never be 0
+    }
+
+    public void clearAndDelete ()
+    {
+        clear ();
+    }
+
+    /**
+     * Add a field to the cache. If it is not already a property it will be
+     * added with its fid.
+     *
+     * @param field The field to add.
+     */
+    public void add (MamaFieldCacheField field)
+    {
+        if (field!=null)
+        {
+            MamaFieldDescriptor desc = field.getDescriptor();
+            if (desc!=null)
+            {
+                mFields.put (new MamaInteger(desc.getFid ()),
+                              new Entry (field, mSerial) );
+            }
+        }
+    }
+
+    /**
+     * Add a field to the cache. If it is not already a property it will be
+     * added with its fid. The field only gets added if the supplied field
+     * is modified.
+     *
+     * @param field The field to add.
+     */
+    public void addIfModified (MamaFieldCacheField field)
+    {
+        if (field!=null && field.isModified ())
+        {
+            MamaFieldDescriptor desc = field.getDescriptor();
+            if (desc!=null)
+            {
+                mFields.put (new MamaInteger(desc.getFid ()),
+                              new Entry (field, mSerial));
+            }
+        }
+    }
+
+    /*public void clearAndDelete()
+    {
+        mSerial += 2; // Will never be 0
+    } */
+
+    /**
+     * Clear the cache and unregister all the properties.
+     *
+     */
+    public void clearAndUnregisterAll ()
+    {
+        mSerial = 1;
+        mFields.clear ();
+    }
+
+    /**
+     * Adds a property. The MamaFieldCacheField will not appear in iterations
+     * until an <code>apply()</code> for that field occurs.
+     *
+     * @param fid The fid
+     * @param field The field.
+     */
+    public void registerProperty(int fid, MamaFieldCacheField  field)
+    {
+        mTmpInt.setValue (fid);
+        if (mFields.get (mTmpInt) != null)
+        {
+            return; // Already registered.
+        }
+
+        if (field!=null)
+        {
+            MamaFieldDescriptor desc = field.getDescriptor();
+            if (desc!=null)
+            {
+                Entry e = new Entry (field);
+                mFields.put(new MamaInteger(fid), e);
+            }
+        }
+    }
+
+    /**
+     * Apply the field to the cache. If the field does not exist as a property
+     * the cache does not change.
+     * @param value The new value
+     * @return true if a the field was found and updated.
+     */
+    public boolean apply (MamaMsgField value)
+    {
+        mTmpInt.setValue (value.getFid ());
+        Entry entry = (Entry) mFields.get (mTmpInt);
+        if (entry != null)
+        {
+            entry.mSerial = mSerial;
+            entry.mField.apply (value);
+            return true;
+        }
+        return false;
+    }
+
+    private boolean apply (MamaFieldCacheField value)
+    {
+        MamaFieldDescriptor desc = value.getDescriptor ();
+        mTmpInt.setValue (desc.getFid ());
+        Entry entry = (Entry) mFields.get (mTmpInt);
+        if (entry != null)
+        {
+            entry.mSerial = mSerial;
+            entry.mField.apply (value);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Find a field by name. This is less efficient than find by Fid or field
+     * descriptor.
+     *
+     * @param name The field name.
+     * @return The field or null.
+     */
+    public MamaFieldCacheField find(String name)
+    {
+        // MLS: This is not very efficient. We could use another map (name->field),
+        // if this causes problems. It is no less efficient than the
+        // MamaFieldCacheFieldList method.
+        if (name!=null)
+        {
+            for (Iterator i = mFields.values ().iterator ();
+                 i.hasNext ();)
+            {
+                Entry e = (Entry) i.next ();
+                if (e.mField.getDescriptor ().getName ().equals (name) &&
+                    e.mSerial == mSerial)
+                {
+                    return e.mField;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Find a field by fid.
+     * @param fid The fid
+     * @return  the field or null.
+     */
+    public MamaFieldCacheField find(int fid)
+    {
+        mTmpInt.setValue (fid);
+        Entry e = (Entry) mFields.get (mTmpInt);
+        if (e != null && e.mSerial == mSerial)
+            return e.mField;
+        return null;
+    }
+
+    /**
+     * Find by field descriptor. This method uses the fid from the descriptor.
+     * @param desc The descriptor.
+     * @return the field or null.
+     */
+    public MamaFieldCacheField find(MamaFieldDescriptor desc)
+    {
+        if (desc != null)
+            return find (desc.getFid ());
+        return null;
+    }
+
+    /**
+     * Return the number of properties in the cache.
+     * @return the size.
+     */
+    public int size()
+    {
+        return mFields.size();
+    }
+
+    /**
+     * Return true if the cache is empty.
+     *
+     * @return true if the cache contains no properties.
+     */
+    public boolean empty()
+    {
+        return mFields.isEmpty();
+    }
+
+    /**
+     * Returns an iterator that only iterates over the properties that have
+     * had values applied.
+     * @return the iterator.
+     */
+    public Iterator getIterator()
+    {
+        return new Iterator()
+        {
+            Iterator mIterator = mFields.values ().iterator ();
+            Entry    mNextEntry = null;
+
+            public void remove ()
+            {
+                mIterator.remove ();
+            }
+
+            public boolean hasNext ()
+            {
+                while (mIterator.hasNext ())
+                {
+                    // Look for a property that is applied.
+                    mNextEntry = (Entry) mIterator.next ();
+                    if (mNextEntry.mSerial == mSerial)
+                        return true;
+                }
+                return false;
+            }
+
+            public Object next ()
+            {
+                if (mNextEntry != null || hasNext ())
+                {
+                    Entry rval = mNextEntry;
+                    mNextEntry = null;
+                    return rval.mField;
+                }
+                throw new NoSuchElementException ();
+            }
+        };
+    }
+
+    public void registerProperties (int[] fids,
+                                    MamaDictionary theDictionary)
+    {
+        for (int i = 0; i < fids.length; i++)
+        {
+            int fid = fids[i];
+            MamaFieldDescriptor field = theDictionary.getFieldByFid (fid);
+
+            if (field == null && mLogger.isLoggable (Level.FINE))
+                mLogger.fine ("Property field not in dictionary fid=" + fid);
+
+            if (field != null)
+            {
+                switch(field.getType ())
+                {
+                    case MamaFieldDescriptor.MSG:
+                        mLogger.fine ("Property type MSG not supported.");
+                        break;
+                    case MamaFieldDescriptor.OPAQUE:
+                        mLogger.fine ("Property type OPAQUE not supported.");
+                        break;
+                    case MamaFieldDescriptor.STRING:
+                        registerProperty(fid, new MamaFieldCacheString (field));
+                        break;
+                    case MamaFieldDescriptor.BOOL:
+                        registerProperty (fid, new MamaFieldCacheBool (field));
+                        break;
+                    case MamaFieldDescriptor.CHAR:
+                        registerProperty (fid, new MamaFieldCacheChar (field));
+                        break;
+                    case MamaFieldDescriptor.I8:
+                        registerProperty (fid, new MamaFieldCacheInt8 (field));
+                        break;
+                    case MamaFieldDescriptor.U8:
+                        registerProperty (fid, new MamaFieldCacheUint8 (field));
+                        break;
+                    case MamaFieldDescriptor.I16:
+                        registerProperty (fid, new MamaFieldCacheInt16 (field));
+                        break;
+                    case MamaFieldDescriptor.U16:
+                        registerProperty(fid, new MamaFieldCacheUint16 (field));
+                        break;
+                    case MamaFieldDescriptor.I32:
+                        registerProperty (fid, new MamaFieldCacheInt32 (field));
+                        break;
+                    case MamaFieldDescriptor.U32:
+                        registerProperty(fid, new MamaFieldCacheUint32 (field));
+                        break;
+                    case MamaFieldDescriptor.I64:
+                        registerProperty (fid, new MamaFieldCacheInt64 (field));
+                        break;
+                    case MamaFieldDescriptor.U64:
+                        registerProperty(fid, new MamaFieldCacheUint64 (field));
+                        break;
+                    case MamaFieldDescriptor.F32:
+                        registerProperty(fid, new MamaFieldCacheFloat32(field));
+                        break;
+                    case MamaFieldDescriptor.F64:
+                        registerProperty(fid, new MamaFieldCacheFloat64(field));
+                        break;
+                    case MamaFieldDescriptor.TIME:
+                        registerProperty(fid,new MamaFieldCacheDateTime(field));
+                        break;
+                    case MamaFieldDescriptor.PRICE:
+                        registerProperty (fid, new MamaFieldCachePrice (field));
+                        break;
+
+                    case MamaFieldDescriptor.I8ARRAY:
+                    case MamaFieldDescriptor.U8ARRAY:
+                    case MamaFieldDescriptor.I16ARRAY:
+                    case MamaFieldDescriptor.U16ARRAY:
+                    case MamaFieldDescriptor.I32ARRAY:
+                    case MamaFieldDescriptor.U32ARRAY:
+                    case MamaFieldDescriptor.I64ARRAY:
+                    case MamaFieldDescriptor.U64ARRAY:
+                    case MamaFieldDescriptor.F32ARRAY:
+                    case MamaFieldDescriptor.F64ARRAY:
+                    case MamaFieldDescriptor.VECTOR_STRING:
+                    case MamaFieldDescriptor.VECTOR_MSG:
+                    case MamaFieldDescriptor.VECTOR_TIME:
+                    case MamaFieldDescriptor.VECTOR_PRICE:
+                    case MamaFieldDescriptor.COLLECTION:
+                    case MamaFieldDescriptor.UNKNOWN:
+                        mLogger.fine ("Property type " + field.getType () +
+                                       " not supported.");
+                        break;
+                }
+
+            }
+        }
+    }
+
+    /**
+     * Apply all the fields in the supplied list for which there are properties.
+     * @param fields The fields to apply.
+     */
+    public void apply (MamaFieldCacheFieldList fields)
+    {
+        for (Iterator i = fields.getIterator (); i.hasNext ();)
+        {
+            MamaFieldCacheField field = (MamaFieldCacheField) i.next ();
+            apply (field);
+        }
+    }
+
+     /**
+     * Dump the order book to standard out.
+     */
+    public void dump()
+    {
+        dump (System.out);
+    }
+
+    /**
+     * Dump the properties to an <code>OutputStream</code>.
+     * @param outputStream the <code>OutputStream</code>
+     */
+    public void dump (OutputStream outputStream)
+    {
+        PrintWriter out = new PrintWriter (outputStream, true);
+        out.println ("Properties:");
+        for (Iterator i = getIterator (); i.hasNext ();)
+        {
+            MamaFieldCacheField field = (MamaFieldCacheField) i.next ();
+            out.print("\t");
+            out.println (field.getDescriptor ().getName () + "=" +
+                         field.getAsString ());            
+        }
+    }
+
+    /**
+     * So we know if a field has been added.
+     *
+     */
+    private class Entry
+    {
+        public MamaFieldCacheField mField   = null;
+        public long mSerial = 0;
+
+        public Entry (MamaFieldCacheField field)
+        {
+            mField = field;
+        }
+
+        public Entry (MamaFieldCacheField field, long serial)
+        {
+            mField = field;
+            mSerial = serial;
+        }
+
+        public Entry (Entry entry)
+        {
+            mField = entry.mField.copy ();
+            mSerial = entry.mSerial;
+        }
+    }
+}

--- a/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheReadOnlyField.java
+++ b/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheReadOnlyField.java
@@ -1,0 +1,82 @@
+//--------------------------------------------------------------------------
+// Copyright (c) 1999-2006 Wombat Financial Software Inc., of Incline
+// Village, NV.  All rights reserved.
+//
+// This software and documentation constitute an unpublished work and
+// contain valuable trade secrets and proprietary information belonging
+// to Wombat.  None of this material may be copied, duplicated or
+// disclosed without the express written permission of Wombat.
+//
+// WOMBAT EXPRESSLY DISCLAIMS ANY AND ALL WARRANTIES CONCERNING THIS
+// SOFTWARE AND DOCUMENTATION, INCLUDING ANY WARRANTIES OF
+// MERCHANTABILITY AND/OR FITNESS FOR ANY PARTICULAR PURPOSE, AND
+// WARRANTIES OF PERFORMANCE, AND ANY WARRANTY THAT MIGHT OTHERWISE ARISE
+// FROM COURSE OF DEALING OR USAGE OF TRADE. NO WARRANTY IS EITHER
+// EXPRESS OR IMPLIED WITH RESPECT TO THE USE OF THE SOFTWARE OR
+// DOCUMENTATION.
+//
+// Under no circumstances shall Wombat be liable for incidental, special,
+// indirect, direct or consequential damages or loss of profits,
+// interruption of business, or related expenses which may arise from use
+// of software or documentation, including but not limited to those
+// resulting from defects in software and/or documentation, or loss or
+// inaccuracy of data of any kind.
+//
+//----------------------------------------------------------------------------
+
+
+package com.wombat.mama;
+
+public interface MamaFieldCacheReadOnlyField
+{   
+    
+    /**
+     * Make a copy of this field.
+     *
+     * @return the copy
+     */
+    public MamaFieldCacheField copy ();
+
+    /**
+     * Create a string value of the field in the buffer provided.
+     */
+     
+    public String getAsString ();
+
+    /**
+     * Return the MamaFieldDescriptor for this field (or NULL).
+     */
+    public MamaFieldDescriptor getDescriptor();
+
+    /**
+     * Return the actual field type for this field.  It is possible to
+     * create fields that actually differ from the type specified in
+     * the dictionary field descriptor.
+     */
+    public short getType();
+
+    /**
+     * Get the track modification state for the field
+     */
+    public boolean getTrackModState ();
+  
+    /**
+     * Get the modification state for the field.
+     */
+    public short getModState ();
+
+    /**
+     * Return whether the field is unmodified.
+     */
+    public boolean isUnmodified ();
+
+    /**
+     * Return whether the field is modified.
+     */
+    public boolean isModified ();
+
+    /**
+     * Return whether the field is modified.
+     */
+    public boolean isTouched ();
+}

--- a/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheString.java
+++ b/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheString.java
@@ -1,0 +1,162 @@
+//--------------------------------------------------------------------------
+// Copyright (c) 1999-2006 Wombat Financial Software Inc., of Incline
+// Village, NV.  All rights reserved.
+//
+// This software and documentation constitute an unpublished work and
+// contain valuable trade secrets and proprietary information belonging
+// to Wombat.  None of this material may be copied, duplicated or
+// disclosed without the express written permission of Wombat.
+//
+// WOMBAT EXPRESSLY DISCLAIMS ANY AND ALL WARRANTIES CONCERNING THIS
+// SOFTWARE AND DOCUMENTATION, INCLUDING ANY WARRANTIES OF
+// MERCHANTABILITY AND/OR FITNESS FOR ANY PARTICULAR PURPOSE, AND
+// WARRANTIES OF PERFORMANCE, AND ANY WARRANTY THAT MIGHT OTHERWISE ARISE
+// FROM COURSE OF DEALING OR USAGE OF TRADE. NO WARRANTY IS EITHER
+// EXPRESS OR IMPLIED WITH RESPECT TO THE USE OF THE SOFTWARE OR
+// DOCUMENTATION.
+//
+// Under no circumstances shall Wombat be liable for incidental, special,
+// indirect, direct or consequential damages or loss of profits,
+// interruption of business, or related expenses which may arise from use
+// of software or documentation, including but not limited to those
+// resulting from defects in software and/or documentation, or loss or
+// inaccuracy of data of any kind.
+//
+//----------------------------------------------------------------------------
+
+package com.wombat.mama;
+
+
+public class MamaFieldCacheString extends MamaFieldCacheField
+{
+    private String mValue;
+    
+    /**
+     * Constructor.  Use one of the create() methods to actually
+     * initialize the field.
+     */
+     
+    public MamaFieldCacheString (MamaFieldDescriptor desc)
+    {
+        super(desc,MamaFieldDescriptor.STRING);
+        mValue = null;
+    }
+    
+    /**
+     * Constructor.
+     */
+     
+    public MamaFieldCacheString (int fid, String name, boolean trackModState)
+    {
+        super(fid,MamaFieldDescriptor.STRING,name,trackModState);
+        mValue=null;
+    }
+
+    /*  Description :   This function will add the contents of the cache field
+     *                  to the supplied message.
+     *  Arguments   :   fieldName   [I] True to add the field name to the message.
+     *                  message     [I] The message where the field will be added.
+     */
+    public void addToMessage(boolean fieldName, MamaMsg message)
+    {
+        // Check to see if field names should be added
+        String name = null;
+        if (fieldName)
+        {
+            // Get the field name from the descriptor
+            name = mDesc.getName();
+        }
+
+        // Add the value
+        message.addString(name, mDesc.getFid (), mValue);
+    }
+
+    public MamaFieldCacheField copy ()
+    {
+        MamaFieldCacheString result = new MamaFieldCacheString (
+            mDesc.getFid (),
+            mDesc.getName (),
+            mTrackModState);
+        result.mValue = mValue;
+        return result;
+    }
+
+    /**
+     * Apply the MamaMsgField to the cached field.
+     */
+    
+    public void apply (MamaMsgField msgField)
+    {
+        mValue = msgField.getString ();
+    }
+
+    /**
+     * Explicitly set the cached value.
+     */
+     
+    public void set (String value)
+    {
+        if (mTrackModState)
+        {
+            if (mValue == value)
+            {
+                if (isModified())
+                    setModState (MamaFieldCacheField.MOD_STATE_TOUCHED);
+                return;
+            }
+            else
+            {
+                setModState (MamaFieldCacheField.MOD_STATE_MODIFIED);
+                // Drop through to assignment.
+            }
+        }
+        mValue = value;         
+    }
+    /**
+     * Return the cached value.
+     */
+    
+     public String get()
+     {
+        return (mValue != null) ? mValue : null;
+     }
+     
+     /**
+      * Copy the cached value into the result.
+      */
+     
+     public void get (String result)
+     {
+        result = mValue;
+     }
+     
+    /**
+     * Check whether the field value is equal.
+     */
+     
+    public boolean isEqual(String value)
+    {
+        if (mValue == null)
+        {
+            return (value == null);
+        }
+        else
+        {
+            return (value != null) ? mValue.equals(value) : false;
+        }
+    }
+    
+    /**
+     * Return a string representation of the value
+     */
+     
+    public String getAsString ()
+    {
+        return (mValue != null) ? mValue : "null";
+    }
+
+    public void apply (MamaFieldCacheField value)
+    {
+        mValue = ((MamaFieldCacheString)value).mValue;
+    }
+}

--- a/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheUint16.java
+++ b/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheUint16.java
@@ -1,0 +1,155 @@
+//--------------------------------------------------------------------------
+// Copyright (c) 1999-2006 Wombat Financial Software Inc., of Incline
+// Village, NV.  All rights reserved.
+//
+// This software and documentation constitute an unpublished work and
+// contain valuable trade secrets and proprietary information belonging
+// to Wombat.  None of this material may be copied, duplicated or
+// disclosed without the express written permission of Wombat.
+//
+// WOMBAT EXPRESSLY DISCLAIMS ANY AND ALL WARRANTIES CONCERNING THIS
+// SOFTWARE AND DOCUMENTATION, INCLUDING ANY WARRANTIES OF
+// MERCHANTABILITY AND/OR FITNESS FOR ANY PARTICULAR PURPOSE, AND
+// WARRANTIES OF PERFORMANCE, AND ANY WARRANTY THAT MIGHT OTHERWISE ARISE
+// FROM COURSE OF DEALING OR USAGE OF TRADE. NO WARRANTY IS EITHER
+// EXPRESS OR IMPLIED WITH RESPECT TO THE USE OF THE SOFTWARE OR
+// DOCUMENTATION.
+//
+// Under no circumstances shall Wombat be liable for incidental, special,
+// indirect, direct or consequential damages or loss of profits,
+// interruption of business, or related expenses which may arise from use
+// of software or documentation, including but not limited to those
+// resulting from defects in software and/or documentation, or loss or
+// inaccuracy of data of any kind.
+//
+//----------------------------------------------------------------------------
+
+
+package com.wombat.mama;
+
+public class MamaFieldCacheUint16 extends MamaFieldCacheField
+{
+    private int mValue;
+    
+    /**
+     * Constructor.  Use one of the create() methods to actually
+     * initialize the field.
+     */
+     
+    public MamaFieldCacheUint16 (MamaFieldDescriptor desc)
+    {
+        super(desc,MamaFieldDescriptor.U16);
+        mValue = 0;
+    }
+    
+    /**
+     * Constructor.
+     */
+     
+    public MamaFieldCacheUint16 (int fid, String name, boolean trackModState)
+    {
+        super(fid,MamaFieldDescriptor.U16,name,trackModState);
+        mValue = 0;
+    }
+
+    public MamaFieldCacheField copy ()
+    {
+        MamaFieldCacheUint16 result = new MamaFieldCacheUint16 (
+            mDesc.getFid (),
+            mDesc.getName (),
+            mTrackModState);
+        result.mValue = mValue;
+        return result;
+    }
+
+    /*  Description :   This function will add the contents of the cache field
+     *                  to the supplied message.
+     *  Arguments   :   fieldName   [I] True to add the field name to the message.
+     *                  message     [I] The message where the field will be added.
+     */
+    public void addToMessage(boolean fieldName, MamaMsg message)
+    {
+        // Check to see if field names should be added
+        String name = null;
+        if (fieldName)
+        {
+            // Get the field name from the descriptor
+            name = mDesc.getName();
+        }
+        // Add the value
+        message.addU16(name, mDesc.getFid (), mValue);
+    }
+
+    /**
+     * Apply the MamaMsgField to the cached field.
+     */
+     
+    public void apply(MamaMsgField msgField)
+    {
+        mValue  = msgField.getU16 ();
+    }
+    
+    /**
+     * Explicitly set the cached value.
+     */
+    
+    public void set (int value)
+    {
+        if (mTrackModState)
+        {
+            if (mValue == value)
+            {
+                if (isModified())
+                    setModState (MamaFieldCacheField.MOD_STATE_TOUCHED);
+                return;
+            }
+            else
+            {
+                setModState (MamaFieldCacheField.MOD_STATE_MODIFIED);
+                // Drop through to assignment.               
+            }            
+        }
+        mValue = value;
+    }
+    
+    /**
+     * Check whether the field value is equal.
+     */
+     
+    public boolean isEqual (int value)
+    {     
+        return value == mValue;      
+    }
+    
+    /**
+     * Return the cached value.
+     */
+     
+    public int get ()
+    {
+        return mValue;
+    }
+    
+    /**
+     * Copy the cached value into the result.
+     */
+    
+    public void get (int result)
+    {
+        result = mValue;
+    }
+   
+    /**
+     * Return a string representation of the value
+     */
+     
+    public String getAsString ()
+    {
+        return new Integer(mValue).toString();    
+    }
+
+    public void apply (MamaFieldCacheField value)
+    {
+        mValue = ((MamaFieldCacheUint16)value).mValue;
+    }
+}

--- a/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheUint32.java
+++ b/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheUint32.java
@@ -1,0 +1,155 @@
+//--------------------------------------------------------------------------
+// Copyright (c) 1999-2006 Wombat Financial Software Inc., of Incline
+// Village, NV.  All rights reserved.
+//
+// This software and documentation constitute an unpublished work and
+// contain valuable trade secrets and proprietary information belonging
+// to Wombat.  None of this material may be copied, duplicated or
+// disclosed without the express written permission of Wombat.
+//
+// WOMBAT EXPRESSLY DISCLAIMS ANY AND ALL WARRANTIES CONCERNING THIS
+// SOFTWARE AND DOCUMENTATION, INCLUDING ANY WARRANTIES OF
+// MERCHANTABILITY AND/OR FITNESS FOR ANY PARTICULAR PURPOSE, AND
+// WARRANTIES OF PERFORMANCE, AND ANY WARRANTY THAT MIGHT OTHERWISE ARISE
+// FROM COURSE OF DEALING OR USAGE OF TRADE. NO WARRANTY IS EITHER
+// EXPRESS OR IMPLIED WITH RESPECT TO THE USE OF THE SOFTWARE OR
+// DOCUMENTATION.
+//
+// Under no circumstances shall Wombat be liable for incidental, special,
+// indirect, direct or consequential damages or loss of profits,
+// interruption of business, or related expenses which may arise from use
+// of software or documentation, including but not limited to those
+// resulting from defects in software and/or documentation, or loss or
+// inaccuracy of data of any kind.
+//
+//----------------------------------------------------------------------------
+
+
+package com.wombat.mama;
+
+public class MamaFieldCacheUint32 extends MamaFieldCacheField
+{
+    private long mValue;
+    
+    /**
+     * Constructor.  Use one of the create() methods to actually
+     * initialize the field.
+     */
+     
+    public MamaFieldCacheUint32 (MamaFieldDescriptor desc)
+    {
+        super(desc,MamaFieldDescriptor.U32);
+        mValue = 0;
+    }
+    
+    /**
+     * Constructor.
+     */
+     
+    public MamaFieldCacheUint32 (int fid, String name, boolean trackModState)
+    {
+        super(fid,MamaFieldDescriptor.U32,name,trackModState);
+        mValue = 0;
+    }
+
+    /*  Description :   This function will add the contents of the cache field
+     *                  to the supplied message.
+     *  Arguments   :   fieldName   [I] True to add the field name to the message.
+     *                  message     [I] The message where the field will be added.
+     */
+    public void addToMessage(boolean fieldName, MamaMsg message)
+    {
+        // Check to see if field names should be added
+        String name = null;
+        if (fieldName)
+        {
+            // Get the field name from the descriptor
+            name = mDesc.getName();
+        }
+        // Add the value
+        message.addU32(name, mDesc.getFid (), mValue);
+    }
+
+    public MamaFieldCacheField copy ()
+    {
+        MamaFieldCacheUint32 result = new MamaFieldCacheUint32 (
+            mDesc.getFid (),
+            mDesc.getName (),
+            mTrackModState);
+        result.mValue = mValue;
+        return result;
+    }
+
+    /**
+     * Apply the MamaMsgField to the cached field.
+     */
+     
+    public void apply(MamaMsgField msgField)
+    {
+        mValue = msgField.getU32 ();
+    }
+    
+    /**
+     * Explicitly set the cached value.
+     */
+    
+    public void set (long value)
+    {
+        if (mTrackModState)
+        {
+            if (mValue == value)
+            {
+                if (isModified())
+                    setModState (MamaFieldCacheField.MOD_STATE_TOUCHED);
+                return;
+            }
+            else
+            {
+                setModState (MamaFieldCacheField.MOD_STATE_MODIFIED);
+                // Drop through to assignment.               
+            }            
+        }
+        mValue = value;
+    }
+    
+    /**
+     * Check whether the field value is equal.
+     */
+     
+    public boolean isEqual (long value)
+    {     
+        return value == mValue;      
+    }
+    
+    /**
+     * Return the cached value.
+     */
+     
+    public long get ()
+    {
+        return mValue;
+    }
+    
+    /**
+     * Copy the cached value into the result.
+     */
+    
+    public void get (long result)
+    {
+        result = mValue;
+    }
+   
+    /**
+     * Return a string representation of the value
+     */
+     
+    public String getAsString ()
+    {
+        return new Long(mValue).toString();    
+    }
+
+    public void apply (MamaFieldCacheField value)
+    {
+        mValue = ((MamaFieldCacheUint32)value).mValue;
+    }
+}

--- a/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheUint64.java
+++ b/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheUint64.java
@@ -1,0 +1,156 @@
+//--------------------------------------------------------------------------
+// Copyright (c) 1999-2006 Wombat Financial Software Inc., of Incline
+// Village, NV.  All rights reserved.
+//
+// This software and documentation constitute an unpublished work and
+// contain valuable trade secrets and proprietary information belonging
+// to Wombat.  None of this material may be copied, duplicated or
+// disclosed without the express written permission of Wombat.
+//
+// WOMBAT EXPRESSLY DISCLAIMS ANY AND ALL WARRANTIES CONCERNING THIS
+// SOFTWARE AND DOCUMENTATION, INCLUDING ANY WARRANTIES OF
+// MERCHANTABILITY AND/OR FITNESS FOR ANY PARTICULAR PURPOSE, AND
+// WARRANTIES OF PERFORMANCE, AND ANY WARRANTY THAT MIGHT OTHERWISE ARISE
+// FROM COURSE OF DEALING OR USAGE OF TRADE. NO WARRANTY IS EITHER
+// EXPRESS OR IMPLIED WITH RESPECT TO THE USE OF THE SOFTWARE OR
+// DOCUMENTATION.
+//
+// Under no circumstances shall Wombat be liable for incidental, special,
+// indirect, direct or consequential damages or loss of profits,
+// interruption of business, or related expenses which may arise from use
+// of software or documentation, including but not limited to those
+// resulting from defects in software and/or documentation, or loss or
+// inaccuracy of data of any kind.
+//
+//----------------------------------------------------------------------------
+
+
+package com.wombat.mama;
+
+public class MamaFieldCacheUint64 extends MamaFieldCacheField
+{
+    private long mValue;
+    
+    /**
+     * Constructor.  Use one of the create() methods to actually
+     * initialize the field.
+     */
+     
+    public MamaFieldCacheUint64 (MamaFieldDescriptor desc)
+    {
+        super(desc,MamaFieldDescriptor.U64);
+        mValue = 0;
+    }
+    
+    /**
+     * Constructor.
+     */
+     
+    public MamaFieldCacheUint64 (int fid, String name, boolean trackModState)
+    {
+        super(fid,MamaFieldDescriptor.U64,name,trackModState);
+        mValue = 0;
+    }
+
+    /*  Description :   This function will add the contents of the cache field
+     *                  to the supplied message.
+     *  Arguments   :   fieldName   [I] True to add the field name to the message.
+     *                  message     [I] The message where the field will be added.
+     */
+    public void addToMessage(boolean fieldName, MamaMsg message)
+    {
+        // Check to see if field names should be added
+        String name = null;
+        if (fieldName)
+        {
+            // Get the field name from the descriptor
+            name = mDesc.getName();
+        }
+        
+        // Add the value
+        message.addU64(name, mDesc.getFid (), mValue);
+    }
+
+    public MamaFieldCacheField copy ()
+    {
+        MamaFieldCacheUint64 result = new MamaFieldCacheUint64 (
+            mDesc.getFid (),
+            mDesc.getName (),
+            mTrackModState);
+        result.mValue = mValue;
+        return result;
+    }
+
+    /**
+     * Apply the MamaMsgField to the cached field.
+     */
+     
+    public void apply(MamaMsgField msgField)
+    {
+        mValue = msgField.getU64 ();
+    }
+    
+    /**
+     * Explicitly set the cached value.
+     */
+    
+    public void set (long value)
+    {
+        if (mTrackModState)
+        {
+            if (mValue == value)
+            {
+                if (isModified())
+                    setModState (MamaFieldCacheField.MOD_STATE_TOUCHED);
+                return;
+            }
+            else
+            {
+                setModState (MamaFieldCacheField.MOD_STATE_MODIFIED);
+                // Drop through to assignment.               
+            }            
+        }
+        mValue = value;
+    }
+    
+    /**
+     * Check whether the field value is equal.
+     */
+     
+    public boolean isEqual (long value)
+    {     
+        return value == mValue;      
+    }
+    
+    /**
+     * Return the cached value.
+     */
+     
+    public long get ()
+    {
+        return mValue;
+    }
+    
+    /**
+     * Copy the cached value into the result.
+     */
+    
+    public void get (long result)
+    {
+        result = mValue;
+    }
+   
+    /**
+     * Return a string representation of the value
+     */
+     
+    public String getAsString ()
+    {
+        return new Long(mValue).toString();    
+    }
+
+    public void apply (MamaFieldCacheField value)
+    {
+        mValue = ((MamaFieldCacheUint64)value).mValue;
+    }
+}

--- a/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheUint8.java
+++ b/mama/jni/src/main/java/com/wombat/mama/MamaFieldCacheUint8.java
@@ -1,0 +1,156 @@
+//--------------------------------------------------------------------------
+// Copyright (c) 1999-2006 Wombat Financial Software Inc., of Incline
+// Village, NV.  All rights reserved.
+//
+// This software and documentation constitute an unpublished work and
+// contain valuable trade secrets and proprietary information belonging
+// to Wombat.  None of this material may be copied, duplicated or
+// disclosed without the express written permission of Wombat.
+//
+// WOMBAT EXPRESSLY DISCLAIMS ANY AND ALL WARRANTIES CONCERNING THIS
+// SOFTWARE AND DOCUMENTATION, INCLUDING ANY WARRANTIES OF
+// MERCHANTABILITY AND/OR FITNESS FOR ANY PARTICULAR PURPOSE, AND
+// WARRANTIES OF PERFORMANCE, AND ANY WARRANTY THAT MIGHT OTHERWISE ARISE
+// FROM COURSE OF DEALING OR USAGE OF TRADE. NO WARRANTY IS EITHER
+// EXPRESS OR IMPLIED WITH RESPECT TO THE USE OF THE SOFTWARE OR
+// DOCUMENTATION.
+//
+// Under no circumstances shall Wombat be liable for incidental, special,
+// indirect, direct or consequential damages or loss of profits,
+// interruption of business, or related expenses which may arise from use
+// of software or documentation, including but not limited to those
+// resulting from defects in software and/or documentation, or loss or
+// inaccuracy of data of any kind.
+//
+//----------------------------------------------------------------------------
+
+
+package com.wombat.mama;
+
+public class MamaFieldCacheUint8 extends MamaFieldCacheField
+{
+    private short mValue;
+    
+    /**
+     * Constructor.  Use one of the create() methods to actually
+     * initialize the field.
+     */
+     
+    public MamaFieldCacheUint8 (MamaFieldDescriptor desc)
+    {
+        super(desc,MamaFieldDescriptor.U8);
+        mValue = 0;
+    }
+    
+    /**
+     * Constructor.
+     */
+     
+    public MamaFieldCacheUint8 (int fid, String name, boolean trackModState)
+    {
+        super(fid,MamaFieldDescriptor.U8,name,trackModState);
+        mValue = 0;
+    }
+
+    /*  Description :   This function will add the contents of the cache field
+     *                  to the supplied message.
+     *  Arguments   :   fieldName   [I] True to add the field name to the message.
+     *                  message     [I] The message where the field will be added.
+     */
+    public void addToMessage(boolean fieldName, MamaMsg message)
+    {
+        // Check to see if field names should be added
+        String name = null;
+        if (fieldName)
+        {
+            // Get the field name from the descriptor
+            name = mDesc.getName();
+        }
+        
+        // Add the value
+        message.addU8(name, mDesc.getFid (), mValue);
+    }
+
+    public MamaFieldCacheField copy ()
+    {
+        MamaFieldCacheUint8 result = new MamaFieldCacheUint8 (
+            mDesc.getFid (),
+            mDesc.getName (),
+            mTrackModState);
+        result.mValue = mValue;
+        return result;
+    }
+
+    /**
+     * Apply the MamaMsgField to the cached field.
+     */
+     
+    public void apply(MamaMsgField msgField)
+    {
+        mValue = msgField.getU8 ();
+    }
+    
+    /**
+     * Explicitly set the cached value.
+     */
+    
+    public void set (short value)
+    {
+        if (mTrackModState)
+        {
+            if (mValue == value)
+            {
+                if (isModified())
+                    setModState (MamaFieldCacheField.MOD_STATE_TOUCHED);
+                return;
+            }
+            else
+            {
+                setModState (MamaFieldCacheField.MOD_STATE_MODIFIED);
+                // Drop through to assignment.               
+            }            
+        }
+        mValue = value;
+    }
+    
+    /**
+     * Check whether the field value is equal.
+     */
+     
+    public boolean isEqual (short value)
+    {     
+        return value == mValue;      
+    }
+    
+    /**
+     * Return the cached value.
+     */
+     
+    public short get ()
+    {
+        return mValue;
+    }
+    
+    /**
+     * Copy the cached value into the result.
+     */
+    
+    public void get (short result)
+    {
+        result = mValue;
+    }
+   
+    /**
+     * Return a string representation of the value
+     */
+     
+    public String getAsString ()
+    {
+        return new Short(mValue).toString();    
+    }
+
+    public void apply (MamaFieldCacheField value)
+    {
+        mValue = ((MamaFieldCacheUint8)value).mValue;
+    }
+}

--- a/mama/jni/src/main/java/com/wombat/mama/examples/MamaListenCached.java
+++ b/mama/jni/src/main/java/com/wombat/mama/examples/MamaListenCached.java
@@ -1,0 +1,1039 @@
+package com.wombat.mama.examples;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.logging.Logger;
+import java.util.logging.Level;
+import com.wombat.mama.MamaTimer;
+import java.util.Map;
+import java.util.Collections;
+import java.util.HashMap;
+import java.io.*;
+import java.util.Random;
+
+import com.wombat.mama.*;
+
+/**
+ * MamaListenCached example program is used to test the MamaFieldCache.
+ *
+ * It creates a local cache for the subscription and prints out all the data each time
+ * a delta arrives.
+ *
+ * Verify option can be used to check the integrity of the cache against the feed cache
+ * every configurable interval.
+ **/
+ 
+public class MamaListenCached
+{
+    private static MamaTransport    transport           = null;
+    private static String           myMiddleware        = "wmw";
+    private static MamaQueue        myDefaultQueue      = null;
+    private static MamaBridge       myBridge            = null;
+    private static double           throttle            = -1;
+    private static MamaDictionary   dictionary          = null;
+    private static String           dictSource          = "WOMBAT";
+    private static boolean          dumpDataDict        = false;
+    private static boolean          buildDataDict       = true;    
+    private static boolean          dictionaryComplete  = false;
+    private static String           transportName       = "internal";
+    private static boolean          requireInitial      = true;
+    private static boolean          snapshot            = false;
+    private static double           timeout             = 10.0;
+    private static int              quietness           = 0;
+    private static boolean          printUsingName      = false;
+    private static boolean          printUsingFid       = false;
+    private static int              numThreads          = 0;
+    private static MamaQueueGroup   queueGroup          = null;
+    private static boolean          qualityForAll       = true;
+    private static final ArrayList  subscriptions       = new ArrayList();
+    private static final ArrayList  subjectList         = new ArrayList();
+    private static String           filename            = null;
+    private static String           mySymbolNamespace   = null;
+    private static final Logger     logger              = Logger.getLogger( "com.wombat.mama" );
+    private static Level            myLogLevel;
+    private static boolean          myGroupSubscription = false;
+    private static MamaSource       mySource;   
+    private static MamaSource       myDictSource;
+    private static boolean          verifyAgainstFeed   = false;
+    private static MamaTimer        myVerifyTimer       = null;
+    private static double           myVerifyInterval    = 1.0;
+    private static String           failedField         = null;
+    private static boolean          display             = true;    
+    
+    public static void main (final String[] args)
+    {
+        parseCommandLine (args);
+
+        try
+        {
+            if (subjectList.isEmpty())
+            {
+                readSubjectsFromFile();
+            }
+
+            initializeMama ();            
+            buildDataDictionary ();
+            dumpDataDictionary ();            
+            
+            subscribeToSubjects ();
+            
+            System.out.println( "Type CTRL-C to exit." );
+            /*This will only block on JNI*/
+            Mama.start (myBridge);
+            /*Keep the main thread running if using pure Java MAMA*/
+            Thread.currentThread().join();
+        }
+        catch (Exception e)
+        {
+            if (e.getCause() != null)
+            {
+                e.getCause ().printStackTrace ();
+            }
+
+            e.printStackTrace ();
+            System.exit (1);
+        }
+        finally
+        {
+            shutdown ();
+        }
+    }
+
+    private static void subscribeToSubjects()
+    {
+        int howMany = 0;
+
+        queueGroup = new MamaQueueGroup (numThreads, myBridge);
+
+        /*Subscribe to all symbols specified on the commanty line or from the
+         * symbol file*/
+        for (Iterator iterator = subjectList.iterator(); iterator.hasNext();)
+        {
+            MamaQueue queue;
+            final String symbol = (String) iterator.next();
+            
+            MamaSubscription subscription = new MamaSubscription ();
+            queue= queueGroup.getNextQueue ();
+            /*Properties common to all subscription types*/
+            subscription.setTimeout (timeout);
+            subscription.setRetries (1);
+            subscription.setRequiresInitial (requireInitial);
+            SubscriptionCallback callback = new SubscriptionCallback(queue, symbol);    
+            subscription.createSubscription (callback,
+                                             queue,
+                                             mySource,
+                                             symbol,
+                                             null);
+           
+
+            logger.fine ("Subscribed to: " + symbol);
+
+            if (++howMany % 1000 == 0)
+            {
+                System.out.println ("Subscribed to " + howMany + " symbols.");
+            }
+        }
+    }
+
+    private static void dumpDataDictionary()
+    {
+        if (dumpDataDict)
+        {
+            for (int i = 0; i < dictionary.getSize(); i++)
+            {
+                MamaFieldDescriptor fd = dictionary.getFieldByIndex (i);
+                print (""+fd.getFid(),5);
+                System.out.print (": ");
+                print (""+fd.getType(),3);
+                System.out.println (": "+fd.getName());
+            }
+        }
+        System.out.flush();
+    }
+
+    private static void buildDataDictionary()
+        throws InterruptedException
+    {
+        MamaDictionaryCallback dictionaryCallback = createDictionaryCallback();
+        
+        MamaSubscription subscription = new MamaSubscription ();
+        
+        if (buildDataDict)
+        {
+            synchronized (dictionaryCallback)
+            {
+                /*The dictionary is obtained through a specialized form of
+                * subscription.*/            
+
+                dictionary = subscription.createDictionarySubscription (
+                        dictionaryCallback,
+                        myDefaultQueue,
+                        myDictSource,
+                        10.0,
+                        2);
+                    
+                /*Mama.start() will only block for JNI*/
+                Mama.start (myBridge);
+                if (!dictionaryComplete) dictionaryCallback.wait( 30000 );
+                if (!dictionaryComplete)
+                {
+                    System.err.println( "Timed out waiting for dictionary." );
+                    System.exit( 0 );
+                }
+            }             
+        }
+    }
+
+    private static MamaDictionaryCallback createDictionaryCallback()
+    {
+        return new MamaDictionaryCallback()
+        {
+            public void onTimeout()
+            {
+                System.err.println( "Timed out waiting for dictionary" );
+                System.exit(1);
+            }
+
+            public void onError (final String s)
+            {
+                System.err.println ("Error getting dictionary: " + s);
+                System.exit (1);
+            }
+
+            public synchronized void onComplete()
+            {
+                dictionaryComplete = true;
+                Mama.stop(myBridge);
+                notifyAll();
+            }
+        };
+    }
+
+    private static void shutdown()
+    {
+        for (Iterator iterator = subscriptions.iterator(); iterator.hasNext();)
+        {
+            final MamaSubscription subscription = (MamaSubscription) iterator.next();
+            subscription.destroy();
+        }
+        if (transport != null)
+        {
+            transport.destroy();
+        }
+        Mama.close();
+    }
+
+    private static void initializeMama()
+    {
+        try
+        {
+            myBridge = Mama.loadBridge (myMiddleware);
+            /*Always the first API method called. Initialized internal API
+             * state*/
+            Mama.open ();
+            myDefaultQueue = Mama.getDefaultQueue (myBridge);
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace ();
+            System.out.println ("Failed to initialize MAMA");
+            System.exit (1);
+        }
+        
+        transport = new MamaTransport ();
+        /*The name specified here is the name identifying properties in the
+         * mama.properties file*/
+        transport.create (transportName, myBridge);
+       
+        /*Receive notification of transport level events*/
+        transport.addTransportListener( new MamaTransportListener()
+        {
+            public void onConnect(short cause, final Object platformInfo)
+            {
+                System.out.println ("TRANSPORT CONNECTED!");
+            }
+            public void onDestroy(short cause, final Object platformInfo)
+            {
+                System.out.println ("TRANSPORT DESTROYED!");
+            }
+            public void onAccept(short cause, final Object platformInfo)
+            {
+                System.out.println ("TRANSPORT ACCEPTED!");
+            }
+            public void onAcceptReconnect(short cause, final Object platformInfo)
+            {
+                System.out.println ("ACCEPTED RECONNECT!");
+            }
+
+            public void onPublisherDisconnect(short cause, final Object platformInfo)
+            {
+                System.out.println ("PUBLISHER DISCONNECTED!");
+            }
+
+            public void onNamingServiceConnect(short cause, final Object platformInfo)
+            {
+                System.out.println ("NAMING SERVICE CONNECTED!");
+            }
+
+            public void onNamingServiceDisconnect(short cause, final Object platformInfo)
+            {
+                System.out.println ("NAMING SERVICE DISCONNECTED!");
+            }
+
+            public void onDisconnect(short cause, final Object platformInfo)
+            {
+                System.out.println ("TRANSPORT DISCONNECTED!");
+            }
+
+            public void onReconnect(short cause, final Object platformInfo)
+            {
+                System.out.println ("TRANSPORT RECONNECTED!");
+            }
+
+            public void onQuality(short cause, final Object platformInfo)
+            {
+                System.out.println ("TRANSPORT QUALITY!");
+                short quality = transport.getQuality();
+                System.out.println ("Transport quality is now " +
+                                    MamaQuality.toString(quality) +
+                                    ", cause " + MamaDQCause.toString (cause) +
+                                    ", platformInfo: " + platformInfo);
+            }
+        } );
+
+        if (!qualityForAll)
+        {
+            transport.setInvokeQualityForAllSubscs (false);
+        }
+
+        /*MamaSource for all subscriptions*/
+        mySource     = new MamaSource ();
+        mySource.setTransport (transport);
+        mySource.setSymbolNamespace (mySymbolNamespace);
+
+        /*MamaSource for dictionary subscription*/
+        myDictSource = new MamaSource ();
+        myDictSource.setTransport (transport);
+        myDictSource.setSymbolNamespace (dictSource);
+
+        if (throttle != -1)
+        {
+            transport.setOutboundThrottle
+                (MamaThrottleInstance.DEFAULT_THROTTLE,throttle);
+        }
+    }
+
+    private static void readSubjectsFromFile() throws IOException
+    {
+        InputStream input;
+        if (filename != null)
+        {
+            input = new FileInputStream (filename);
+        }
+        else
+        {
+            input = System.in;
+            System.out.println ("Enter one symbol per line and terminate with a .");
+            System.out.print ("SUBJECT>");
+        }
+
+        final BufferedReader reader =
+            new BufferedReader (new InputStreamReader (input));
+
+        String symbol;
+        while (null != (symbol = reader.readLine()))
+        {
+            if (!symbol.equals(""))
+            {
+                if (symbol.equals( "." ))
+                {
+                    break;
+                }
+                subjectList.add (symbol);
+            }
+
+            if (input == System.in)
+            {
+                System.out.print ("SUBJECT>");
+            }
+        }
+
+        if (subjectList.isEmpty())
+        {
+            System.err.println ("No subjects specified");
+            System.exit (1);
+        }
+        System.out.flush();
+    }
+
+    private static void print (final String what, final int width)
+    {
+        if(quietness < 1)
+        {
+            int whatLength = 0;
+            if (what!=null)
+                whatLength = what.length();
+
+            final int spaces = width - whatLength;
+            System.out.print (what);
+
+            for (int i = 0; i < spaces; i++)
+                System.out.print(" ");
+        }
+        System.out.flush();
+    }
+
+    private static void parseCommandLine (final String[] args)
+    {
+        for(int i = 0; i < args.length;)
+        {
+            if (args[i].equals ("-source") || args[i].equals("-S"))
+            {
+                mySymbolNamespace = args[i +1];
+                i += 2;
+            }
+            else if (args[i].equals ("-d"))
+            {
+                dictSource = args[i + 1];
+                i += 2;
+            }
+            else if (args[i].equals ("-D"))
+            {
+                dumpDataDict = true;
+                i++;
+            }
+            else if (args[i].equals ("-B"))
+            {
+                buildDataDict = false;
+                i++;
+            }
+            else if (args[i].equals ("-I"))
+            {
+                requireInitial = false;
+                i++;
+            }
+            else if (args[i].equals ("-s"))
+            {
+                subjectList.add (args[i + 1]);
+                i += 2;
+            }
+            else if (args[i].equals ("-f"))
+            {
+                filename = args[i + 1];
+                i += 2;
+            }
+            else if (args[i].equals ("-1"))
+            {
+                snapshot = true;
+                i++;
+            }
+            else if (args[i].equals ("-r"))
+            {
+                throttle = Double.parseDouble (args[i + 1]);
+                i += 2;
+            }
+            else if (args[i].equals ("-t"))
+            {
+                timeout = Double.parseDouble (args[i + 1]);
+                i += 2;
+            }
+            else if (args[i].equals ("-tport"))
+            {
+                transportName = args[i + 1];
+                i += 2;
+            }
+            else if (args[i].equals ("-threads"))
+            {
+                numThreads = Integer.parseInt (args[i+1]);
+                i += 2;
+            }
+            else if (args[i].equals ("-A"))
+            {
+                qualityForAll = false;
+                i++;
+            }
+            else if (args[i].equals ("-printUsingName"))
+            {
+                printUsingName = true;
+                i++;
+            }
+            else if (args[i].equals ("-printUsingFid"))
+            {
+                printUsingFid = true;
+                i++;
+            }
+            else if (args[i].equals ("-q"))
+            {
+                quietness++;
+                i++;
+            }
+            else if (args[i].equals ("-g"))
+            {
+                myGroupSubscription =  true;
+                i++;
+            }
+            else if (args[i].equals ("-m"))
+            {
+                myMiddleware = args[i + 1];
+                i += 2;
+            }
+            else if (args[i].equals ("-v"))
+            {
+                myLogLevel = myLogLevel == null
+                            ? Level.FINE    :
+                            myLogLevel == Level.FINE    
+                            ? Level.FINER   : 
+                            Level.FINEST;
+
+                Mama.enableLogging (myLogLevel);
+                i++;
+            }
+            else if (args[i].equals ("-verify"))
+            {
+                verifyAgainstFeed = true;                
+                i++;
+            }
+            else if (args[i].equals ("-verifyInterval"))
+            {
+                myVerifyInterval = Double.parseDouble (args[i + 1]);
+                i += 2;
+            }           
+        }
+    }
+
+    /*Class for processing all event callbacks for all subscriptions*/
+    private static class SubscriptionCallback implements MamaSubscriptionCallback
+    {
+        MamaFieldCache  myFieldCache = new MamaFieldCache();
+        MamaTimer       myVerifyTimer;  
+        int             myRandomNo;             
+        MamaQueue       myQueue;      
+
+        public SubscriptionCallback (MamaQueue queue, String symbol)
+        {
+            Random generator = new Random();
+            myRandomNo = generator.nextInt (10);
+            myQueue = queue;
+            if (verifyAgainstFeed)
+            {                
+                if (myVerifyInterval > 0)
+                {
+                    try
+                    {                
+                        myVerifyTimer = new MamaTimer();                    
+                        myVerifyTimer.create (myQueue, new VerifyCallback(this,symbol), 
+                        myVerifyInterval+1);
+                    }                 
+                    catch (Exception e)
+                    {
+                        e.printStackTrace( );
+                        System.err.println( "Error creating timer: " + e );
+                        System.exit(1);  
+                    }
+                }                
+            }
+        }
+        
+        public void onMsg (final MamaSubscription subscription, final MamaMsg msg)
+        {            
+            try
+            {
+                switch (MamaMsgType.typeForMsg (msg))
+                {
+                    case MamaMsgType.TYPE_DELETE:
+                    case MamaMsgType.TYPE_EXPIRE:
+                        subscription.destroy ();
+                        subscriptions.remove (subscription);
+                        return;
+                    case MamaMsgType.TYPE_SNAPSHOT:
+                        return;
+                }
+
+                switch (MamaMsgStatus.statusForMsg (msg))
+                {
+                    case MamaMsgStatus.STATUS_BAD_SYMBOL:
+                    case MamaMsgStatus.STATUS_EXPIRED:
+                    case MamaMsgStatus.STATUS_TIMEOUT:
+                        subscription.destroy();
+                        subscriptions.remove (subscription);
+                        return;
+                }
+            }
+            catch (Exception ex) 
+            {
+                ex.printStackTrace ();
+                System.exit (0);
+            }          
+            
+            //Apply the message to the FieldCache
+            myFieldCache.apply(msg,dictionary,null);
+            displayAllFields (subscription, msg);
+        }
+
+        /*Class for processing fields within a message - for the message
+         * iterator*/
+        private class FieldIterator implements MamaMsgFieldIterator
+        {
+            private boolean fieldHasName = true;
+            public void onField (MamaMsg        msg,
+                                 MamaMsgField   field,
+                                 MamaDictionary dictionary,
+                                 Object         closure)
+            {    
+                String fieldName = null;
+                try
+                {
+                    if (fieldHasName)
+                    {
+                        fieldName = field.getName ();
+                    }
+                }
+                catch (Exception e)
+                {
+                    fieldHasName = false;
+                }
+                    
+                print (" \t ", 0);
+                print (fieldName,20);
+                print (" | ", 0);
+                print ("" + field.getFid(),4);
+                print (" | ", 0);
+                print ("" + field.getTypeName(),10);
+                print (" | ", 0);
+
+                if (printUsingName == true)
+                {
+                    if (buildDataDict)
+                    {
+                        printUsingName (field);
+                    }
+                    else 
+                    {
+                        System.out.println ("CANNOT ACCESS FIELDS BY NAME");
+                        System.exit(1);                            
+                    }
+                }
+                else
+                {                                               
+                    printUsingFid (field);
+                }
+                print (" \n ", 0);
+            }
+
+            /*Access the data from the field objects*/
+            private void printUsingFid (MamaMsgField field)
+            {                
+                short fieldType = field.getType ();
+                switch (fieldType)
+                {
+                    case MamaFieldDescriptor.BOOL:
+                        MamaFieldCacheBool mfcb = (MamaFieldCacheBool) 
+                                            myFieldCache.find (field.getFid());
+                        print ("" + mfcb.get(), 20);
+                        break;
+                    case MamaFieldDescriptor.CHAR:
+                        MamaFieldCacheChar mfcc = (MamaFieldCacheChar) 
+                                            myFieldCache.find (field.getFid());
+                        print ("" + mfcc.get(), 20);
+                        break;
+                    case MamaFieldDescriptor.I8:
+                        MamaFieldCacheInt8 mfci8 = (MamaFieldCacheInt8) 
+                                            myFieldCache.find (field.getFid());
+                        print ("" + mfci8.get(), 20);
+                        break;
+                    case MamaFieldDescriptor.U8:
+                        MamaFieldCacheUint8 mfcui8 = (MamaFieldCacheUint8) 
+                                            myFieldCache.find (field.getFid());
+                        print ("" + mfcui8.get(), 20);
+                        break;
+                    case MamaFieldDescriptor.I16:
+                        MamaFieldCacheInt16 mfci16 = (MamaFieldCacheInt16) 
+                                            myFieldCache.find (field.getFid());
+                        print ("" + mfci16.get(), 20);
+                        break;
+                    case MamaFieldDescriptor.U16:
+                        MamaFieldCacheUint16 mfcui16 = (MamaFieldCacheUint16) 
+                                            myFieldCache.find (field.getFid());
+                        print ("" + mfcui16.get(), 20);
+                        break;
+                    case MamaFieldDescriptor.I32:
+                        MamaFieldCacheInt32 mfci32 = (MamaFieldCacheInt32) 
+                                            myFieldCache.find (field.getFid());
+                        print ("" + mfci32.get(), 20);
+                        break;
+                    case MamaFieldDescriptor.U32:
+                        MamaFieldCacheUint32 mfcui32 = (MamaFieldCacheUint32) 
+                                            myFieldCache.find (field.getFid());
+                        print ("" + mfcui32.get(), 20);
+                        break;
+                    case MamaFieldDescriptor.I64:
+                        MamaFieldCacheInt64 mfci64 = (MamaFieldCacheInt64) 
+                                            myFieldCache.find (field.getFid());
+                        print ("" + mfci64.get(), 20);
+                        break;
+                    case MamaFieldDescriptor.U64:
+                        MamaFieldCacheUint64 mfcui64 = (MamaFieldCacheUint64) 
+                                            myFieldCache.find (field.getFid());
+                        print ("" + mfcui64.get(), 20);
+                        break;
+                    case MamaFieldDescriptor.F32:
+                        MamaFieldCacheFloat32 mfcf32 = (MamaFieldCacheFloat32) 
+                                            myFieldCache.find (field.getFid());
+                        print ("" + mfcf32.get(), 20);
+                        break;
+                    case MamaFieldDescriptor.F64:
+                        MamaFieldCacheFloat64 mfcf64 = (MamaFieldCacheFloat64) 
+                                            myFieldCache.find (field.getFid());
+                        print ("" + mfcf64.get(), 20);
+                        break;
+                    case MamaFieldDescriptor.STRING:
+                        MamaFieldCacheString mfcs = (MamaFieldCacheString) 
+                                            myFieldCache.find (field.getFid());
+                        print (mfcs.get(), 20);
+                        break;
+                    case MamaFieldDescriptor.TIME:
+                        MamaFieldCacheDateTime mfcdt = (MamaFieldCacheDateTime) 
+                                            myFieldCache.find (field.getFid());
+                        print ("" + mfcdt.get(), 20);
+                        break;
+                    case MamaFieldDescriptor.PRICE:
+                        MamaFieldCachePrice mfcp = (MamaFieldCachePrice) 
+                                            myFieldCache.find (field.getFid());
+                        print ("" + mfcp.get(), 20);
+                        break;
+                    default:
+                        print ("Unknown type: " + fieldType, 20);
+                }
+            }
+
+            /*Access the data from the message object - random access*/
+            private void printUsingName (MamaMsgField field)
+            {                
+                short fieldType = field.getType();
+                switch (fieldType)
+                {
+                    case MamaFieldDescriptor.BOOL:
+                        MamaFieldCacheBool mfcb = (MamaFieldCacheBool) 
+                                            myFieldCache.find (field.getName());
+                        print ("" + mfcb.get(), 20);
+                        break;
+                    case MamaFieldDescriptor.CHAR:
+                        MamaFieldCacheChar mfcc = (MamaFieldCacheChar) 
+                                            myFieldCache.find (field.getName());
+                        print ("" + mfcc.get(), 20);
+                        break;
+                    case MamaFieldDescriptor.I8:
+                        MamaFieldCacheInt8 mfci8 = (MamaFieldCacheInt8) 
+                                            myFieldCache.find (field.getName());
+                        print ("" + mfci8.get(), 20);
+                        break;
+                    case MamaFieldDescriptor.U8:
+                        MamaFieldCacheUint8 mfcui8 = (MamaFieldCacheUint8) 
+                                            myFieldCache.find (field.getName());
+                        print ("" + mfcui8.get(), 20);
+                        break;
+                    case MamaFieldDescriptor.I16:
+                        MamaFieldCacheInt16 mfci16 = (MamaFieldCacheInt16) 
+                                            myFieldCache.find (field.getName());
+                        print ("" + mfci16.get(), 20);
+                        break;
+                    case MamaFieldDescriptor.U16:
+                        MamaFieldCacheUint16 mfcui16 = (MamaFieldCacheUint16) 
+                                            myFieldCache.find (field.getName());
+                        print ("" + mfcui16.get(), 20);
+                        break;
+                    case MamaFieldDescriptor.I32:
+                        MamaFieldCacheInt32 mfci32 = (MamaFieldCacheInt32) 
+                                            myFieldCache.find (field.getName());
+                        print ("" + mfci32.get(), 20);
+                        break;
+                    case MamaFieldDescriptor.U32:
+                        MamaFieldCacheUint32 mfcui32 = (MamaFieldCacheUint32) 
+                                            myFieldCache.find (field.getName());
+                        print ("" + mfcui32.get(), 20);
+                        break;
+                    case MamaFieldDescriptor.I64:
+                        MamaFieldCacheInt64 mfci64 = (MamaFieldCacheInt64) 
+                                            myFieldCache.find (field.getName());
+                        print ("" + mfci64.get(), 20);
+                        break;
+                    case MamaFieldDescriptor.U64:
+                        MamaFieldCacheUint64 mfcui64 = (MamaFieldCacheUint64) 
+                                            myFieldCache.find (field.getName());
+                        print ("" + mfcui64.get(), 20);
+                        break;
+                    case MamaFieldDescriptor.F32:
+                        MamaFieldCacheFloat32 mfcf32 = (MamaFieldCacheFloat32) 
+                                            myFieldCache.find (field.getName());
+                        print ("" + mfcf32.get(), 20);
+                        break;
+                    case MamaFieldDescriptor.F64:
+                        MamaFieldCacheFloat64 mfcf64 = (MamaFieldCacheFloat64) 
+                                            myFieldCache.find (field.getName());
+                        print ("" + mfcf64.get(), 20);
+                        break;
+                    case MamaFieldDescriptor.STRING:
+                        MamaFieldCacheString mfcs = (MamaFieldCacheString) 
+                                            myFieldCache.find (field.getName());
+                        print (mfcs.get(), 20);
+                        break;
+                    case MamaFieldDescriptor.TIME:
+                        MamaFieldCacheDateTime mfcdt = (MamaFieldCacheDateTime) 
+                                            myFieldCache.find (field.getName());
+                        print ("" + mfcdt.get(), 20);
+                        break;
+                    case MamaFieldDescriptor.PRICE:
+                        MamaFieldCachePrice mfcp = (MamaFieldCachePrice) 
+                                            myFieldCache.find (field.getName());
+                        print ("" + mfcp.get(), 20);
+                        break;
+                    default:
+                        print ("Unknown type: " + fieldType, 20);
+                }              
+            }
+        }
+
+        /* Class for processing fields and asserting the value of the cache 
+         * against the feed*/
+        private class FieldAsserter implements MamaMsgFieldIterator
+        {
+            public void onField (MamaMsg        msg,
+                                 MamaMsgField   field,
+                                 MamaDictionary dictionary,
+                                 Object         closure)
+            { 
+                try
+                {
+                    assertField (field);
+                }
+                catch (Exception ex)
+                {
+                    ex.printStackTrace();
+                }                
+            }
+            
+            /* Assert the data from the snapshot message against the cache*/
+            private void assertField (MamaMsgField field)
+            {
+                short fieldType = field.getType ();
+                if (field.getFid () == MamaReservedFields.MsgType.getId() ||
+                    field.getFid () == MamaReservedFields.AppMsgType.getId())
+                {
+                    return;
+                }
+                
+                switch (fieldType)
+                {
+                    case MamaFieldDescriptor.BOOL:
+                         MamaFieldCacheBool mfcb = (MamaFieldCacheBool) 
+                                            myFieldCache.find (field.getFid());
+                         if (mfcb.get() != field.getBoolean())   
+                            failedField = failedField + " " + field.getName();                            
+                         break;
+                    case MamaFieldDescriptor.CHAR:
+                         MamaFieldCacheChar mfcc = (MamaFieldCacheChar) 
+                                            myFieldCache.find (field.getFid());
+                         if (mfcc.get() != field.getChar())
+                            failedField = failedField + " " + field.getName();                            
+                         break;
+                    case MamaFieldDescriptor.I8:
+                         MamaFieldCacheInt8 mfci8 = (MamaFieldCacheInt8) 
+                                            myFieldCache.find (field.getFid());
+                         if (mfci8.get() != field.getI8())
+                            failedField = failedField + " " + field.getName();                            
+                         break;
+                    case MamaFieldDescriptor.U8:
+                         MamaFieldCacheUint8 mfcui8 = (MamaFieldCacheUint8) 
+                                            myFieldCache.find (field.getFid());
+                         if (mfcui8.get() != field.getU8())
+                            failedField = failedField + " " + field.getName();                            
+                         break;
+                    case MamaFieldDescriptor.I16:
+                         MamaFieldCacheInt16 mfci16 = (MamaFieldCacheInt16) 
+                                            myFieldCache.find (field.getFid());
+                         if (mfci16.get() != field.getI16())             
+                            failedField = failedField + " " + field.getName();
+                         break;
+                    case MamaFieldDescriptor.U16:
+                         MamaFieldCacheUint16 mfcui16 = (MamaFieldCacheUint16) 
+                                            myFieldCache.find (field.getFid());
+                         if (mfcui16.get() != field.getU16())
+                           failedField = failedField + " " + field.getName();
+                         break;
+                    case MamaFieldDescriptor.I32:
+                         MamaFieldCacheInt32 mfci32 = (MamaFieldCacheInt32) 
+                                            myFieldCache.find (field.getFid());
+                         if (mfci32.get() != field.getI32())
+                            failedField = failedField + " " + field.getName();                         
+                        break;
+                    case MamaFieldDescriptor.U32:
+                         MamaFieldCacheUint32 mfcui32 = (MamaFieldCacheUint32) 
+                                            myFieldCache.find (field.getFid()); 
+                 
+                         if (mfcui32.get() != field.getU32())
+                         failedField = failedField + " " + field.getName();                            
+                         break;
+                    case MamaFieldDescriptor.I64:
+                         MamaFieldCacheInt64 mfci64 = (MamaFieldCacheInt64) 
+                                            myFieldCache.find (field.getFid());
+                         if (mfci64.get() != field.getI64())
+                             failedField = failedField + " " + field.getName();                            
+                         break;
+                    case MamaFieldDescriptor.U64:
+                         MamaFieldCacheUint64 mfcui64 = (MamaFieldCacheUint64) 
+                                            myFieldCache.find (field.getFid());
+                         if (mfcui64.get() != field.getU64())
+                            failedField = failedField + " " + field.getName();                            
+                         break;
+                    case MamaFieldDescriptor.F32:
+                         MamaFieldCacheFloat32 mfcf32 = (MamaFieldCacheFloat32) 
+                                            myFieldCache.find (field.getFid());
+                         if (mfcf32.get() != field.getF32())
+                            failedField = failedField + " " + field.getName();                            
+                         break;
+                    case MamaFieldDescriptor.F64:
+                         MamaFieldCacheFloat64 mfcf64 = (MamaFieldCacheFloat64) 
+                                            myFieldCache.find (field.getFid());
+                         if (mfcf64.get() != field.getF64())
+                            failedField = failedField + " " + field.getName();                            
+                         break;
+                    case MamaFieldDescriptor.STRING:
+                         MamaFieldCacheString mfcs = (MamaFieldCacheString) 
+                                            myFieldCache.find (field.getFid());
+                         if (!mfcs.get().equals (field.getString()))
+                            failedField = failedField + " " + field.getName();
+                         break;
+                    case MamaFieldDescriptor.TIME:
+                         MamaFieldCacheDateTime mfcdt = (MamaFieldCacheDateTime)
+                                            myFieldCache.find (field.getFid());
+                         if (!mfcdt.get().equals (field.getDateTime()))
+                            failedField = failedField + " " + field.getName();                        
+                         break;
+                    case MamaFieldDescriptor.PRICE:
+                         MamaFieldCachePrice mfcp = (MamaFieldCachePrice) 
+                                            myFieldCache.find (field.getFid());
+                         if (!mfcp.get().equals (field.getPrice()))
+                            failedField = failedField + " " + field.getName();                            
+                        break;
+                    default:
+                        print ("Unknown type: " + fieldType, 20);    
+                }                        
+            }
+        }        
+      
+        private synchronized void displayAllFields(
+                final MamaSubscription subscription,
+                final MamaMsg          msg )
+        {   
+             if (quietness < 1)
+             {
+                  System.out.println (subscription.getSymbol () +
+                         " Type: " + MamaMsgType.stringForType (msg) +
+                         " Status: " + MamaMsgStatus.stringForStatus (msg));       
+             }
+             
+             if (quietness < 2)
+             {
+                if (printUsingFid || printUsingName)
+                {
+                    msg.iterateFields (new FieldIterator(), dictionary, "Closure");    
+                }
+                
+                Iterator fieldCacheIterator = myFieldCache.getIterator ();
+                while (fieldCacheIterator.hasNext())
+                {
+                    MamaFieldCacheField myField = (MamaFieldCacheField)
+                                                    fieldCacheIterator.next();
+                    MamaFieldDescriptor myDesc  = myField.getDescriptor();
+                    print (" \t ", 0);
+                    print (myDesc.getName(),20);
+                    print (" | ", 0);
+                    print ("" + myDesc.getFid(),4);
+                    print (" | ", 0);
+                    print ("" + myDesc.getTypeName(myDesc.getType()),10);
+                    print (" | ", 0);
+                    print ("" + myField.getAsString(), 20);
+                    print (" \n ", 0);                    
+                }
+             }
+        }
+
+        /*Invoked once the subscrption request has been dispatched from the
+         * throttle queue.*/
+        public void onCreate (MamaSubscription subscription)
+        {
+            subscriptions.add (subscription);  
+        }
+
+        /*Invoked if any errors are encountered during subscription processing*/
+        public void onError(MamaSubscription subscription,
+                            short            mamaStatus,
+                            int              tibrvStatus, 
+                            String           subject, 
+                            Exception        e)
+        {
+            System.err.println ("Symbol=[" + subscription.getSymbol() + "] : " +
+                                "An error occurred creating subscription: " +
+                                MamaStatus.stringForStatus (mamaStatus));
+
+        }
+
+        /*Invoked if the quality status for the subscription changes*/
+        public void onQuality (MamaSubscription subscription, short quality,
+                               short cause, final Object platformInfo)
+        {
+            System.err.println( subscription.getSymbol () + 
+                                ": quality is now " +
+                                MamaQuality.toString (quality) +
+                                ", cause " + cause + 
+                                ", platformInfo: " + platformInfo);
+        }
+        public void onGap (MamaSubscription subscription)
+        {
+            System.err.println (subscription.getSymbol () + ": gap detected ");
+        }
+            
+        public void onRecapRequest (MamaSubscription subscription)
+        {
+            System.err.println (subscription.getSymbol () + ": recap requested ");
+        }
+
+        public void onDestroy(MamaSubscription mamaSub)
+        {
+            System.out.println("SUBSCRIPTION DESTROYED!");
+        }
+    }
+    
+    /* Callback used to verify the data in the fieldcache against the feed*/
+    private static class VerifyCallback implements MamaTimerCallback
+    {
+        SubscriptionCallback myCallback;
+        String mySymbol;
+        
+        public VerifyCallback (SubscriptionCallback callback,String symbol)
+        {
+            myCallback = callback;
+            mySymbol   = symbol;
+        }
+        
+        public synchronized void onTimer (MamaTimer timer)
+        {
+            MamaSubscription subscription = new MamaSubscription ();
+                           
+            //Properties common to all subscription types
+            subscription.setTimeout (timeout);
+            subscription.setRetries (1);                                
+            subscription.createSnapshotSubscription (
+                                                    myCallback,
+                                                    queueGroup.getNextQueue (),
+                                                    mySource,
+                                                    mySymbol,
+                                                    null);                     
+        }
+
+        public void onDestroy(MamaTimer mamaTimer)
+        {
+            System.out.println("TIMER DESTROYED!");
+        }
+    }
+}

--- a/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/Main.java
+++ b/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/Main.java
@@ -1,0 +1,81 @@
+/* $Id$
+ *
+ * OpenMAMA: The open middleware agnostic messaging API
+ * Copyright (C) 2011 NYSE Technologies, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+import junit.framework.Test;
+import junit.framework.TestSuite;
+import com.wombat.mama.*;
+
+public class Main
+{
+    private static MamaBridge mbridge;
+
+    public static MamaBridge GetBridge()
+    {
+        return mbridge;
+    }
+
+    public static Test suite()
+    {
+        // Create a new test suite
+        TestSuite suite = new TestSuite();
+
+        // Add all tests
+        suite.addTestSuite(MamaFieldCacheBoolTest.class);
+        suite.addTestSuite(MamaFieldCacheCharTest.class);
+        suite.addTestSuite(MamaFieldCacheDateTimeTest.class);
+        suite.addTestSuite(MamaFieldCacheEnumTest.class);
+        suite.addTestSuite(MamaFieldCacheFloat32Test.class);
+        suite.addTestSuite(MamaFieldCacheFloat64Test.class);
+        suite.addTestSuite(MamaFieldCacheStringTest.class);
+        suite.addTestSuite(MamaFieldCacheUint16Test.class);
+        suite.addTestSuite(MamaFieldCacheUint32Test.class);
+        suite.addTestSuite(MamaFieldCacheUint64Test.class);
+        suite.addTestSuite(MamaFieldCacheUint8Test.class);
+        suite.addTestSuite(MamaFieldCacheInt16Test.class);
+        suite.addTestSuite(MamaFieldCacheInt32Test.class);
+        suite.addTestSuite(MamaFieldCacheInt64Test.class);
+        suite.addTestSuite(MamaFieldCacheInt8Test.class);
+        suite.addTestSuite(MamaFieldCachePriceTest.class);
+        suite.addTestSuite(MamaFieldCacheFieldTest.class);
+        suite.addTestSuite(MamaFieldCacheFieldListTest.class);
+        suite.addTestSuite(MamaFieldCachePropertiesTest.class);
+        suite.addTestSuite(MamaFieldCacheTest.class);
+
+        return suite;
+    }
+
+    public static void main(String[] args)
+    {
+        // Open mama to satisfy all link references
+        mbridge = Mama.loadBridge("wmw");
+
+        /*Always the first API method called. Initialized internal API
+         * state*/
+        Mama.open ();
+
+        // Run the test suite
+        junit.textui.TestRunner.run(suite());
+
+        // Close mama
+        Mama.close();
+    }
+
+}

--- a/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCacheBoolTest.java
+++ b/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCacheBoolTest.java
@@ -1,0 +1,163 @@
+/* $Id$
+ *
+ * OpenMAMA: The open middleware agnostic messaging API
+ * Copyright (C) 2011 NYSE Technologies, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+import junit.framework.*;
+import com.wombat.mama.*;
+
+/**
+ *
+ * This class will test MamaFieldCacheBool's functions
+ */
+public class MamaFieldCacheBoolTest extends TestCase
+{
+    /* ****************************************************** */
+    /* Protected Member Variables. */
+    /* ****************************************************** */
+    
+    protected MamaMsg mMsg;
+    protected MamaFieldCacheBool mFieldCacheBool;
+
+    /* ****************************************************** */
+    /* Protected Functions. */
+    /* ****************************************************** */
+
+    @Override
+    protected void setUp()
+    {
+        mFieldCacheBool = new MamaFieldCacheBool(101, "example", true);
+        mMsg = new MamaMsg();   
+    }
+
+    @Override
+    protected void tearDown()
+    {
+    }
+
+    /* ****************************************************** */
+    /* Test Functions. */
+    /* ****************************************************** */
+
+    public void testAddToMessage()
+    {
+        //set the value of the field to true (the default, otherwise, is false
+        mFieldCacheBool.set(true);
+        //add it to the message
+        mFieldCacheBool.addToMessage(false, mMsg);
+        //check we can get the value of true returned to us when searching for the field
+        assertTrue(mMsg.getBoolean("example", 101));
+    }
+
+    public void testAddToMessagefieldName()
+    {
+        //set the value of the field to true (the default, otherwise, is false
+        mFieldCacheBool.set(true);
+        //add it to the message
+        mFieldCacheBool.addToMessage(true, mMsg);
+        //check we can get the value of true returned to us when searching for the field
+        assertTrue(mMsg.getBoolean("example", 101));
+    }
+
+    public void testCopy()
+    {
+        MamaFieldCacheField copyCache =  mFieldCacheBool.copy();
+        assertEquals(mFieldCacheBool.getAsString(), copyCache.getAsString());
+    }
+
+    public void testApplyMsgField()
+    {
+        MamaFieldCacheBool testCacheBool = new MamaFieldCacheBool(102, "example2", true);
+        testCacheBool.set(true);
+        assertTrue(testCacheBool.get());
+        assertFalse(mFieldCacheBool.get());
+        mFieldCacheBool.apply(testCacheBool);
+        assertTrue(mFieldCacheBool.get());
+    }
+
+    public void testApplyFieldCache()
+    {
+       MamaFieldCacheBool testField  = new MamaFieldCacheBool(102, "example2", true);
+       testField.set(true);
+       mFieldCacheBool.apply(testField);
+       assertTrue(mFieldCacheBool.get());
+    }
+
+
+    public void testSet()
+    {
+        MamaFieldCacheBool testCacheBool = new MamaFieldCacheBool(102, "example2", false);
+
+        assertFalse(testCacheBool.get());
+        testCacheBool.set(false);
+        //unset without track state
+        assertFalse(testCacheBool.get());
+
+        assertEquals(MamaFieldCacheField.MOD_STATE_MODIFIED, testCacheBool.getModState());
+
+        assertFalse(testCacheBool.get());
+        testCacheBool.set(true);
+        //set without track state
+        assertTrue(testCacheBool.get());
+
+        assertEquals(MamaFieldCacheField.MOD_STATE_MODIFIED, testCacheBool.getModState());
+
+    }
+
+    public void testSetTrackState()
+    {
+        assertFalse(mFieldCacheBool.get());
+        mFieldCacheBool.set(false);
+        //unset with track state
+        assertFalse(mFieldCacheBool.get());
+        assertEquals(MamaFieldCacheField.MOD_STATE_TOUCHED, mFieldCacheBool.getModState());
+
+        assertFalse(mFieldCacheBool.get());
+        mFieldCacheBool.set(true);
+        //set with track state
+        assertTrue(mFieldCacheBool.get());
+        assertEquals(MamaFieldCacheField.MOD_STATE_MODIFIED, mFieldCacheBool.getModState());
+    }
+
+    public void testIsEqual()
+    {   
+        MamaFieldCacheBool testCacheBool = new MamaFieldCacheBool(102, "example2", true);
+        testCacheBool.set(true);
+        mFieldCacheBool.set(true);
+        assertTrue(testCacheBool.get());
+        assertTrue(mFieldCacheBool.get());
+        assertTrue(testCacheBool.isEqual(mFieldCacheBool.get()));
+    }
+
+    public void testGet()
+    {
+        assertFalse(mFieldCacheBool.get());
+        mFieldCacheBool.set(true);
+        assertTrue(mFieldCacheBool.get());
+    }
+
+    public void testGetAsString()
+    {
+        assertFalse(mFieldCacheBool.get());
+        assertEquals("false", mFieldCacheBool.getAsString());
+        mFieldCacheBool.set(true);
+        assertTrue(mFieldCacheBool.get());
+        assertEquals("true", mFieldCacheBool.getAsString());
+    }
+}

--- a/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCacheCharTest.java
+++ b/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCacheCharTest.java
@@ -1,0 +1,164 @@
+/* $Id$
+ *
+ * OpenMAMA: The open middleware agnostic messaging API
+ * Copyright (C) 2011 NYSE Technologies, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+
+import junit.framework.*;
+import com.wombat.mama.*;
+
+/**
+ *
+ * This class will test MamaFieldCacheChar's functions
+ */
+public class MamaFieldCacheCharTest extends TestCase
+{
+    /* ****************************************************** */
+    /* Protected Member Variables. */
+    /* ****************************************************** */
+    
+    protected MamaMsg mMsg;
+    protected MamaFieldCacheChar mFieldCacheChar;
+
+    /* ****************************************************** */
+    /* Protected Functions. */
+    /* ****************************************************** */
+
+    @Override
+    protected void setUp()
+    {
+        mFieldCacheChar = new MamaFieldCacheChar(101, "example", true);
+        mMsg = new MamaMsg();   
+    }
+
+    @Override
+    protected void tearDown()
+    {
+    }
+
+    /* ****************************************************** */
+    /* Test Functions. */
+    /* ****************************************************** */
+
+    public void testAddToMessage()
+    {
+        //set the value of the field to true (the default, otherwise, is false
+        mFieldCacheChar.set('a');
+        //add it to the message
+        mFieldCacheChar.addToMessage(false, mMsg);
+        //check we can get the value of true returned to us when searching for the field
+        assertEquals(mMsg.getChar("example", 101), 'a');
+    }
+
+    public void testAddToMessagefieldName()
+    {
+        //set the value of the field to true (the default, otherwise, is false
+        mFieldCacheChar.set('a');
+        //add it to the message
+        mFieldCacheChar.addToMessage(true, mMsg);
+        //check we can get the value of true returned to us when searching for the field
+        assertEquals(mMsg.getChar("example", 101), 'a');
+    }
+
+    public void testCopy()
+    {
+        MamaFieldCacheField copyCache =  mFieldCacheChar.copy();
+        assertEquals(mFieldCacheChar.getAsString(), copyCache.getAsString());
+    }
+
+    public void testApplyMsgField()
+    {
+        MamaFieldCacheChar testCacheChar = new MamaFieldCacheChar(102, "example2", true);
+        mFieldCacheChar.set('b');
+        testCacheChar.set('a');
+        assertEquals(testCacheChar.get(), 'a');
+        assertEquals(mFieldCacheChar.get(), 'b');
+        mFieldCacheChar.apply(testCacheChar);
+        assertEquals(mFieldCacheChar.get(), 'a');
+    }
+
+    public void testApplyFieldCache()
+    {
+       MamaFieldCacheChar testField  = new MamaFieldCacheChar(102, "example2", true);
+       testField.set('a');
+       mFieldCacheChar.apply(testField);
+       assertEquals(mFieldCacheChar.get(), 'a');
+    }
+
+
+    public void testSet()
+    {
+        MamaFieldCacheChar testCacheChar = new MamaFieldCacheChar(102, "example2", false);
+
+        assertEquals(testCacheChar.get(), '\0');
+        testCacheChar.set('a');
+        //set without track state
+        assertEquals(testCacheChar.get(), 'a');
+
+        assertEquals(MamaFieldCacheField.MOD_STATE_MODIFIED, testCacheChar.getModState());
+
+    }
+
+    public void testSetTrackState()
+    {
+        assertEquals(mFieldCacheChar.get(), '\0');
+        mFieldCacheChar.set('a');
+        //set with track state
+        assertEquals(mFieldCacheChar.get(), 'a');
+        assertEquals(MamaFieldCacheField.MOD_STATE_MODIFIED, mFieldCacheChar.getModState());
+    }
+
+    public void testSetTrackStateTouched()
+    {
+    
+        assertEquals(mFieldCacheChar.get(), '\0');
+        mFieldCacheChar.set('a');
+        mFieldCacheChar.set('a');
+        //set with track state
+        assertEquals(mFieldCacheChar.get(), 'a');
+        assertEquals(MamaFieldCacheField.MOD_STATE_TOUCHED, mFieldCacheChar.getModState());
+
+    }
+
+    public void testIsEqual()
+    {   
+        MamaFieldCacheChar testCacheChar = new MamaFieldCacheChar(102, "example2", true);
+        testCacheChar.set('a');
+        mFieldCacheChar.set('a');
+        assertEquals(testCacheChar.get(), 'a');
+        assertEquals(mFieldCacheChar.get(), 'a');
+        assertTrue(testCacheChar.isEqual(mFieldCacheChar.get()));
+    }
+
+    public void testGet()
+    {
+        assertEquals(mFieldCacheChar.get(), '\0');
+        mFieldCacheChar.set('a');
+        assertEquals(mFieldCacheChar.get(), 'a');
+    }
+
+    public void testGetAsString()
+    {
+        assertEquals(mFieldCacheChar.get(), '\0');
+        assertEquals("\0", mFieldCacheChar.getAsString());
+        mFieldCacheChar.set('a');
+        assertEquals(mFieldCacheChar.get(), 'a');
+        assertEquals("a", mFieldCacheChar.getAsString());
+    }
+}

--- a/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCacheDateTimeTest.java
+++ b/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCacheDateTimeTest.java
@@ -1,0 +1,169 @@
+/* $Id$
+ *
+ * OpenMAMA: The open middleware agnostic messaging API
+ * Copyright (C) 2011 NYSE Technologies, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+
+import junit.framework.*;
+import com.wombat.mama.*;
+import java.util.TimeZone;
+
+/**
+ *
+ * This class will test MamaFieldCacheDateTime's functions
+ */
+public class MamaFieldCacheDateTimeTest extends TestCase
+{
+    /* ****************************************************** */
+    /* Protected Member Variables. */
+    /* ****************************************************** */
+    
+    protected MamaMsg mMsg;
+    protected MamaFieldCacheDateTime mFieldCacheDateTime;
+    protected MamaDateTime mdateTime;
+    protected MamaTimeZone mtimeZone;
+    protected String nineAM = "09:00:00";
+    protected String tenAM  = "10:00:00";
+    /* ****************************************************** */
+    /* Protected Functions. */
+    /* ****************************************************** */
+
+    @Override
+    protected void setUp()
+    {
+        mFieldCacheDateTime = new MamaFieldCacheDateTime(101, "example", true);
+        mdateTime = new MamaDateTime();
+        mtimeZone = new MamaTimeZone ();
+        mtimeZone = mtimeZone.utc();
+        mdateTime.setTime(9,0,0,0L, MamaDateTimePrecision.PREC_SECONDS, mtimeZone);
+        mMsg = new MamaMsg(); 
+    }
+
+    @Override
+    protected void tearDown()
+    {
+    }
+
+    /* ****************************************************** */
+    /* Test Functions. */
+    /* ****************************************************** */
+
+    public void testAddToMessage()
+    {
+        mFieldCacheDateTime.set(mdateTime);
+        //add it to the message
+        mFieldCacheDateTime.addToMessage(false, mMsg);
+        //check we can get the value of true returned to us when searching for the field
+        assertEquals(mMsg.getDateTime("example", 101).getAsString(), "09:00:00");
+    }
+
+    public void testAddToMessagefieldName()
+    {
+        mFieldCacheDateTime.set(mdateTime);
+        //add it to the message
+        mFieldCacheDateTime.addToMessage(true, mMsg);
+        //check we can get the value of true returned to us when searching for the field
+        assertEquals(mMsg.getDateTime("example", 101).getAsString(), "09:00:00");
+    }
+
+    public void testCopy()
+    {
+        mFieldCacheDateTime.set(mdateTime);
+        MamaFieldCacheField copyCache =  mFieldCacheDateTime.copy();
+        assertEquals(mFieldCacheDateTime.getAsString(), copyCache.getAsString());
+    }
+
+    public void testApplyMsgField()
+    {
+        MamaFieldCacheDateTime testCacheDateTime = new MamaFieldCacheDateTime(102, "example2", true);
+        mFieldCacheDateTime.set(mdateTime);
+        
+        mdateTime.setTime(10,0,0,0L, MamaDateTimePrecision.PREC_SECONDS, mtimeZone);
+        testCacheDateTime.set(mdateTime);
+        assertEquals(testCacheDateTime.get().getAsString(), tenAM);
+        assertEquals(mFieldCacheDateTime.get().getAsString(), nineAM);
+        mFieldCacheDateTime.apply(testCacheDateTime);
+        assertEquals(mFieldCacheDateTime.get().getAsString(), tenAM);
+    }
+
+    public void testApplyFieldCache()
+    {
+       MamaFieldCacheDateTime testField  = new MamaFieldCacheDateTime(102, "example2", true);
+       testField.set(mdateTime);
+       mFieldCacheDateTime.apply(testField);
+       assertEquals(mFieldCacheDateTime.get().getAsString(), nineAM);
+    }
+
+
+    public void testSet()
+    {
+        MamaFieldCacheDateTime testCacheDateTime = new MamaFieldCacheDateTime(102, "example2", false);
+        assertEquals(testCacheDateTime.get(), null);
+        testCacheDateTime.set(mdateTime);
+        //set without track state
+        assertEquals(testCacheDateTime.get().getAsString(), nineAM);
+
+        assertEquals(MamaFieldCacheField.MOD_STATE_MODIFIED, testCacheDateTime.getModState());
+    }
+
+    public void testSetTrackState()
+    {
+        assertEquals(mFieldCacheDateTime.get(), null);
+        mFieldCacheDateTime.set(mdateTime);
+        //set with track state
+        assertEquals(mFieldCacheDateTime.get().getAsString(), nineAM);
+        assertEquals(MamaFieldCacheField.MOD_STATE_MODIFIED, mFieldCacheDateTime.getModState());
+    }
+
+    public void testSetTrackStateTouched()
+    {
+        assertEquals(mFieldCacheDateTime.get(), null);
+        mFieldCacheDateTime.set(mdateTime);
+        mFieldCacheDateTime.set(mdateTime);
+        //set with track state
+        assertEquals(mFieldCacheDateTime.get().getAsString(), nineAM);
+        assertEquals(MamaFieldCacheField.MOD_STATE_MODIFIED, mFieldCacheDateTime.getModState());
+
+    }
+
+    public void testIsEqual()
+    {   
+        MamaFieldCacheDateTime testCacheDateTime = new MamaFieldCacheDateTime(102, "example2", true);
+        testCacheDateTime.set(mdateTime);
+        mFieldCacheDateTime.set(mdateTime);
+        assertEquals(testCacheDateTime.get().getAsString(), nineAM);
+        assertEquals(mFieldCacheDateTime.get().getAsString(), nineAM);
+        assertTrue(testCacheDateTime.isEqual(mFieldCacheDateTime.get()));
+    }
+
+    public void testGet()
+    {
+        assertEquals(mFieldCacheDateTime.get(), null);
+        mFieldCacheDateTime.set(mdateTime);
+        assertEquals(mFieldCacheDateTime.get().getAsString(), nineAM);
+    }
+
+    public void testGetAsString()
+    {
+        assertEquals(mFieldCacheDateTime.get(), null);
+        assertEquals("null", mFieldCacheDateTime.getAsString());
+        mFieldCacheDateTime.set(mdateTime);
+        assertEquals(mFieldCacheDateTime.get().getAsString(), nineAM);
+    }
+}

--- a/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCacheEnumTest.java
+++ b/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCacheEnumTest.java
@@ -1,0 +1,164 @@
+
+/* $Id$
+ *
+ * OpenMAMA: The open middleware agnostic messaging API
+ * Copyright (C) 2011 NYSE Technologies, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+import junit.framework.*;
+import com.wombat.mama.*;
+
+/**
+ *
+ * This class will test MamaFieldCacheEnum's functions
+ */
+public class MamaFieldCacheEnumTest extends TestCase
+{
+    /* ****************************************************** */
+    /* Protected Member Variables. */
+    /* ****************************************************** */
+    
+    protected MamaMsg mMsg;
+    protected MamaFieldCacheEnum mFieldCacheEnum;
+
+    /* ****************************************************** */
+    /* Protected Functions. */
+    /* ****************************************************** */
+
+    @Override
+    protected void setUp()
+    {
+        mFieldCacheEnum = new MamaFieldCacheEnum(101, "example", true);
+        mMsg = new MamaMsg();   
+    }
+
+    @Override
+    protected void tearDown()
+    {
+    }
+
+    /* ****************************************************** */
+    /* Test Functions. */
+    /* ****************************************************** */
+
+    public void testAddToMessage()
+    {
+        //set the value of the field to true (the default, otherwise, is false
+        mFieldCacheEnum.set(1);
+        //add it to the message
+        mFieldCacheEnum.addToMessage(false, mMsg);
+        //check we can get the value of true returned to us when searching for the field
+        assertEquals(mMsg.getI32("example", 101), 1);
+    }
+
+    public void testAddToMessagefieldName()
+    {
+        //set the value of the field to true (the default, otherwise, is false
+        mFieldCacheEnum.set(1);
+        //add it to the message
+        mFieldCacheEnum.addToMessage(true, mMsg);
+        //check we can get the value of true returned to us when searching for the field
+        assertEquals(mMsg.getI32("example", 101), 1);
+    }
+
+    public void testCopy()
+    {
+        MamaFieldCacheField copyCache =  mFieldCacheEnum.copy();
+        assertEquals(mFieldCacheEnum.getAsString(), copyCache.getAsString());
+    }
+
+    public void testApplyMsgField()
+    {
+        MamaFieldCacheEnum testCacheEnum = new MamaFieldCacheEnum(102, "example2", true);
+        mFieldCacheEnum.set(2);
+        testCacheEnum.set(1);
+        assertEquals(testCacheEnum.get(), 1);
+        assertEquals(mFieldCacheEnum.get(), 2);
+        mFieldCacheEnum.apply(testCacheEnum);
+        assertEquals(mFieldCacheEnum.get(), 1);
+    }
+
+    public void testApplyFieldCache()
+    {
+       MamaFieldCacheEnum testField  = new MamaFieldCacheEnum(102, "example2", true);
+       testField.set(1);
+       mFieldCacheEnum.apply(testField);
+       assertEquals(mFieldCacheEnum.get(), 1);
+    }
+
+
+    public void testSet()
+    {
+        MamaFieldCacheEnum testCacheEnum = new MamaFieldCacheEnum(102, "example2", false);
+
+        assertEquals(testCacheEnum.get(), 0);
+        testCacheEnum.set(1);
+        //set without track state
+        assertEquals(testCacheEnum.get(), 1);
+
+        assertEquals(MamaFieldCacheField.MOD_STATE_MODIFIED, testCacheEnum.getModState());
+
+    }
+
+    public void testSetTrackState()
+    {
+        assertEquals(mFieldCacheEnum.get(), 0);
+        mFieldCacheEnum.set(1);
+        //set with track state
+        assertEquals(mFieldCacheEnum.get(), 1);
+        assertEquals(MamaFieldCacheField.MOD_STATE_MODIFIED, mFieldCacheEnum.getModState());
+    }
+
+    public void testSetTrackStateTouched()
+    {
+    
+        assertEquals(mFieldCacheEnum.get(), 0);
+        mFieldCacheEnum.set(1);
+        mFieldCacheEnum.set(1);
+        //set with track state
+        assertEquals(mFieldCacheEnum.get(), 1);
+        assertEquals(MamaFieldCacheField.MOD_STATE_TOUCHED, mFieldCacheEnum.getModState());
+
+    }
+
+    public void testIsEqual()
+    {   
+        MamaFieldCacheEnum testCacheEnum = new MamaFieldCacheEnum(102, "example2", true);
+        testCacheEnum.set(1);
+        mFieldCacheEnum.set(1);
+        assertEquals(testCacheEnum.get(), 1);
+        assertEquals(mFieldCacheEnum.get(), 1);
+        assertTrue(testCacheEnum.isEqual(mFieldCacheEnum.get()));
+    }
+
+    public void testGet()
+    {
+        assertEquals(mFieldCacheEnum.get(), 0);
+        mFieldCacheEnum.set(1);
+        assertEquals(mFieldCacheEnum.get(), 1);
+    }
+
+    public void testGetAsString()
+    {
+        assertEquals(mFieldCacheEnum.get(), 0);
+        assertEquals("0", mFieldCacheEnum.getAsString());
+        mFieldCacheEnum.set(1);
+        assertEquals(mFieldCacheEnum.get(), 1);
+        assertEquals("1", mFieldCacheEnum.getAsString());
+    }
+}

--- a/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCacheFieldListTest.java
+++ b/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCacheFieldListTest.java
@@ -1,0 +1,151 @@
+/* $Id$
+ *
+ * OpenMAMA: The open middleware agnostic messaging API
+ * Copyright (C) 2011 NYSE Technologies, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+import junit.framework.*;
+import com.wombat.mama.*;
+import java.util.Iterator;
+/**
+ *
+ * This class will test MamaFieldCacheFieldList's functions
+ */
+public class MamaFieldCacheFieldListTest extends TestCase
+{
+    /* ****************************************************** */
+    /* Protected Member Variables. */
+    /* ****************************************************** */
+    
+    protected MamaFieldCacheFieldList mFieldCacheFieldList;
+
+    /* ****************************************************** */
+    /* Protected Functions. */
+    /* ****************************************************** */
+
+    @Override
+    protected void setUp()
+    {
+        mFieldCacheFieldList = new MamaFieldCacheFieldList();
+    }
+
+    @Override
+    protected void tearDown()
+    {
+    }
+
+    /* ****************************************************** */
+    /* Test Functions. */
+    /* ****************************************************** */
+    
+    public void testClear()
+    {
+        MamaFieldCacheInt8 testField = new MamaFieldCacheInt8(101, "example", true);
+        mFieldCacheFieldList.add(testField);
+        assertEquals(mFieldCacheFieldList.find("example"), testField);
+        mFieldCacheFieldList.clear();
+        assertEquals(mFieldCacheFieldList.find("example"), null);
+    }
+
+    public void testClearAndDelete()
+    {
+        MamaFieldCacheInt8 testField = new MamaFieldCacheInt8(101, "example", true);
+        mFieldCacheFieldList.add(testField);
+        assertEquals(mFieldCacheFieldList.find("example"), testField);
+        mFieldCacheFieldList.clearAndDelete();
+        assertEquals(mFieldCacheFieldList.find("example"), null);
+    }
+
+    public void testAddIfModifiedNotModified()
+    {
+        MamaFieldCacheInt8 testField = new MamaFieldCacheInt8(101, "example", true);
+        testField.setModState(MamaFieldCacheField.MOD_STATE_NOT_MODIFIED);
+        mFieldCacheFieldList.addIfModified(testField);
+        assertEquals(mFieldCacheFieldList.find("example"), null); 
+    }
+
+    public void testAddIfModifiedModified()
+    {
+        MamaFieldCacheInt8 testField = new MamaFieldCacheInt8(101, "example", true);
+        mFieldCacheFieldList.addIfModified(testField);
+        assertEquals(mFieldCacheFieldList.find("example"), testField); 
+    }
+
+    public void testFind()
+    {
+        MamaFieldCacheInt8 testField = new MamaFieldCacheInt8(101, "example", true);
+        MamaFieldCacheInt8 testField2 = new MamaFieldCacheInt8(102, "example2", true);
+        mFieldCacheFieldList.add(testField);
+        mFieldCacheFieldList.add(testField2);
+        assertEquals(mFieldCacheFieldList.find("example"), testField); 
+        assertEquals(mFieldCacheFieldList.find("example2"), testField2); 
+    }
+
+    public void findByFid()
+    {
+        MamaFieldCacheInt8 testField = new MamaFieldCacheInt8(101, "example", true);
+        MamaFieldCacheInt8 testField2 = new MamaFieldCacheInt8(102, "example2", true);
+        mFieldCacheFieldList.add(testField);
+        mFieldCacheFieldList.add(testField2);
+        assertEquals(mFieldCacheFieldList.find(101), testField); 
+        assertEquals(mFieldCacheFieldList.find(102), testField2); 
+    }
+
+    public void findByDesc()
+    {
+        MamaFieldDescriptor desc = new MamaFieldDescriptor(101, (short) 38, "example", null);
+        MamaFieldDescriptor desc2 = new MamaFieldDescriptor(102, (short) 38, "example2", null);
+        MamaFieldCacheInt8 testField = new MamaFieldCacheInt8(101, "example", true);
+        MamaFieldCacheInt8 testField2 = new MamaFieldCacheInt8(102, "example2", true);
+        mFieldCacheFieldList.add(testField);
+        mFieldCacheFieldList.add(testField2);
+        assertEquals(mFieldCacheFieldList.find(desc), testField); 
+        assertEquals(mFieldCacheFieldList.find(desc2), testField2); 
+    }
+
+    public void testSize()
+    {
+        MamaFieldCacheInt8 testField = new MamaFieldCacheInt8(101, "example", true);
+        MamaFieldCacheInt8 testField2 = new MamaFieldCacheInt8(102, "example2", true);
+        assertEquals(mFieldCacheFieldList.size(), 0);
+        mFieldCacheFieldList.add(testField);
+        assertEquals(mFieldCacheFieldList.size(), 1);
+        mFieldCacheFieldList.add(testField2);
+        assertEquals(mFieldCacheFieldList.size(), 2);
+    }
+
+    public void testEmpty()
+    {
+        MamaFieldCacheInt8 testField = new MamaFieldCacheInt8(101, "example", true);
+        MamaFieldCacheInt8 testField2 = new MamaFieldCacheInt8(102, "example2", true);
+        assertTrue(mFieldCacheFieldList.empty());
+        mFieldCacheFieldList.add(testField);
+        assertFalse(mFieldCacheFieldList.empty());
+        mFieldCacheFieldList.add(testField2);
+        assertFalse(mFieldCacheFieldList.empty());
+    }
+
+    public void testGetIterator()
+    {
+        Iterator i;
+        MamaFieldCacheInt8 testField = new MamaFieldCacheInt8(101, "example", true);
+        mFieldCacheFieldList.add(testField);
+        i = mFieldCacheFieldList.getIterator();
+        assertTrue(i.hasNext());
+    }
+}

--- a/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCacheFieldTest.java
+++ b/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCacheFieldTest.java
@@ -1,0 +1,110 @@
+/* $Id$
+ *
+ * OpenMAMA: The open middleware agnostic messaging API
+ * Copyright (C) 2011 NYSE Technologies, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+import junit.framework.*;
+import com.wombat.mama.*;
+
+/**
+ *
+ * This class will test MamaFieldCacheField's functions - Implemented through Int32
+ */
+public class MamaFieldCacheFieldTest extends TestCase
+{
+    /* ****************************************************** */
+    /* Protected Member Variables. */
+    /* ****************************************************** */
+    
+    protected MamaMsg mMsg;
+    protected MamaFieldCacheInt32 mFieldCacheInt32;
+
+    /* ****************************************************** */
+    /* Protected Functions. */
+    /* ****************************************************** */
+
+    @Override
+    protected void setUp()
+    {
+        mFieldCacheInt32 = new MamaFieldCacheInt32(101, "example", true);
+
+        mMsg = new MamaMsg();   
+    }
+
+    @Override
+    protected void tearDown()
+    {
+    }
+
+    /* ****************************************************** */
+    /* Test Functions. */
+    /* ****************************************************** */
+    
+    public void testSetDescriptor()
+    {
+        MamaFieldDescriptor desc = new MamaFieldDescriptor(101, (short) 38, "example", null);
+        mFieldCacheInt32.setDescriptor(desc);
+        assertEquals(MamaFieldCacheField.MOD_STATE_MODIFIED, mFieldCacheInt32.getModState());
+        assertEquals(mFieldCacheInt32.getDescriptor(), desc);
+    }
+    
+    public void testGetType()
+    {
+        assertEquals(mFieldCacheInt32.getType(), MamaFieldDescriptor.I32);
+    }
+
+    public void testGetTrackModState()
+    {
+        assertTrue(mFieldCacheInt32.getTrackModState());
+    }
+
+    public void testSetTrackModState()
+    {
+        mFieldCacheInt32.setTrackModState(false);
+        assertFalse(mFieldCacheInt32.getTrackModState());
+    }
+
+    public void testClearModState()
+    {
+        mFieldCacheInt32.clearModState();
+        assertEquals(MamaFieldCacheField.MOD_STATE_NOT_MODIFIED, mFieldCacheInt32.getModState());
+    }
+
+    public void testIsUnmodified()
+    {
+        assertFalse(mFieldCacheInt32.isUnmodified());
+        mFieldCacheInt32.clearModState();
+        assertTrue(mFieldCacheInt32.isUnmodified());
+    }
+    
+    public void testIsModified()
+    {
+        assertTrue(mFieldCacheInt32.isModified());
+        mFieldCacheInt32.setModState(MamaFieldCacheField.MOD_STATE_NOT_MODIFIED);
+        assertFalse(mFieldCacheInt32.isModified());
+    }
+
+    public void testTouch()
+    {
+        assertFalse(mFieldCacheInt32.isTouched());
+        mFieldCacheInt32.clearModState();
+        mFieldCacheInt32.touch();
+        assertTrue(mFieldCacheInt32.isTouched());
+    }
+}

--- a/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCacheFloat32Test.java
+++ b/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCacheFloat32Test.java
@@ -1,0 +1,163 @@
+/* $Id$
+ *
+ * OpenMAMA: The open middleware agnostic messaging API
+ * Copyright (C) 2011 NYSE Technologies, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+import junit.framework.*;
+import com.wombat.mama.*;
+
+/**
+ *
+ * This class will test MamaFieldCacheFloat32's functions
+ */
+public class MamaFieldCacheFloat32Test extends TestCase
+{
+    /* ****************************************************** */
+    /* Protected Member Variables. */
+    /* ****************************************************** */
+    
+    protected MamaMsg mMsg;
+    protected MamaFieldCacheFloat32 mFieldCacheFloat32;
+
+    /* ****************************************************** */
+    /* Protected Functions. */
+    /* ****************************************************** */
+
+    @Override
+    protected void setUp()
+    {
+        mFieldCacheFloat32 = new MamaFieldCacheFloat32(101, "example", true);
+        mMsg = new MamaMsg();   
+    }
+
+    @Override
+    protected void tearDown()
+    {
+    }
+
+    /* ****************************************************** */
+    /* Test Functions. */
+    /* ****************************************************** */
+
+    public void testAddToMessage()
+    {
+        //set the value of the field to true (the default, otherwise, is false
+        mFieldCacheFloat32.set(1.0f);
+        //add it to the message
+        mFieldCacheFloat32.addToMessage(false, mMsg);
+        //check we can get the value of true returned to us when searching for the field
+        assertEquals(mMsg.getF64("example", 101), 1.0);
+    }
+
+    public void testAddToMessagefieldName()
+    {
+        //set the value of the field to true (the default, otherwise, is false
+        mFieldCacheFloat32.set(1.0f);
+        //add it to the message
+        mFieldCacheFloat32.addToMessage(true, mMsg);
+        //check we can get the value of true returned to us when searching for the field
+        assertEquals(mMsg.getF64("example", 101), 1.0);
+    }
+
+    public void testCopy()
+    {
+        MamaFieldCacheField copyCache =  mFieldCacheFloat32.copy();
+        assertEquals(mFieldCacheFloat32.getAsString(), copyCache.getAsString());
+    }
+
+    public void testApplyMsgField()
+    {
+        MamaFieldCacheFloat32 testCacheFloat32 = new MamaFieldCacheFloat32(102, "example2", true);
+        mFieldCacheFloat32.set(2);
+        testCacheFloat32.set(1.0f);
+        assertEquals(testCacheFloat32.get(), 1.0f);
+        assertEquals(mFieldCacheFloat32.get(), 2.0f);
+        mFieldCacheFloat32.apply(testCacheFloat32);
+        assertEquals(mFieldCacheFloat32.get(), 1.0f);
+    }
+
+    public void testApplyFieldCache()
+    {
+       MamaFieldCacheFloat32 testField  = new MamaFieldCacheFloat32(102, "example2", true);
+       testField.set(1.0f);
+       mFieldCacheFloat32.apply(testField);
+       assertEquals(mFieldCacheFloat32.get(), 1.0f);
+    }
+
+
+    public void testSet()
+    {
+        MamaFieldCacheFloat32 testCacheFloat32 = new MamaFieldCacheFloat32(102, "example2", false);
+
+        assertEquals(testCacheFloat32.get(), 0.0f);
+        testCacheFloat32.set(1.0f);
+        //set without track state
+        assertEquals(testCacheFloat32.get(), 1.0f);
+
+        assertEquals(MamaFieldCacheField.MOD_STATE_MODIFIED, testCacheFloat32.getModState());
+
+    }
+
+    public void testSetTrackState()
+    {
+        assertEquals(mFieldCacheFloat32.get(), 0.0f);
+        mFieldCacheFloat32.set(1.0f);
+        //set with track state
+        assertEquals(mFieldCacheFloat32.get(), 1.0f);
+        assertEquals(MamaFieldCacheField.MOD_STATE_MODIFIED, mFieldCacheFloat32.getModState());
+    }
+
+    public void testSetTrackStateTouched()
+    {
+    
+        assertEquals(mFieldCacheFloat32.get(), 0.0f);
+        mFieldCacheFloat32.set(1.0f);
+        mFieldCacheFloat32.set(1.0f);
+        //set with track state
+        assertEquals(mFieldCacheFloat32.get(), 1.0f);
+        assertEquals(MamaFieldCacheField.MOD_STATE_TOUCHED, mFieldCacheFloat32.getModState());
+
+    }
+
+    public void testIsEqual()
+    {   
+        MamaFieldCacheFloat32 testCacheFloat32 = new MamaFieldCacheFloat32(102, "example2", true);
+        testCacheFloat32.set(1.0f);
+        mFieldCacheFloat32.set(1.0f);
+        assertEquals(testCacheFloat32.get(), 1.0f);
+        assertEquals(mFieldCacheFloat32.get(), 1.0f);
+        assertTrue(testCacheFloat32.isEqual(mFieldCacheFloat32.get()));
+    }
+
+    public void testGet()
+    {
+        assertEquals(mFieldCacheFloat32.get(), 0.0f);
+        mFieldCacheFloat32.set(1.0f);
+        assertEquals(mFieldCacheFloat32.get(), 1.0f);
+    }
+
+    public void testGetAsString()
+    {
+        assertEquals(mFieldCacheFloat32.get(), 0.0f);
+        assertEquals("0.0", mFieldCacheFloat32.getAsString());
+        mFieldCacheFloat32.set(1.0f);
+        assertEquals(mFieldCacheFloat32.get(), 1.0f);
+        assertEquals("1.0", mFieldCacheFloat32.getAsString());
+    }
+}

--- a/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCacheFloat64Test.java
+++ b/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCacheFloat64Test.java
@@ -1,0 +1,163 @@
+/* $Id$
+ *
+ * OpenMAMA: The open middleware agnostic messaging API
+ * Copyright (C) 2011 NYSE Technologies, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+import junit.framework.*;
+import com.wombat.mama.*;
+
+/**
+ *
+ * This class will test MamaFieldCacheFloat64's functions
+ */
+public class MamaFieldCacheFloat64Test extends TestCase
+{
+    /* ****************************************************** */
+    /* Protected Member Variables. */
+    /* ****************************************************** */
+    
+    protected MamaMsg mMsg;
+    protected MamaFieldCacheFloat64 mFieldCacheFloat64;
+
+    /* ****************************************************** */
+    /* Protected Functions. */
+    /* ****************************************************** */
+
+    @Override
+    protected void setUp()
+    {
+        mFieldCacheFloat64 = new MamaFieldCacheFloat64(101, "example", true);
+        mMsg = new MamaMsg();   
+    }
+
+    @Override
+    protected void tearDown()
+    {
+    }
+
+    /* ****************************************************** */
+    /* Test Functions. */
+    /* ****************************************************** */
+
+    public void testAddToMessage()
+    {
+        //set the value of the field to true (the default, otherwise, is false
+        mFieldCacheFloat64.set(1.0);
+        //add it to the message
+        mFieldCacheFloat64.addToMessage(false, mMsg);
+        //check we can get the value of true returned to us when searching for the field
+        assertEquals(mMsg.getF64("example", 101), 1.0);
+    }
+
+    public void testAddToMessagefieldName()
+    {
+        //set the value of the field to true (the default, otherwise, is false
+        mFieldCacheFloat64.set(1.0);
+        //add it to the message
+        mFieldCacheFloat64.addToMessage(true, mMsg);
+        //check we can get the value of true returned to us when searching for the field
+        assertEquals(mMsg.getF64("example", 101), 1.0);
+    }
+
+    public void testCopy()
+    {
+        MamaFieldCacheField copyCache =  mFieldCacheFloat64.copy();
+        assertEquals(mFieldCacheFloat64.getAsString(), copyCache.getAsString());
+    }
+
+    public void testApplyMsgField()
+    {
+        MamaFieldCacheFloat64 testCacheFloat64 = new MamaFieldCacheFloat64(102, "example2", true);
+        mFieldCacheFloat64.set(2);
+        testCacheFloat64.set(1.0);
+        assertEquals(testCacheFloat64.get(), 1.0);
+        assertEquals(mFieldCacheFloat64.get(), 2.0);
+        mFieldCacheFloat64.apply(testCacheFloat64);
+        assertEquals(mFieldCacheFloat64.get(), 1.0);
+    }
+
+    public void testApplyFieldCache()
+    {
+       MamaFieldCacheFloat64 testField  = new MamaFieldCacheFloat64(102, "example2", true);
+       testField.set(1.0);
+       mFieldCacheFloat64.apply(testField);
+       assertEquals(mFieldCacheFloat64.get(), 1.0);
+    }
+
+
+    public void testSet()
+    {
+        MamaFieldCacheFloat64 testCacheFloat64 = new MamaFieldCacheFloat64(102, "example2", false);
+
+        assertEquals(testCacheFloat64.get(), 0.0);
+        testCacheFloat64.set(1.0);
+        //set without track state
+        assertEquals(testCacheFloat64.get(), 1.0);
+
+        assertEquals(MamaFieldCacheField.MOD_STATE_MODIFIED, testCacheFloat64.getModState());
+
+    }
+
+    public void testSetTrackState()
+    {
+        assertEquals(mFieldCacheFloat64.get(), 0.0);
+        mFieldCacheFloat64.set(1.0);
+        //set with track state
+        assertEquals(mFieldCacheFloat64.get(), 1.0);
+        assertEquals(MamaFieldCacheField.MOD_STATE_MODIFIED, mFieldCacheFloat64.getModState());
+    }
+
+    public void testSetTrackStateTouched()
+    {
+    
+        assertEquals(mFieldCacheFloat64.get(), 0.0);
+        mFieldCacheFloat64.set(1.0);
+        mFieldCacheFloat64.set(1.0);
+        //set with track state
+        assertEquals(mFieldCacheFloat64.get(), 1.0);
+        assertEquals(MamaFieldCacheField.MOD_STATE_TOUCHED, mFieldCacheFloat64.getModState());
+
+    }
+
+    public void testIsEqual()
+    {   
+        MamaFieldCacheFloat64 testCacheFloat64 = new MamaFieldCacheFloat64(102, "example2", true);
+        testCacheFloat64.set(1.0);
+        mFieldCacheFloat64.set(1.0);
+        assertEquals(testCacheFloat64.get(), 1.0);
+        assertEquals(mFieldCacheFloat64.get(), 1.0);
+        assertTrue(testCacheFloat64.isEqual(mFieldCacheFloat64.get()));
+    }
+
+    public void testGet()
+    {
+        assertEquals(mFieldCacheFloat64.get(), 0.0);
+        mFieldCacheFloat64.set(1.0);
+        assertEquals(mFieldCacheFloat64.get(), 1.0);
+    }
+
+    public void testGetAsString()
+    {
+        assertEquals(mFieldCacheFloat64.get(), 0.0);
+        assertEquals("0.0", mFieldCacheFloat64.getAsString());
+        mFieldCacheFloat64.set(1.0);
+        assertEquals(mFieldCacheFloat64.get(), 1.0);
+        assertEquals("1.0", mFieldCacheFloat64.getAsString());
+    }
+}

--- a/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCacheInt16Test.java
+++ b/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCacheInt16Test.java
@@ -1,0 +1,163 @@
+/* $Id$
+ *
+ * OpenMAMA: The open middleware agnostic messaging API
+ * Copyright (C) 2011 NYSE Technologies, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+import junit.framework.*;
+import com.wombat.mama.*;
+
+/**
+ *
+ * This class will test MamaFieldCacheInt16's functions
+ */
+public class MamaFieldCacheInt16Test extends TestCase
+{
+    /* ****************************************************** */
+    /* Protected Member Variables. */
+    /* ****************************************************** */
+    
+    protected MamaMsg mMsg;
+    protected MamaFieldCacheInt16 mFieldCacheInt16;
+
+    /* ****************************************************** */
+    /* Protected Functions. */
+    /* ****************************************************** */
+
+    @Override
+    protected void setUp()
+    {
+        mFieldCacheInt16 = new MamaFieldCacheInt16(101, "example", true);
+        mMsg = new MamaMsg();   
+    }
+
+    @Override
+    protected void tearDown()
+    {
+    }
+
+    /* ****************************************************** */
+    /* Test Functions. */
+    /* ****************************************************** */
+
+    public void testAddToMessage()
+    {
+        //set the value of the field to true (the default, otherwise, is false
+        mFieldCacheInt16.set((short) 1);
+        //add it to the message
+        mFieldCacheInt16.addToMessage(false, mMsg);
+        //check we can get the value of true returned to us when searching for the field
+        assertEquals(mMsg.getU16("example", 101), (short)1);
+    }
+
+    public void testAddToMessagefieldName()
+    {
+        //set the value of the field to true (the default, otherwise, is false
+        mFieldCacheInt16.set((short) 1);
+        //add it to the message
+        mFieldCacheInt16.addToMessage(true, mMsg);
+        //check we can get the value of true returned to us when searching for the field
+        assertEquals(mMsg.getI16("example", 101), (short) 1);
+    }
+
+    public void testCopy()
+    {
+        MamaFieldCacheField copyCache =  mFieldCacheInt16.copy();
+        assertEquals(mFieldCacheInt16.getAsString(), copyCache.getAsString());
+    }
+
+    public void testApplyMsgField()
+    {
+        MamaFieldCacheInt16 testCacheInt16 = new MamaFieldCacheInt16(102, "example2", true);
+        mFieldCacheInt16.set((short) 2);
+        testCacheInt16.set((short) 1);
+        assertEquals(testCacheInt16.get(), (short) 1);
+        assertEquals(mFieldCacheInt16.get(), (short) 2);
+        mFieldCacheInt16.apply(testCacheInt16);
+        assertEquals(mFieldCacheInt16.get(), 1);
+    }
+
+    public void testApplyFieldCache()
+    {
+       MamaFieldCacheInt16 testField  = new MamaFieldCacheInt16(102, "example2", true);
+       testField.set((short) 1);
+       mFieldCacheInt16.apply(testField);
+       assertEquals(mFieldCacheInt16.get(), (short) 1);
+    }
+
+
+    public void testSet()
+    {
+        MamaFieldCacheInt16 testCacheInt16 = new MamaFieldCacheInt16(102, "example2", false);
+
+        assertEquals(testCacheInt16.get(), (short) 0);
+        testCacheInt16.set((short) 1);
+        //set without track state
+        assertEquals(testCacheInt16.get(), (short) 1);
+
+        assertEquals(MamaFieldCacheField.MOD_STATE_MODIFIED, testCacheInt16.getModState());
+
+    }
+
+    public void testSetTrackState()
+    {
+        assertEquals(mFieldCacheInt16.get(), (short) 0);
+        mFieldCacheInt16.set((short) 1);
+        //set with track state
+        assertEquals(mFieldCacheInt16.get(), (short) 1);
+        assertEquals(MamaFieldCacheField.MOD_STATE_MODIFIED, mFieldCacheInt16.getModState());
+    }
+
+    public void testSetTrackStateTouched()
+    {
+    
+        assertEquals(mFieldCacheInt16.get(), (short) 0);
+        mFieldCacheInt16.set((short) 1);
+        mFieldCacheInt16.set((short) 1);
+        //set with track state
+        assertEquals(mFieldCacheInt16.get(), (short) 1);
+        assertEquals(MamaFieldCacheField.MOD_STATE_TOUCHED, mFieldCacheInt16.getModState());
+
+    }
+
+    public void testIsEqual()
+    {   
+        MamaFieldCacheInt16 testCacheInt16 = new MamaFieldCacheInt16(102, "example2", true);
+        testCacheInt16.set((short) 1);
+        mFieldCacheInt16.set((short) 1);
+        assertEquals(testCacheInt16.get(), (short) 1);
+        assertEquals(mFieldCacheInt16.get(), (short) 1);
+        assertTrue(testCacheInt16.isEqual(mFieldCacheInt16.get()));
+    }
+
+    public void testGet()
+    {
+        assertEquals(mFieldCacheInt16.get(), 0);
+        mFieldCacheInt16.set((short) 1);
+        assertEquals(mFieldCacheInt16.get(), (short) 1);
+    }
+
+    public void testGetAsString()
+    {
+        assertEquals(mFieldCacheInt16.get(), 0);
+        assertEquals("0", mFieldCacheInt16.getAsString());
+        mFieldCacheInt16.set((short) 1);
+        assertEquals(mFieldCacheInt16.get(), (short) 1);
+        assertEquals("1", mFieldCacheInt16.getAsString());
+    }
+}

--- a/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCacheInt32Test.java
+++ b/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCacheInt32Test.java
@@ -1,0 +1,163 @@
+/* $Id$
+ *
+ * OpenMAMA: The open middleware agnostic messaging API
+ * Copyright (C) 2011 NYSE Technologies, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+import junit.framework.*;
+import com.wombat.mama.*;
+
+/**
+ *
+ * This class will test MamaFieldCacheInt32's functions
+ */
+public class MamaFieldCacheInt32Test extends TestCase
+{
+    /* ****************************************************** */
+    /* Protected Member Variables. */
+    /* ****************************************************** */
+    
+    protected MamaMsg mMsg;
+    protected MamaFieldCacheInt32 mFieldCacheInt32;
+
+    /* ****************************************************** */
+    /* Protected Functions. */
+    /* ****************************************************** */
+
+    @Override
+    protected void setUp()
+    {
+        mFieldCacheInt32 = new MamaFieldCacheInt32(101, "example", true);
+        mMsg = new MamaMsg();   
+    }
+
+    @Override
+    protected void tearDown()
+    {
+    }
+
+    /* ****************************************************** */
+    /* Test Functions. */
+    /* ****************************************************** */
+
+    public void testAddToMessage()
+    {
+        //set the value of the field to true (the default, otherwise, is false
+        mFieldCacheInt32.set(1);
+        //add it to the message
+        mFieldCacheInt32.addToMessage(false, mMsg);
+        //check we can get the value of true returned to us when searching for the field
+        assertEquals(mMsg.getU32("example", 101), 1);
+    }
+
+    public void testAddToMessagefieldName()
+    {
+        //set the value of the field to true (the default, otherwise, is false
+        mFieldCacheInt32.set(1);
+        //add it to the message
+        mFieldCacheInt32.addToMessage(true, mMsg);
+        //check we can get the value of true returned to us when searching for the field
+        assertEquals(mMsg.getU32("example", 101), 1);
+    }
+
+    public void testCopy()
+    {
+        MamaFieldCacheField copyCache =  mFieldCacheInt32.copy();
+        assertEquals(mFieldCacheInt32.getAsString(), copyCache.getAsString());
+    }
+
+    public void testApplyMsgField()
+    {
+        MamaFieldCacheInt32 testCacheInt32 = new MamaFieldCacheInt32(102, "example2", true);
+        mFieldCacheInt32.set(2);
+        testCacheInt32.set(1);
+        assertEquals(testCacheInt32.get(), 1);
+        assertEquals(mFieldCacheInt32.get(), 2);
+        mFieldCacheInt32.apply(testCacheInt32);
+        assertEquals(mFieldCacheInt32.get(), 1);
+    }
+
+    public void testApplyFieldCache()
+    {
+       MamaFieldCacheInt32 testField  = new MamaFieldCacheInt32(102, "example2", true);
+       testField.set(1);
+       mFieldCacheInt32.apply(testField);
+       assertEquals(mFieldCacheInt32.get(), 1);
+    }
+
+
+    public void testSet()
+    {
+        MamaFieldCacheInt32 testCacheInt32 = new MamaFieldCacheInt32(102, "example2", false);
+
+        assertEquals(testCacheInt32.get(), 0);
+        testCacheInt32.set(1);
+        //set without track state
+        assertEquals(testCacheInt32.get(), 1);
+
+        assertEquals(MamaFieldCacheField.MOD_STATE_MODIFIED, testCacheInt32.getModState());
+
+    }
+
+    public void testSetTrackState()
+    {
+        assertEquals(mFieldCacheInt32.get(), 0);
+        mFieldCacheInt32.set(1);
+        //set with track state
+        assertEquals(mFieldCacheInt32.get(), 1);
+        assertEquals(MamaFieldCacheField.MOD_STATE_MODIFIED, mFieldCacheInt32.getModState());
+    }
+
+    public void testSetTrackStateTouched()
+    {
+    
+        assertEquals(mFieldCacheInt32.get(), 0);
+        mFieldCacheInt32.set(1);
+        mFieldCacheInt32.set(1);
+        //set with track state
+        assertEquals(mFieldCacheInt32.get(), 1);
+        assertEquals(MamaFieldCacheField.MOD_STATE_TOUCHED, mFieldCacheInt32.getModState());
+
+    }
+
+    public void testIsEqual()
+    {   
+        MamaFieldCacheInt32 testCacheInt32 = new MamaFieldCacheInt32(102, "example2", true);
+        testCacheInt32.set(1);
+        mFieldCacheInt32.set(1);
+        assertEquals(testCacheInt32.get(), 1);
+        assertEquals(mFieldCacheInt32.get(), 1);
+        assertTrue(testCacheInt32.isEqual(mFieldCacheInt32.get()));
+    }
+
+    public void testGet()
+    {
+        assertEquals(mFieldCacheInt32.get(), 0);
+        mFieldCacheInt32.set(1);
+        assertEquals(mFieldCacheInt32.get(), 1);
+    }
+
+    public void testGetAsString()
+    {
+        assertEquals(mFieldCacheInt32.get(), 0);
+        assertEquals("0", mFieldCacheInt32.getAsString());
+        mFieldCacheInt32.set(1);
+        assertEquals(mFieldCacheInt32.get(), 1);
+        assertEquals("1", mFieldCacheInt32.getAsString());
+    }
+}

--- a/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCacheInt64Test.java
+++ b/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCacheInt64Test.java
@@ -1,0 +1,163 @@
+/* $Id$
+ *
+ * OpenMAMA: The open middleware agnostic messaging API
+ * Copyright (C) 2011 NYSE Technologies, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+import junit.framework.*;
+import com.wombat.mama.*;
+
+/**
+ *
+ * This class will test MamaFieldCacheInt64's functions
+ */
+public class MamaFieldCacheInt64Test extends TestCase
+{
+    /* ****************************************************** */
+    /* Protected Member Variables. */
+    /* ****************************************************** */
+    
+    protected MamaMsg mMsg;
+    protected MamaFieldCacheInt64 mFieldCacheInt64;
+
+    /* ****************************************************** */
+    /* Protected Functions. */
+    /* ****************************************************** */
+
+    @Override
+    protected void setUp()
+    {
+        mFieldCacheInt64 = new MamaFieldCacheInt64(101, "example", true);
+        mMsg = new MamaMsg();   
+    }
+
+    @Override
+    protected void tearDown()
+    {
+    }
+
+    /* ****************************************************** */
+    /* Test Functions. */
+    /* ****************************************************** */
+
+    public void testAddToMessage()
+    {
+        //set the value of the field to true (the default, otherwise, is false
+        mFieldCacheInt64.set(1L);
+        //add it to the message
+        mFieldCacheInt64.addToMessage(false, mMsg);
+        //check we can get the value of true returned to us when searching for the field
+        assertEquals(mMsg.getU64("example", 101), 1L);
+    }
+
+    public void testAddToMessagefieldName()
+    {
+        //set the value of the field to true (the default, otherwise, is false
+        mFieldCacheInt64.set(1L);
+        //add it to the message
+        mFieldCacheInt64.addToMessage(true, mMsg);
+        //check we can get the value of true returned to us when searching for the field
+        assertEquals(mMsg.getU64("example", 101), 1L);
+    }
+
+    public void testCopy()
+    {
+        MamaFieldCacheField copyCache =  mFieldCacheInt64.copy();
+        assertEquals(mFieldCacheInt64.getAsString(), copyCache.getAsString());
+    }
+
+    public void testApplyMsgField()
+    {
+        MamaFieldCacheInt64 testCacheInt64 = new MamaFieldCacheInt64(102, "example2L", true);
+        mFieldCacheInt64.set(2L);
+        testCacheInt64.set(1L);
+        assertEquals(testCacheInt64.get(), 1L);
+        assertEquals(mFieldCacheInt64.get(), 2L);
+        mFieldCacheInt64.apply(testCacheInt64);
+        assertEquals(mFieldCacheInt64.get(), 1L);
+    }
+
+    public void testApplyFieldCache()
+    {
+       MamaFieldCacheInt64 testField  = new MamaFieldCacheInt64(102, "example2L", true);
+       testField.set(1L);
+       mFieldCacheInt64.apply(testField);
+       assertEquals(mFieldCacheInt64.get(), 1L);
+    }
+
+
+    public void testSet()
+    {
+        MamaFieldCacheInt64 testCacheInt64 = new MamaFieldCacheInt64(102, "example2L", false);
+
+        assertEquals(testCacheInt64.get(), 0);
+        testCacheInt64.set(1L);
+        //set without track state
+        assertEquals(testCacheInt64.get(), 1L);
+
+        assertEquals(MamaFieldCacheField.MOD_STATE_MODIFIED, testCacheInt64.getModState());
+
+    }
+
+    public void testSetTrackState()
+    {
+        assertEquals(mFieldCacheInt64.get(), 0);
+        mFieldCacheInt64.set(1L);
+        //set with track state
+        assertEquals(mFieldCacheInt64.get(), 1L);
+        assertEquals(MamaFieldCacheField.MOD_STATE_MODIFIED, mFieldCacheInt64.getModState());
+    }
+
+    public void testSetTrackStateTouched()
+    {
+    
+        assertEquals(mFieldCacheInt64.get(), 0);
+        mFieldCacheInt64.set(1L);
+        mFieldCacheInt64.set(1L);
+        //set with track state
+        assertEquals(mFieldCacheInt64.get(), 1L);
+        assertEquals(MamaFieldCacheField.MOD_STATE_TOUCHED, mFieldCacheInt64.getModState());
+
+    }
+
+    public void testIsEqual()
+    {   
+        MamaFieldCacheInt64 testCacheInt64 = new MamaFieldCacheInt64(102, "example2L", true);
+        testCacheInt64.set(1L);
+        mFieldCacheInt64.set(1L);
+        assertEquals(testCacheInt64.get(), 1L);
+        assertEquals(mFieldCacheInt64.get(), 1L);
+        assertTrue(testCacheInt64.isEqual(mFieldCacheInt64.get()));
+    }
+
+    public void testGet()
+    {
+        assertEquals(mFieldCacheInt64.get(), 0);
+        mFieldCacheInt64.set(1L);
+        assertEquals(mFieldCacheInt64.get(), 1L);
+    }
+
+    public void testGetAsString()
+    {
+        assertEquals(mFieldCacheInt64.get(), 0);
+        assertEquals("0", mFieldCacheInt64.getAsString());
+        mFieldCacheInt64.set(1L);
+        assertEquals(mFieldCacheInt64.get(), 1L);
+        assertEquals("1", mFieldCacheInt64.getAsString());
+    }
+}

--- a/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCacheInt8Test.java
+++ b/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCacheInt8Test.java
@@ -1,0 +1,163 @@
+/* $Id$
+ *
+ * OpenMAMA: The open middleware agnostic messaging API
+ * Copyright (C) 2011 NYSE Technologies, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+import junit.framework.*;
+import com.wombat.mama.*;
+
+/**
+ *
+ * This class will test MamaFieldCacheInt8's functions
+ */
+public class MamaFieldCacheInt8Test extends TestCase
+{
+    /* ****************************************************** */
+    /* Protected Member Variables. */
+    /* ****************************************************** */
+    
+    protected MamaMsg mMsg;
+    protected MamaFieldCacheInt8 mFieldCacheInt8;
+
+    /* ****************************************************** */
+    /* Protected Functions. */
+    /* ****************************************************** */
+
+    @Override
+    protected void setUp()
+    {
+        mFieldCacheInt8 = new MamaFieldCacheInt8(101, "example", true);
+        mMsg = new MamaMsg();   
+    }
+
+    @Override
+    protected void tearDown()
+    {
+    }
+
+    /* ****************************************************** */
+    /* Test Functions. */
+    /* ****************************************************** */
+
+    public void testAddToMessage()
+    {
+        //set the value of the field to true (the default, otherwise, is false
+        mFieldCacheInt8.set((byte) 1);
+        //add it to the message
+        mFieldCacheInt8.addToMessage(false, mMsg);
+        //check we can get the value of true returned to us when searching for the field
+        assertEquals(mMsg.getU8("example", 101), (byte)1);
+    }
+
+    public void testAddToMessagefieldName()
+    {
+        //set the value of the field to true (the default, otherwise, is false
+        mFieldCacheInt8.set((byte) 1);
+        //add it to the message
+        mFieldCacheInt8.addToMessage(true, mMsg);
+        //check we can get the value of true returned to us when searching for the field
+        assertEquals(mMsg.getI8("example", 101), (byte) 1);
+    }
+
+    public void testCopy()
+    {
+        MamaFieldCacheField copyCache =  mFieldCacheInt8.copy();
+        assertEquals(mFieldCacheInt8.getAsString(), copyCache.getAsString());
+    }
+
+    public void testApplyMsgField()
+    {
+        MamaFieldCacheInt8 testCacheInt8 = new MamaFieldCacheInt8(102, "example2", true);
+        mFieldCacheInt8.set((byte) 2);
+        testCacheInt8.set((byte) 1);
+        assertEquals(testCacheInt8.get(), (byte) 1);
+        assertEquals(mFieldCacheInt8.get(), (byte) 2);
+        mFieldCacheInt8.apply(testCacheInt8);
+        assertEquals(mFieldCacheInt8.get(), 1);
+    }
+
+    public void testApplyFieldCache()
+    {
+       MamaFieldCacheInt8 testField  = new MamaFieldCacheInt8(102, "example2", true);
+       testField.set((byte) 1);
+       mFieldCacheInt8.apply(testField);
+       assertEquals(mFieldCacheInt8.get(), (byte) 1);
+    }
+
+
+    public void testSet()
+    {
+        MamaFieldCacheInt8 testCacheInt8 = new MamaFieldCacheInt8(102, "example2", false);
+
+        assertEquals(testCacheInt8.get(), (byte) 0);
+        testCacheInt8.set((byte) 1);
+        //set without track state
+        assertEquals(testCacheInt8.get(), (byte) 1);
+
+        assertEquals(MamaFieldCacheField.MOD_STATE_MODIFIED, testCacheInt8.getModState());
+
+    }
+
+    public void testSetTrackState()
+    {
+        assertEquals(mFieldCacheInt8.get(), (byte) 0);
+        mFieldCacheInt8.set((byte) 1);
+        //set with track state
+        assertEquals(mFieldCacheInt8.get(), (byte) 1);
+        assertEquals(MamaFieldCacheField.MOD_STATE_MODIFIED, mFieldCacheInt8.getModState());
+    }
+
+    public void testSetTrackStateTouched()
+    {
+    
+        assertEquals(mFieldCacheInt8.get(), (byte) 0);
+        mFieldCacheInt8.set((byte) 1);
+        mFieldCacheInt8.set((byte) 1);
+        //set with track state
+        assertEquals(mFieldCacheInt8.get(), (byte) 1);
+        assertEquals(MamaFieldCacheField.MOD_STATE_TOUCHED, mFieldCacheInt8.getModState());
+
+    }
+
+    public void testIsEqual()
+    {   
+        MamaFieldCacheInt8 testCacheInt8 = new MamaFieldCacheInt8(102, "example2", true);
+        testCacheInt8.set((byte) 1);
+        mFieldCacheInt8.set((byte) 1);
+        assertEquals(testCacheInt8.get(), (byte) 1);
+        assertEquals(mFieldCacheInt8.get(), (byte) 1);
+        assertTrue(testCacheInt8.isEqual(mFieldCacheInt8.get()));
+    }
+
+    public void testGet()
+    {
+        assertEquals(mFieldCacheInt8.get(), 0);
+        mFieldCacheInt8.set((byte) 1);
+        assertEquals(mFieldCacheInt8.get(), (byte) 1);
+    }
+
+    public void testGetAsString()
+    {
+        assertEquals(mFieldCacheInt8.get(), 0);
+        assertEquals("0", mFieldCacheInt8.getAsString());
+        mFieldCacheInt8.set((byte) 1);
+        assertEquals(mFieldCacheInt8.get(), (byte) 1);
+        assertEquals("1", mFieldCacheInt8.getAsString());
+    }
+}

--- a/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCachePriceTest.java
+++ b/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCachePriceTest.java
@@ -1,0 +1,154 @@
+/* $Id$
+ *
+ * OpenMAMA: The open middleware agnostic messaging API
+ * Copyright (C) 2011 NYSE Technologies, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+import junit.framework.*;
+import com.wombat.mama.*;
+
+/**
+ *
+ * This class will test MamaFieldCachePrice's functions
+ */
+public class MamaFieldCachePriceTest extends TestCase
+{
+    /* ****************************************************** */
+    /* Protected Member Variables. */
+    /* ****************************************************** */
+    
+    protected MamaMsg mMsg;
+    protected MamaFieldCachePrice mFieldCachePrice;
+    protected MamaPrice           mprice;
+    /* ****************************************************** */
+    /* Protected Functions. */
+    /* ****************************************************** */
+
+    @Override
+    protected void setUp()
+    {
+        mFieldCachePrice = new MamaFieldCachePrice(101, "example", true);
+        mprice = new MamaPrice(10.01);
+        mMsg = new MamaMsg();   
+    }
+
+    @Override
+    protected void tearDown()
+    {
+    }
+
+    /* ****************************************************** */
+    /* Test Functions. */
+    /* ****************************************************** */
+
+    public void testAddToMessage()
+    {
+        //set the value of the field to true (the default, otherwise, is false
+        mFieldCachePrice.set(mprice);
+        //add it to the message
+        mFieldCachePrice.addToMessage(false, mMsg);
+        //check we can get the value of true returned to us when searching for the field
+        assertEquals(mMsg.getPrice("example", 101).getValue(), 10.01);
+    }
+
+    public void testAddToMessagefieldName()
+    {
+        //set the value of the field to true (the default, otherwise, is false
+        mFieldCachePrice.set(mprice);
+        //add it to the message
+        mFieldCachePrice.addToMessage(true, mMsg);
+        //check we can get the value of true returned to us when searching for the field
+        assertEquals(mMsg.getPrice("example", 101).getValue(), 10.01);
+    }
+
+    public void testCopy()
+    {
+        mFieldCachePrice.set(mprice);
+        MamaFieldCacheField copyCache =  mFieldCachePrice.copy();
+        assertEquals(mFieldCachePrice.getAsString(), copyCache.getAsString());
+    }
+
+    public void testApplyMsgField()
+    {
+        MamaFieldCachePrice testCachePrice = new MamaFieldCachePrice(102, "example2", true);
+        testCachePrice.set(new MamaPrice(20.02));
+        mFieldCachePrice.set(mprice);
+        assertEquals(testCachePrice.get().getValue(), 20.02);
+        assertEquals(mFieldCachePrice.get().getValue(), 10.01);
+        mFieldCachePrice.apply(testCachePrice);
+        assertEquals(mFieldCachePrice.get().getValue(), 20.02);
+    }
+
+    public void testApplyFieldCache()
+    {
+       MamaFieldCachePrice testField  = new MamaFieldCachePrice(102, "example2", true);
+       testField.set(new MamaPrice(20.02));
+       mFieldCachePrice.apply(testField);
+       assertEquals(mFieldCachePrice.get().getValue(), 20.02);
+    }
+
+
+    public void testSet()
+    {
+        MamaFieldCachePrice testCachePrice = new MamaFieldCachePrice(102, "example2", false);
+
+        assertEquals(testCachePrice.get(), null);
+        testCachePrice.set(mprice);
+        //set without track state
+        assertEquals(testCachePrice.get().getValue(), 10.01);
+
+        assertEquals(MamaFieldCacheField.MOD_STATE_MODIFIED, testCachePrice.getModState());
+
+    }
+
+    public void testSetTrackState()
+    {
+        assertEquals(mFieldCachePrice.get(), null);
+        mFieldCachePrice.set(mprice);
+        //set with track state
+        assertEquals(mFieldCachePrice.get().getValue(), 10.01);
+        assertEquals(MamaFieldCacheField.MOD_STATE_MODIFIED, mFieldCachePrice.getModState());
+    }
+
+    public void testIsEqual()
+    {   
+        MamaFieldCachePrice testCachePrice = new MamaFieldCachePrice(102, "example2", true);
+        testCachePrice.set(mprice);
+        mFieldCachePrice.set(mprice);
+        assertEquals(testCachePrice.get().getValue(), 10.01);
+        assertEquals(mFieldCachePrice.get().getValue(), 10.01);
+        assertTrue(testCachePrice.isEqual(mFieldCachePrice.get()));
+    }
+
+    public void testGet()
+    {
+        assertEquals(mFieldCachePrice.get(), null);
+        mFieldCachePrice.set(mprice);
+        assertEquals(mFieldCachePrice.get(), 10.01);
+    }
+
+    public void testGetAsString()
+    {
+        assertEquals(mFieldCachePrice.get(), null);
+        assertEquals("null", mFieldCachePrice.getAsString());
+        mFieldCachePrice.set(mprice);
+        assertEquals(mFieldCachePrice.get().getValue(), 10.01);
+        assertEquals("10.01", mFieldCachePrice.getAsString());
+    }
+
+}

--- a/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCachePropertiesTest.java
+++ b/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCachePropertiesTest.java
@@ -1,0 +1,193 @@
+/* $Id$
+ *
+ * OpenMAMA: The open middleware agnostic messaging API
+ * Copyright (C) 2011 NYSE Technologies, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+import junit.framework.*;
+import com.wombat.mama.*;
+import java.util.Iterator;
+import java.io.OutputStream;
+import java.io.BufferedOutputStream;
+/**
+ *
+ * This class will test MamaFieldCacheProperties's functions
+ */
+public class MamaFieldCachePropertiesTest extends TestCase
+{
+    /* ****************************************************** */
+    /* Protected Member Variables. */
+    /* ****************************************************** */
+    
+    protected MamaFieldCacheProperties mFieldCacheProperties;
+    protected MamaFieldCacheInt32 mFieldCacheInt32;
+    protected MamaFieldCacheInt32 mFieldCacheInt32_2;
+    protected Iterator i;
+
+    /* ****************************************************** */
+    /* Protected Functions. */
+    /* ****************************************************** */
+
+    @Override
+    protected void setUp()
+    {
+        mFieldCacheProperties = new MamaFieldCacheProperties();
+        mFieldCacheInt32 = new MamaFieldCacheInt32(101, "example", true);
+        mFieldCacheInt32_2 = new MamaFieldCacheInt32(102, "example2", true);
+    }
+
+    @Override
+    protected void tearDown()
+    {
+    }
+
+    /* ****************************************************** */
+    /* Test Functions. */
+    /* ****************************************************** */
+   
+    public void testClearAndDelete()
+    {
+        mFieldCacheProperties.add(mFieldCacheInt32);
+        assertEquals(mFieldCacheProperties.find(101), mFieldCacheInt32);
+        mFieldCacheProperties.clear();
+        assertEquals(mFieldCacheProperties.find(101), null);
+    }
+
+     public void testAddIfModifiedNotModified()
+     {
+         mFieldCacheInt32.setModState(MamaFieldCacheField.MOD_STATE_NOT_MODIFIED);
+         mFieldCacheProperties.addIfModified(mFieldCacheInt32);
+         assertEquals(mFieldCacheProperties.find("example"), null);
+     }
+
+     public void testAddIfModifiedModified()
+     {
+         mFieldCacheProperties.addIfModified(mFieldCacheInt32);
+         assertEquals(mFieldCacheProperties.find("example"), mFieldCacheInt32);
+     }
+
+    public void testClearAndUnregisterAll()
+    {
+        mFieldCacheProperties.add(mFieldCacheInt32);
+        assertEquals(mFieldCacheProperties.find(101), mFieldCacheInt32);
+        mFieldCacheProperties.clear();
+        assertEquals(mFieldCacheProperties.find(101), null);
+    }
+
+    public void testRegisterProperty()
+    {
+        MamaFieldCacheFieldList testFieldList = new MamaFieldCacheFieldList();
+
+        testFieldList.add(mFieldCacheInt32);
+        testFieldList.add(mFieldCacheInt32);
+
+        mFieldCacheProperties.registerProperty(101, mFieldCacheInt32);
+        mFieldCacheProperties.apply(testFieldList);
+        
+        assertEquals(mFieldCacheProperties.find(101), mFieldCacheInt32);
+    }
+
+    public void testRegisterPropertyFieldNull()
+    {
+        MamaFieldCacheFieldList testFieldList = new MamaFieldCacheFieldList();
+        mFieldCacheInt32 = null;
+        testFieldList.add(mFieldCacheInt32);
+        testFieldList.add(mFieldCacheInt32);
+
+        mFieldCacheProperties.registerProperty(101, mFieldCacheInt32);
+        mFieldCacheProperties.apply(testFieldList);
+        
+        assertEquals(mFieldCacheProperties.find(101), null);
+    }
+
+    public void testApply()
+    {
+        MamaFieldCacheFieldList testFieldList = new MamaFieldCacheFieldList();
+        testFieldList.add(mFieldCacheInt32);
+        
+        mFieldCacheProperties.registerProperty(101, mFieldCacheInt32);
+        assertEquals(mFieldCacheProperties.find(101), null);
+
+        mFieldCacheProperties.apply(testFieldList);
+        assertEquals(mFieldCacheProperties.find(101), mFieldCacheInt32);
+    }
+
+    public void testFindNullName()
+    {
+        MamaFieldCacheFieldList testFieldList = new MamaFieldCacheFieldList();
+        testFieldList.add(mFieldCacheInt32);
+        
+        mFieldCacheProperties.registerProperty(101, mFieldCacheInt32);
+        assertEquals(mFieldCacheProperties.find(101), null);
+
+        mFieldCacheProperties.apply(testFieldList);
+        assertEquals(mFieldCacheProperties.find(101), mFieldCacheInt32);
+        assertEquals(mFieldCacheProperties.find(""), null);
+    }
+
+    public void testFindByDesc()
+    {
+        MamaFieldCacheFieldList testFieldList = new MamaFieldCacheFieldList();
+        testFieldList.add(mFieldCacheInt32);
+        
+        mFieldCacheProperties.registerProperty(101, mFieldCacheInt32);
+        assertEquals(mFieldCacheProperties.find(101), null);
+
+        mFieldCacheProperties.apply(testFieldList);
+        assertEquals(mFieldCacheProperties.find("example"), mFieldCacheInt32);
+    }
+
+    public void testSize()
+    {
+        MamaFieldCacheFieldList testFieldList = new MamaFieldCacheFieldList();
+        assertEquals(mFieldCacheProperties.size(), 0);
+        testFieldList.add(mFieldCacheInt32);
+        
+        mFieldCacheProperties.registerProperty(101, mFieldCacheInt32);
+
+        mFieldCacheProperties.apply(testFieldList);
+        assertEquals(mFieldCacheProperties.size(), 1);
+    }
+
+    public void testEmpty()
+    {
+        MamaFieldCacheFieldList testFieldList = new MamaFieldCacheFieldList();
+        assertEquals(mFieldCacheProperties.empty(), true);
+        testFieldList.add(mFieldCacheInt32);
+        
+        mFieldCacheProperties.registerProperty(101, mFieldCacheInt32);
+
+        mFieldCacheProperties.apply(testFieldList);
+        assertEquals(mFieldCacheProperties.empty(), false);
+    }
+    public void testGetIterator()
+    {
+        MamaFieldCacheFieldList testFieldList = new MamaFieldCacheFieldList();
+
+        assertEquals(mFieldCacheProperties.empty(), true);
+        i = mFieldCacheProperties.getIterator();
+        assertFalse(i.hasNext());
+        testFieldList.add(mFieldCacheInt32);
+        mFieldCacheProperties.registerProperty(101, mFieldCacheInt32);
+        mFieldCacheProperties.apply(testFieldList);
+
+        assertEquals(mFieldCacheProperties.empty(), false);
+        i = mFieldCacheProperties.getIterator();
+        assertTrue(i.hasNext());
+    }
+}

--- a/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCacheStringTest.java
+++ b/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCacheStringTest.java
@@ -1,0 +1,163 @@
+/* $Id$
+ *
+ * OpenMAMA: The open middleware agnostic messaging API
+ * Copyright (C) 2011 NYSE Technologies, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+import junit.framework.*;
+import com.wombat.mama.*;
+
+/**
+ *
+ * This class will test MamaFieldCacheString's functions
+ */
+public class MamaFieldCacheStringTest extends TestCase
+{
+    /* ****************************************************** */
+    /* Protected Member Variables. */
+    /* ****************************************************** */
+    
+    protected MamaMsg mMsg;
+    protected MamaFieldCacheString mFieldCacheString;
+
+    /* ****************************************************** */
+    /* Protected Functions. */
+    /* ****************************************************** */
+
+    @Override
+    protected void setUp()
+    {
+        mFieldCacheString = new MamaFieldCacheString(101, "example", true);
+        mMsg = new MamaMsg();   
+    }
+
+    @Override
+    protected void tearDown()
+    {
+    }
+
+    /* ****************************************************** */
+    /* Test Functions. */
+    /* ****************************************************** */
+
+    public void testAddToMessage()
+    {
+        //set the value of the field to true (the default, otherwise, is false
+        mFieldCacheString.set("a");
+        //add it to the message
+        mFieldCacheString.addToMessage(false, mMsg);
+        //check we can get the value of true returned to us when searching for the field
+        assertEquals(mMsg.getString("example", 101), "a");
+    }
+
+    public void testAddToMessagefieldName()
+    {
+        //set the value of the field to true (the default, otherwise, is false
+        mFieldCacheString.set("a");
+        //add it to the message
+        mFieldCacheString.addToMessage(true, mMsg);
+        //check we can get the value of true returned to us when searching for the field
+        assertEquals(mMsg.getString("example", 101), "a");
+    }
+
+    public void testCopy()
+    {
+        MamaFieldCacheField copyCache =  mFieldCacheString.copy();
+        assertEquals(mFieldCacheString.getAsString(), copyCache.getAsString());
+    }
+
+    public void testApplyMsgField()
+    {
+        MamaFieldCacheString testCacheString = new MamaFieldCacheString(102, "example2", true);
+        mFieldCacheString.set("b");
+        testCacheString.set("a");
+        assertEquals(testCacheString.get(), "a");
+        assertEquals(mFieldCacheString.get(), "b");
+        mFieldCacheString.apply(testCacheString);
+        assertEquals(mFieldCacheString.get(), "a");
+    }
+
+    public void testApplyFieldCache()
+    {
+       MamaFieldCacheString testField  = new MamaFieldCacheString(102, "example2", true);
+       testField.set("a");
+       mFieldCacheString.apply(testField);
+       assertEquals(mFieldCacheString.get(), "a");
+    }
+
+
+    public void testSet()
+    {
+        MamaFieldCacheString testCacheString = new MamaFieldCacheString(102, "example2", false);
+
+        assertEquals(testCacheString.get(), null);
+        testCacheString.set("a");
+        //set without track state
+        assertEquals(testCacheString.get(), "a");
+
+        assertEquals(MamaFieldCacheField.MOD_STATE_MODIFIED, testCacheString.getModState());
+
+    }
+
+    public void testSetTrackState()
+    {
+        assertEquals(mFieldCacheString.get(), null);
+        mFieldCacheString.set("a");
+        //set with track state
+        assertEquals(mFieldCacheString.get(), "a");
+        assertEquals(MamaFieldCacheField.MOD_STATE_MODIFIED, mFieldCacheString.getModState());
+    }
+
+    public void testSetTrackStateTouched()
+    {
+    
+        assertEquals(mFieldCacheString.get(), null);
+        mFieldCacheString.set("a");
+        mFieldCacheString.set("a");
+        //set with track state
+        assertEquals(mFieldCacheString.get(), "a");
+        assertEquals(MamaFieldCacheField.MOD_STATE_TOUCHED, mFieldCacheString.getModState());
+
+    }
+
+    public void testIsEqual()
+    {   
+        MamaFieldCacheString testCacheString = new MamaFieldCacheString(102, "example2", true);
+        testCacheString.set("a");
+        mFieldCacheString.set("a");
+        assertEquals(testCacheString.get(), "a");
+        assertEquals(mFieldCacheString.get(), "a");
+        assertTrue(testCacheString.isEqual(mFieldCacheString.get()));
+    }
+
+    public void testGet()
+    {
+        assertEquals(mFieldCacheString.get(), null);
+        mFieldCacheString.set("a");
+        assertEquals(mFieldCacheString.get(), "a");
+    }
+
+    public void testGetAsString()
+    {
+        assertEquals(mFieldCacheString.get(), null);
+        assertEquals("null", mFieldCacheString.getAsString());
+        mFieldCacheString.set("a");
+        assertEquals(mFieldCacheString.get(), "a");
+        assertEquals("a", mFieldCacheString.getAsString());
+    }
+}

--- a/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCacheTest.java
+++ b/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCacheTest.java
@@ -1,0 +1,98 @@
+/* $Id$
+ *
+ * OpenMAMA: The open middleware agnostic messaging API
+ * Copyright (C) 2011 NYSE Technologies, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+import junit.framework.*;
+import com.wombat.mama.*;
+
+/**
+ *
+ * This class will test MamaFieldCache's functions
+ */
+public class MamaFieldCacheTest extends TestCase
+{
+    /* ****************************************************** */
+    /* Protected Member Variables. */
+    /* ****************************************************** */
+    
+    protected MamaFieldCache mFieldCache;
+    protected MamaFieldCacheInt32 mFieldCacheInt32;
+    protected MamaFieldCacheInt32 mFieldCacheInt32_2;
+    protected MamaFieldDescriptor mFieldDescriptor;
+
+    /* ****************************************************** */
+    /* Protected Functions. */
+    /* ****************************************************** */
+
+    @Override
+    protected void setUp()
+    {
+        mFieldCache = new MamaFieldCache();
+        mFieldCacheInt32 = new MamaFieldCacheInt32(101, "example", true);
+        mFieldCacheInt32_2 = new MamaFieldCacheInt32(102, "example2", true);
+    }
+
+    @Override
+    protected void tearDown()
+    {
+    }
+
+    /* ****************************************************** */
+    /* Test Functions. */
+    /* ****************************************************** */
+  
+    public void testAdd()
+    {
+        mFieldCache.add(mFieldCacheInt32);
+        assertEquals(mFieldCache.find(101), mFieldCacheInt32);
+    }
+
+    public void testFindOrAddDescriptor()
+    {
+        String example3 = "example3";
+        mFieldDescriptor = new MamaFieldDescriptor( 101, (short) 18, "example3", example3);
+        assertEquals(mFieldCache.find(mFieldDescriptor), null);
+        mFieldCache.findOrAdd(mFieldDescriptor);
+        assertEquals(mFieldCache.find(101).getDescriptor().toString(), example3);
+    }
+
+    public void testFindOrAdd()
+    {
+        String example3 = "example3";
+        assertEquals(mFieldCache.find(101), null);
+        mFieldCache.findOrAdd(101, (short) 18, "example3");
+        assertEquals(mFieldCache.find(101).getDescriptor().toString(), "I32");
+    }
+
+    public void testSetTrackModState()
+    {
+        assertEquals(mFieldCache.getTrackModState(), false);
+        mFieldCache.setTrackModState(true);
+        assertEquals(mFieldCache.getTrackModState(), true);
+    }
+
+    public void testSetOverrideDescriptorTrackModState()
+    {
+        assertEquals(mFieldCache.getOverrideDescriptorTrackModState(), true);
+        mFieldCache.setOverrideDescriptorTrackModState(false);
+        assertEquals(mFieldCache.getOverrideDescriptorTrackModState(), false);
+    }
+
+}

--- a/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCacheUint16Test.java
+++ b/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCacheUint16Test.java
@@ -1,0 +1,163 @@
+/* $Id$
+ *
+ * OpenMAMA: The open middleware agnostic messaging API
+ * Copyright (C) 2011 NYSE Technologies, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+import junit.framework.*;
+import com.wombat.mama.*;
+
+/**
+ *
+ * This class will test MamaFieldCacheUint16's functions
+ */
+public class MamaFieldCacheUint16Test extends TestCase
+{
+    /* ****************************************************** */
+    /* Protected Member Variables. */
+    /* ****************************************************** */
+    
+    protected MamaMsg mMsg;
+    protected MamaFieldCacheUint16 mFieldCacheUint16;
+
+    /* ****************************************************** */
+    /* Protected Functions. */
+    /* ****************************************************** */
+
+    @Override
+    protected void setUp()
+    {
+        mFieldCacheUint16 = new MamaFieldCacheUint16(101, "example", true);
+        mMsg = new MamaMsg();   
+    }
+
+    @Override
+    protected void tearDown()
+    {
+    }
+
+    /* ****************************************************** */
+    /* Test Functions. */
+    /* ****************************************************** */
+
+    public void testAddToMessage()
+    {
+        //set the value of the field to true (the default, otherwise, is false
+        mFieldCacheUint16.set(1);
+        //add it to the message
+        mFieldCacheUint16.addToMessage(false, mMsg);
+        //check we can get the value of true returned to us when searching for the field
+        assertEquals(mMsg.getU16("example", 101), 1);
+    }
+
+    public void testAddToMessagefieldName()
+    {
+        //set the value of the field to true (the default, otherwise, is false
+        mFieldCacheUint16.set(1);
+        //add it to the message
+        mFieldCacheUint16.addToMessage(true, mMsg);
+        //check we can get the value of true returned to us when searching for the field
+        assertEquals(mMsg.getU16("example", 101), 1);
+    }
+
+    public void testCopy()
+    {
+        MamaFieldCacheField copyCache =  mFieldCacheUint16.copy();
+        assertEquals(mFieldCacheUint16.getAsString(), copyCache.getAsString());
+    }
+
+    public void testApplyMsgField()
+    {
+        MamaFieldCacheUint16 testCacheUint16 = new MamaFieldCacheUint16(102, "example2", true);
+        mFieldCacheUint16.set(2);
+        testCacheUint16.set(1);
+        assertEquals(testCacheUint16.get(), 1);
+        assertEquals(mFieldCacheUint16.get(), 2);
+        mFieldCacheUint16.apply(testCacheUint16);
+        assertEquals(mFieldCacheUint16.get(), 1);
+    }
+
+    public void testApplyFieldCache()
+    {
+       MamaFieldCacheUint16 testField  = new MamaFieldCacheUint16(102, "example2", true);
+       testField.set(1);
+       mFieldCacheUint16.apply(testField);
+       assertEquals(mFieldCacheUint16.get(), 1);
+    }
+
+
+    public void testSet()
+    {
+        MamaFieldCacheUint16 testCacheUint16 = new MamaFieldCacheUint16(102, "example2", false);
+
+        assertEquals(testCacheUint16.get(), 0);
+        testCacheUint16.set(1);
+        //set without track state
+        assertEquals(testCacheUint16.get(), 1);
+
+        assertEquals(MamaFieldCacheField.MOD_STATE_MODIFIED, testCacheUint16.getModState());
+
+    }
+
+    public void testSetTrackState()
+    {
+        assertEquals(mFieldCacheUint16.get(), 0);
+        mFieldCacheUint16.set(1);
+        //set with track state
+        assertEquals(mFieldCacheUint16.get(), 1);
+        assertEquals(MamaFieldCacheField.MOD_STATE_MODIFIED, mFieldCacheUint16.getModState());
+    }
+
+    public void testSetTrackStateTouched()
+    {
+    
+        assertEquals(mFieldCacheUint16.get(), 0);
+        mFieldCacheUint16.set(1);
+        mFieldCacheUint16.set(1);
+        //set with track state
+        assertEquals(mFieldCacheUint16.get(), 1);
+        assertEquals(MamaFieldCacheField.MOD_STATE_TOUCHED, mFieldCacheUint16.getModState());
+
+    }
+
+    public void testIsEqual()
+    {   
+        MamaFieldCacheUint16 testCacheUint16 = new MamaFieldCacheUint16(102, "example2", true);
+        testCacheUint16.set(1);
+        mFieldCacheUint16.set(1);
+        assertEquals(testCacheUint16.get(), 1);
+        assertEquals(mFieldCacheUint16.get(), 1);
+        assertTrue(testCacheUint16.isEqual(mFieldCacheUint16.get()));
+    }
+
+    public void testGet()
+    {
+        assertEquals(mFieldCacheUint16.get(), 0);
+        mFieldCacheUint16.set(1);
+        assertEquals(mFieldCacheUint16.get(), 1);
+    }
+
+    public void testGetAsString()
+    {
+        assertEquals(mFieldCacheUint16.get(), 0);
+        assertEquals("0", mFieldCacheUint16.getAsString());
+        mFieldCacheUint16.set(1);
+        assertEquals(mFieldCacheUint16.get(), 1);
+        assertEquals("1", mFieldCacheUint16.getAsString());
+    }
+}

--- a/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCacheUint32Test.java
+++ b/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCacheUint32Test.java
@@ -1,0 +1,163 @@
+/* $Id$
+ *
+ * OpenMAMA: The open middleware agnostic messaging API
+ * Copyright (C) 2011 NYSE Technologies, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+import junit.framework.*;
+import com.wombat.mama.*;
+
+/**
+ *
+ * This class will test MamaFieldCacheUint32's functions
+ */
+public class MamaFieldCacheUint32Test extends TestCase
+{
+    /* ****************************************************** */
+    /* Protected Member Variables. */
+    /* ****************************************************** */
+    
+    protected MamaMsg mMsg;
+    protected MamaFieldCacheUint32 mFieldCacheUint32;
+
+    /* ****************************************************** */
+    /* Protected Functions. */
+    /* ****************************************************** */
+
+    @Override
+    protected void setUp()
+    {
+        mFieldCacheUint32 = new MamaFieldCacheUint32(101, "example", true);
+        mMsg = new MamaMsg();   
+    }
+
+    @Override
+    protected void tearDown()
+    {
+    }
+
+    /* ****************************************************** */
+    /* Test Functions. */
+    /* ****************************************************** */
+
+    public void testAddToMessage()
+    {
+        //set the value of the field to true (the default, otherwise, is false
+        mFieldCacheUint32.set(1);
+        //add it to the message
+        mFieldCacheUint32.addToMessage(false, mMsg);
+        //check we can get the value of true returned to us when searching for the field
+        assertEquals(mMsg.getU32("example", 101), 1);
+    }
+
+    public void testAddToMessagefieldName()
+    {
+        //set the value of the field to true (the default, otherwise, is false
+        mFieldCacheUint32.set(1);
+        //add it to the message
+        mFieldCacheUint32.addToMessage(true, mMsg);
+        //check we can get the value of true returned to us when searching for the field
+        assertEquals(mMsg.getU32("example", 101), 1);
+    }
+
+    public void testCopy()
+    {
+        MamaFieldCacheField copyCache =  mFieldCacheUint32.copy();
+        assertEquals(mFieldCacheUint32.getAsString(), copyCache.getAsString());
+    }
+
+    public void testApplyMsgField()
+    {
+        MamaFieldCacheUint32 testCacheUint32 = new MamaFieldCacheUint32(102, "example2", true);
+        mFieldCacheUint32.set(2);
+        testCacheUint32.set(1);
+        assertEquals(testCacheUint32.get(), 1);
+        assertEquals(mFieldCacheUint32.get(), 2);
+        mFieldCacheUint32.apply(testCacheUint32);
+        assertEquals(mFieldCacheUint32.get(), 1);
+    }
+
+    public void testApplyFieldCache()
+    {
+       MamaFieldCacheUint32 testField  = new MamaFieldCacheUint32(102, "example2", true);
+       testField.set(1);
+       mFieldCacheUint32.apply(testField);
+       assertEquals(mFieldCacheUint32.get(), 1);
+    }
+
+
+    public void testSet()
+    {
+        MamaFieldCacheUint32 testCacheUint32 = new MamaFieldCacheUint32(102, "example2", false);
+
+        assertEquals(testCacheUint32.get(), 0);
+        testCacheUint32.set(1);
+        //set without track state
+        assertEquals(testCacheUint32.get(), 1);
+
+        assertEquals(MamaFieldCacheField.MOD_STATE_MODIFIED, testCacheUint32.getModState());
+
+    }
+
+    public void testSetTrackState()
+    {
+        assertEquals(mFieldCacheUint32.get(), 0);
+        mFieldCacheUint32.set(1);
+        //set with track state
+        assertEquals(mFieldCacheUint32.get(), 1);
+        assertEquals(MamaFieldCacheField.MOD_STATE_MODIFIED, mFieldCacheUint32.getModState());
+    }
+
+    public void testSetTrackStateTouched()
+    {
+    
+        assertEquals(mFieldCacheUint32.get(), 0);
+        mFieldCacheUint32.set(1);
+        mFieldCacheUint32.set(1);
+        //set with track state
+        assertEquals(mFieldCacheUint32.get(), 1);
+        assertEquals(MamaFieldCacheField.MOD_STATE_TOUCHED, mFieldCacheUint32.getModState());
+
+    }
+
+    public void testIsEqual()
+    {   
+        MamaFieldCacheUint32 testCacheUint32 = new MamaFieldCacheUint32(102, "example2", true);
+        testCacheUint32.set(1);
+        mFieldCacheUint32.set(1);
+        assertEquals(testCacheUint32.get(), 1);
+        assertEquals(mFieldCacheUint32.get(), 1);
+        assertTrue(testCacheUint32.isEqual(mFieldCacheUint32.get()));
+    }
+
+    public void testGet()
+    {
+        assertEquals(mFieldCacheUint32.get(), 0);
+        mFieldCacheUint32.set(1);
+        assertEquals(mFieldCacheUint32.get(), 1);
+    }
+
+    public void testGetAsString()
+    {
+        assertEquals(mFieldCacheUint32.get(), 0);
+        assertEquals("0", mFieldCacheUint32.getAsString());
+        mFieldCacheUint32.set(1);
+        assertEquals(mFieldCacheUint32.get(), 1);
+        assertEquals("1", mFieldCacheUint32.getAsString());
+    }
+}

--- a/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCacheUint64Test.java
+++ b/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCacheUint64Test.java
@@ -1,0 +1,163 @@
+/* $Id$
+ *
+ * OpenMAMA: The open middleware agnostic messaging API
+ * Copyright (C) 2011 NYSE Technologies, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+import junit.framework.*;
+import com.wombat.mama.*;
+
+/**
+ *
+ * This class will test MamaFieldCacheUint64's functions
+ */
+public class MamaFieldCacheUint64Test extends TestCase
+{
+    /* ****************************************************** */
+    /* Protected Member Variables. */
+    /* ****************************************************** */
+    
+    protected MamaMsg mMsg;
+    protected MamaFieldCacheUint64 mFieldCacheUint64;
+
+    /* ****************************************************** */
+    /* Protected Functions. */
+    /* ****************************************************** */
+
+    @Override
+    protected void setUp()
+    {
+        mFieldCacheUint64 = new MamaFieldCacheUint64(101, "example", true);
+        mMsg = new MamaMsg();   
+    }
+
+    @Override
+    protected void tearDown()
+    {
+    }
+
+    /* ****************************************************** */
+    /* Test Functions. */
+    /* ****************************************************** */
+
+    public void testAddToMessage()
+    {
+        //set the value of the field to true (the default, otherwise, is false
+        mFieldCacheUint64.set(1);
+        //add it to the message
+        mFieldCacheUint64.addToMessage(false, mMsg);
+        //check we can get the value of true returned to us when searching for the field
+        assertEquals(mMsg.getU64("example", 101), 1);
+    }
+
+    public void testAddToMessagefieldName()
+    {
+        //set the value of the field to true (the default, otherwise, is false
+        mFieldCacheUint64.set(1);
+        //add it to the message
+        mFieldCacheUint64.addToMessage(true, mMsg);
+        //check we can get the value of true returned to us when searching for the field
+        assertEquals(mMsg.getU64("example", 101), 1);
+    }
+
+    public void testCopy()
+    {
+        MamaFieldCacheField copyCache =  mFieldCacheUint64.copy();
+        assertEquals(mFieldCacheUint64.getAsString(), copyCache.getAsString());
+    }
+
+    public void testApplyMsgField()
+    {
+        MamaFieldCacheUint64 testCacheUint64 = new MamaFieldCacheUint64(102, "example2", true);
+        mFieldCacheUint64.set(2);
+        testCacheUint64.set(1);
+        assertEquals(testCacheUint64.get(), 1);
+        assertEquals(mFieldCacheUint64.get(), 2);
+        mFieldCacheUint64.apply(testCacheUint64);
+        assertEquals(mFieldCacheUint64.get(), 1);
+    }
+
+    public void testApplyFieldCache()
+    {
+       MamaFieldCacheUint64 testField  = new MamaFieldCacheUint64(102, "example2", true);
+       testField.set(1);
+       mFieldCacheUint64.apply(testField);
+       assertEquals(mFieldCacheUint64.get(), 1);
+    }
+
+
+    public void testSet()
+    {
+        MamaFieldCacheUint64 testCacheUint64 = new MamaFieldCacheUint64(102, "example2", false);
+
+        assertEquals(testCacheUint64.get(), 0);
+        testCacheUint64.set(1);
+        //set without track state
+        assertEquals(testCacheUint64.get(), 1);
+
+        assertEquals(MamaFieldCacheField.MOD_STATE_MODIFIED, testCacheUint64.getModState());
+
+    }
+
+    public void testSetTrackState()
+    {
+        assertEquals(mFieldCacheUint64.get(), 0);
+        mFieldCacheUint64.set(1);
+        //set with track state
+        assertEquals(mFieldCacheUint64.get(), 1);
+        assertEquals(MamaFieldCacheField.MOD_STATE_MODIFIED, mFieldCacheUint64.getModState());
+    }
+
+    public void testSetTrackStateTouched()
+    {
+    
+        assertEquals(mFieldCacheUint64.get(), 0);
+        mFieldCacheUint64.set(1);
+        mFieldCacheUint64.set(1);
+        //set with track state
+        assertEquals(mFieldCacheUint64.get(), 1);
+        assertEquals(MamaFieldCacheField.MOD_STATE_TOUCHED, mFieldCacheUint64.getModState());
+
+    }
+
+    public void testIsEqual()
+    {   
+        MamaFieldCacheUint64 testCacheUint64 = new MamaFieldCacheUint64(102, "example2", true);
+        testCacheUint64.set(1);
+        mFieldCacheUint64.set(1);
+        assertEquals(testCacheUint64.get(), 1);
+        assertEquals(mFieldCacheUint64.get(), 1);
+        assertTrue(testCacheUint64.isEqual(mFieldCacheUint64.get()));
+    }
+
+    public void testGet()
+    {
+        assertEquals(mFieldCacheUint64.get(), 0);
+        mFieldCacheUint64.set(1);
+        assertEquals(mFieldCacheUint64.get(), 1);
+    }
+
+    public void testGetAsString()
+    {
+        assertEquals(mFieldCacheUint64.get(), 0);
+        assertEquals("0", mFieldCacheUint64.getAsString());
+        mFieldCacheUint64.set(1);
+        assertEquals(mFieldCacheUint64.get(), 1);
+        assertEquals("1", mFieldCacheUint64.getAsString());
+    }
+}

--- a/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCacheUint8Test.java
+++ b/mama/jni/src/test/java/com/wombat/mama/junittests/fieldcache/MamaFieldCacheUint8Test.java
@@ -1,0 +1,163 @@
+/* $Id$
+ *
+ * OpenMAMA: The open middleware agnostic messaging API
+ * Copyright (C) 2011 NYSE Technologies, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+import junit.framework.*;
+import com.wombat.mama.*;
+
+/**
+ *
+ * This class will test MamaFieldCacheUint8's functions
+ */
+public class MamaFieldCacheUint8Test extends TestCase
+{
+    /* ****************************************************** */
+    /* Protected Member Variables. */
+    /* ****************************************************** */
+    
+    protected MamaMsg mMsg;
+    protected MamaFieldCacheUint8 mFieldCacheUint8;
+
+    /* ****************************************************** */
+    /* Protected Functions. */
+    /* ****************************************************** */
+
+    @Override
+    protected void setUp()
+    {
+        mFieldCacheUint8 = new MamaFieldCacheUint8(101, "example", true);
+        mMsg = new MamaMsg();   
+    }
+
+    @Override
+    protected void tearDown()
+    {
+    }
+
+    /* ****************************************************** */
+    /* Test Functions. */
+    /* ****************************************************** */
+
+    public void testAddToMessage()
+    {
+        //set the value of the field to true (the default, otherwise, is false
+        mFieldCacheUint8.set((short)1);
+        //add it to the message
+        mFieldCacheUint8.addToMessage(false, mMsg);
+        //check we can get the value of true returned to us when searching for the field
+        assertEquals(mMsg.getU8("example", 101), 1);
+    }
+
+    public void testAddToMessagefieldName()
+    {
+        //set the value of the field to true (the default, otherwise, is false
+        mFieldCacheUint8.set((short)1);
+        //add it to the message
+        mFieldCacheUint8.addToMessage(true, mMsg);
+        //check we can get the value of true returned to us when searching for the field
+        assertEquals(mMsg.getU8("example", 101), 1);
+    }
+
+    public void testCopy()
+    {
+        MamaFieldCacheField copyCache =  mFieldCacheUint8.copy();
+        assertEquals(mFieldCacheUint8.getAsString(), copyCache.getAsString());
+    }
+
+    public void testApplyMsgField()
+    {
+        MamaFieldCacheUint8 testCacheUint8 = new MamaFieldCacheUint8(102, "example2", true);
+        mFieldCacheUint8.set((short)2);
+        testCacheUint8.set((short)1);
+        assertEquals(testCacheUint8.get(), 1);
+        assertEquals(mFieldCacheUint8.get(), 2);
+        mFieldCacheUint8.apply(testCacheUint8);
+        assertEquals(mFieldCacheUint8.get(), 1);
+    }
+
+    public void testApplyFieldCache()
+    {
+       MamaFieldCacheUint8 testField  = new MamaFieldCacheUint8(102, "example2", true);
+       testField.set((short)1);
+       mFieldCacheUint8.apply(testField);
+       assertEquals(mFieldCacheUint8.get(), 1);
+    }
+
+
+    public void testSet()
+    {
+        MamaFieldCacheUint8 testCacheUint8 = new MamaFieldCacheUint8(102, "example2", false);
+
+        assertEquals(testCacheUint8.get(), 0);
+        testCacheUint8.set((short)1);
+        //set without track state
+        assertEquals(testCacheUint8.get(), 1);
+
+        assertEquals(MamaFieldCacheField.MOD_STATE_MODIFIED, testCacheUint8.getModState());
+
+    }
+
+    public void testSetTrackState()
+    {
+        assertEquals(mFieldCacheUint8.get(), 0);
+        mFieldCacheUint8.set((short)1);
+        //set with track state
+        assertEquals(mFieldCacheUint8.get(), 1);
+        assertEquals(MamaFieldCacheField.MOD_STATE_MODIFIED, mFieldCacheUint8.getModState());
+    }
+
+    public void testSetTrackStateTouched()
+    {
+    
+        assertEquals(mFieldCacheUint8.get(), 0);
+        mFieldCacheUint8.set((short)1);
+        mFieldCacheUint8.set((short)1);
+        //set with track state
+        assertEquals(mFieldCacheUint8.get(), 1);
+        assertEquals(MamaFieldCacheField.MOD_STATE_TOUCHED, mFieldCacheUint8.getModState());
+
+    }
+
+    public void testIsEqual()
+    {   
+        MamaFieldCacheUint8 testCacheUint8 = new MamaFieldCacheUint8(102, "example2", true);
+        testCacheUint8.set((short)1);
+        mFieldCacheUint8.set((short)1);
+        assertEquals(testCacheUint8.get(), 1);
+        assertEquals(mFieldCacheUint8.get(), 1);
+        assertTrue(testCacheUint8.isEqual(mFieldCacheUint8.get()));
+    }
+
+    public void testGet()
+    {
+        assertEquals(mFieldCacheUint8.get(), 0);
+        mFieldCacheUint8.set((short)1);
+        assertEquals(mFieldCacheUint8.get(), 1);
+    }
+
+    public void testGetAsString()
+    {
+        assertEquals(mFieldCacheUint8.get(), 0);
+        assertEquals("0", mFieldCacheUint8.getAsString());
+        mFieldCacheUint8.set((short)1);
+        assertEquals(mFieldCacheUint8.get(), 1);
+        assertEquals("1", mFieldCacheUint8.getAsString());
+    }
+}


### PR DESCRIPTION
# PLAT-1181
## Summary
Adding fieldcache functionality to JNI in OpenMAMA

## Areas Affected
*Place an 'x' within the braces to check the box*
- [ ] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [X] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [X] Unit Tests
- [ ] Examples

## Testing
Includes relevant junittests
