### PR TITLE
PLAT-1309

### DIFF
--- a/mama/jni/build.xml
+++ b/mama/jni/build.xml
@@ -49,6 +49,12 @@
         <javac source="1.5" srcdir="src/main/java" destdir="${build}" debug="true" deprecation="on">
             <!-- All the JNI Java files required -->
             <patternset refid="src.base"></patternset>
+            <!-- Will include any Common java files required for the build (searched by javac) -->
+            <sourcepath location="${basedir}/../../common/jni/src">
+                <fileset dir=".">
+                    <include name="**/*.java"></include>
+                </fileset>
+            </sourcepath>
         </javac>
     </target>
 
@@ -70,6 +76,7 @@
         <copy flatten="true" todir="${dist}/examples">
             <fileset dir="${basedir}/../jni/src/main/java">
                 <include name="com/**/MamaListen.java"></include>
+                <include name="com/**/MamaListenCached.java"></include>
                 <include name="com/**/MamaTest.java"></include>
                 <include name="com/**/MamaTestJava.java"></include>
                 <include name="com/**/MamaPublisherJava.java"></include>
@@ -153,6 +160,11 @@
         <!-- JUnit jar must already be on the classpath -->
         <javac source="1.5" srcdir="src/test/java" destdir="${build}/junittests" debug="true" deprecation="on">
             <patternset refid="src.junittests"></patternset>
+            <classpath>
+            <fileset dir="../../../thirdparty/junit">
+                    <include name="junit-4.10.jar"></include>
+            </fileset>
+            </classpath>
             <classpath>
                 <fileset dir="${dist}/lib/">
                     <include name="${base}.jar"></include>

--- a/mamda/java/build.xml
+++ b/mamda/java/build.xml
@@ -175,6 +175,16 @@
         <javac source="1.5" srcdir="${top}/src/test/java" destdir="${build}_junittests" debug="true">
             <patternset refid="src.junittests"></patternset>
             <classpath>
+            <fileset dir="../../../thirdparty/junit">
+                    <include name="junit-4.10.jar"></include>
+            </fileset>
+            </classpath>             
+           <classpath>
+            <fileset dir="${dist}/lib">
+                    <include name="${product}_book.jar"></include>
+            </fileset>
+            </classpath>
+            <classpath>
                 <fileset dir="${mama.dir}/lib">
                     <include name="mama.jar"></include>
                     <include name="mama_noent.jar"></include>


### PR DESCRIPTION
* PLAT-1309: 

# PLAT-1309
## Summary
Remove the JUnittests from building by default

## Areas Affected
*Place an 'x' within the braces to check the box*
- [ ] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [X] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details

Move the junittests from being built with a normal jni build.
Now they will only be built when specifically building with
"-g --with-unittests=xxx"