### PR TITLE
PLAT 1365

### DIFF
--- a/mama/c_cpp/src/c/dqpublisher.c
+++ b/mama/c_cpp/src/c/dqpublisher.c
@@ -112,6 +112,8 @@ mama_status mamaDQPublisher_addTopic (mamaDQPublisher pub, const char* topic)
     if (!ctx)
     {
         ctx = calloc (1, sizeof (topicCtx));
+        ctx->mSeqNum = 1;
+        ctx->mStatus = MAMA_MSG_STATUS_OK;
 
         if (wtable_insert (impl->mTopicCtxs, (char*)topic, ctx) != 1)
         {
@@ -206,7 +208,12 @@ mama_status mamaDQPublisher_sendReply (mamaDQPublisher pub,
     topicCtx*            ctx    = NULL;
     mama_status          status = MAMA_STATUS_OK;
 
-    status = getTopicCtx (pub, request, &ctx);
+    status = getTopicCtx (pub, reply, &ctx);
+
+    if (status != MAMA_STATUS_OK)
+    {
+        return status;
+    }
 
     if (impl->mSenderId != 0)
         updateSenderId(impl, reply);
@@ -238,6 +245,11 @@ mama_status mamaDQPublisher_sendReplyWithHandle (mamaDQPublisher pub,
     mama_status          status = MAMA_STATUS_OK;
 
     status = getTopicCtx (pub, reply, &ctx);
+
+    if (status != MAMA_STATUS_OK)
+    {
+        return status;
+    }
 
     if (impl->mSenderId != 0)
         updateSenderId(impl, reply);
@@ -467,6 +479,7 @@ static mama_status getTopicCtx (mamaDQPublisher pub, mamaMsg msg, topicCtx** ctx
     }
     else
     {
+
         status = msgUtils_getIssueSymbol (msg, &symbol);
 
         if (status != MAMA_STATUS_OK)

--- a/mama/c_cpp/src/c/mama/dqpublisher.h
+++ b/mama/c_cpp/src/c/mama/dqpublisher.h
@@ -56,9 +56,18 @@ extern mama_status
 mamaDQPublisher_create (mamaDQPublisher pub, mamaTransport transport,
                  	 	 const char* topic);
 
-//STUTEST
-mama_status mamaDQPPublisher_createGroupPublisher (mamaDQPublisher pub, mamaTransport transport,
-                                                   const char* topic);
+
+/**
+ * Add a new topic context to a mamaDQPublisher.
+ *
+ * Having topic contexts allows a single publisher to publish messages with
+ * different wIssueSymbol fields with sequence number and status tracked
+ * separately for each wIssueSymbol.
+ *
+ */
+MAMAExpDLL
+mama_status mamaDQPublisher_addTopic (mamaDQPublisher pub, const char* topic);
+
 
 /**
  * Send a message.

--- a/mama/c_cpp/src/c/mama/dqpublisher.h
+++ b/mama/c_cpp/src/c/mama/dqpublisher.h
@@ -56,6 +56,10 @@ extern mama_status
 mamaDQPublisher_create (mamaDQPublisher pub, mamaTransport transport,
                  	 	 const char* topic);
 
+//STUTEST
+mama_status mamaDQPPublisher_createGroupPublisher (mamaDQPublisher pub, mamaTransport transport,
+                                                   const char* topic);
+
 /**
  * Send a message.
  *


### PR DESCRIPTION
# PLAT-1365
## Summary
Create multiple publishers with the same topic

## Areas Affected
*Place an 'x' within the braces to check the box*
- [X] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
This change allows a mamaDQPublisher object to be used to publish to a group subscription.  A single mamaDQPublisher object can now be associated with multiple wIssueSymbols (or wIndexSymbol) but publish to one overall symbol. Eg the publisher's symbol could be MSFT.GROUP but you could associate MSFT.A and MSFT.B with it. Messages could be sent from that publisher containing either MSFT.A or MSFT.B in the wIssueSymbol field. Messages with different wIssueSymbols have separate streams of sequence numbers so a single publisher object could send 

message 1: wIssueSymbol MSFT.A MdSeqNum = 1
message 2: wIssueSymbol MSFT.B MdSeqNum = 1
message 3: wIssueSymbol MSFT.B MdSeqNum = 2
message 3: wIssueSymbol MSFT.A MdSeqNum = 2

There is a new function added which allows you to associate topics with the publisher.