### PR TITLE
Fix timezone double add in mamaDateTime_getAsFormattedStringWithTz(),…

### DIFF
--- a/mama/c_cpp/src/c/datetime.c
+++ b/mama/c_cpp/src/c/datetime.c
@@ -1410,8 +1410,6 @@ mamaDateTime_getAsFormattedStringWithTz (const mamaDateTime dateTime,
 
     if (offset != 0)
     {
-        mamaDateTime  tmpDateTime = (mama_datetime_t*)dateTime;
-        mamaDateTime_addWholeSeconds (tmpDateTime, offset);
         // Convert time into an Apache APR exploded time
         apr_time_ansi_put(&time_apr, (time_t)impl->mSeconds);
         apr_time_exp_tz(&time_apr_exploded, time_apr, (apr_int32_t)offset);


### PR DESCRIPTION
# PR_TITLE
## Summary

Fix timezone double add in mamaDateTime_getAsFormattedStringWithTz(), apr_time_exp_tz() adds it already.

## Areas Affected
- [x] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details

Remove the two lines that add the timezone offset before calling apr_time_exp_tz() which adds the timezone offset again.

## Testing

Construct a message using local timezone, then print the message using local timezone.  The mamaproducerc_v2 and mamaconsumerc_v2 use a local timezone.
