### PR TITLE
Mama date time get struct time val with tz fix

### DIFF
--- a/mama/c_cpp/src/c/datetime.c
+++ b/mama/c_cpp/src/c/datetime.c
@@ -1059,7 +1059,7 @@ mamaDateTime_getStructTimeValWithTz(const mamaDateTime dateTime,
     {
         mama_i32_t  offset   = 0;
         mamaTimeZone_getOffset (tz, &offset);
-        result->tv_usec += offset;
+        result->tv_sec += offset;
     }
 
     return MAMA_STATUS_OK;


### PR DESCRIPTION
# PR_TITLE
## Summary
Timezone offset added to tv_usec instead of tv_sec.

## Areas Affected
- [ x] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
mamaDateTime_getStructTimeValWithTz() returns a struct timeval, with timezone offset applied.  The timezone is in seconds, not microseconds, so it should be added to tv_sec.

## Testing