### PR TITLE
Plugin Fixes

### DIFF
--- a/mama/c_cpp/src/c/dqstrategyplugin/dqstrategyplugin.c
+++ b/mama/c_cpp/src/c/dqstrategyplugin/dqstrategyplugin.c
@@ -382,6 +382,12 @@ dqstrategyMamaPlugin_subscriptionDestroyHook(mamaPluginInfo pluginInfo,
 
     strategy = mamaSubscription_getDqStrategy(subscription);
 
+    /* basic subscriptions will not have a dqStrategy */
+    if (NULL == strategy)
+    {
+        return MAMA_STATUS_OK;
+    }
+
     if (MAMA_STATUS_OK == dqStrategy_destroy(strategy))
     {
         return MAMA_STATUS_OK;

--- a/mama/c_cpp/src/c/plugin.c
+++ b/mama/c_cpp/src/c/plugin.c
@@ -527,7 +527,7 @@ mamaPlugin_fireSubscriptionDestroyHook (mamaSubscription subscription)
     {
         if (gPlugins[plugin] != NULL)
         {
-            if (gPlugins[plugin]->mamaPluginSubscriptionPreMsgHook != NULL)
+            if (gPlugins[plugin]->mamaPluginSubscriptionDestroyHook != NULL)
             {
                 status = gPlugins[plugin]->mamaPluginSubscriptionDestroyHook (gPlugins[plugin]->mPluginInfo, subscription);
 


### PR DESCRIPTION
# Plugin Fixes
## Summary
Several bugfixes to mama plugins

## Areas Affected
- [x] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
A few changes to mama plugins to:
- Fixed a test condition within mamaPlugin_fireSubscriptionDestroyHook() causing
the subscriptionDestroyHook to be wrongly fired - when you specify a subscriptionPreMsgHook but not a subscriptionDestroyHook.
- Fixed a minor dqstrategy plugin issue destroying basic subscriptions.
- Remove several valgrind "invalid read/write" errors.

## Testing

- Running a mamaproducerc_v2 / mamaconsumerc_v2 test (with a plugin) would core on shutdown due to mamaPlugin_fireSubscriptionDestroyHook() being called incorrectly.

- You would get the following warning on shutdown when trying to destroy a basic subscription:
```
2018-06-14 06:21:26: mamaPlugin_subscriptionDestroyHook      (): Subscription destroy failed for mama plugin [dqstrategy]
```

- We were getting the following valgrind output with the dqstrategy plugin when no other plugins were specified/loaded via the mama.properties:
```
==16785== Invalid write of size 8
==16785==    at 0x4C467A4: mama_loadPlugin (plugin.c:309)
==16785==    by 0x4C46556: mama_initPlugins (plugin.c:203)
==16785==    by 0x4C42098: mama_openWithPropertiesCount (mama.c:932)
==16785==    by 0x4C429CC: mama_open (mama.c:1223)
==16785==    by 0x403F15: initializeMama (mamalistenc.c:800)
==16785==    by 0x403251: main (mamalistenc.c:333)
==16785==  Address 0x6defb58 is 0 bytes after a block of size 8 alloc'd
==16785==    at 0x4A057BB: calloc (vg_replace_malloc.c:593)
==16785==    by 0x4C46508: mama_initPlugins (plugin.c:193)
==16785==    by 0x4C42098: mama_openWithPropertiesCount (mama.c:932)
==16785==    by 0x4C429CC: mama_open (mama.c:1223)
==16785==    by 0x403F15: initializeMama (mamalistenc.c:800)
==16785==    by 0x403251: main (mamalistenc.c:333)
==16785== 
==16785== Invalid read of size 8
==16785==    at 0x4C46B84: mamaPlugin_fireTransportPostCreateHook (plugin.c:405)
==16785==    by 0x4C73A88: mamaTransport_create (transport.c:930)
==16785==    by 0x4040BF: initializeMama (mamalistenc.c:854)
==16785==    by 0x403251: main (mamalistenc.c:333)
==16785==  Address 0x6defb58 is 0 bytes after a block of size 8 alloc'd
==16785==    at 0x4A057BB: calloc (vg_replace_malloc.c:593)
==16785==    by 0x4C46508: mama_initPlugins (plugin.c:193)
==16785==    by 0x4C42098: mama_openWithPropertiesCount (mama.c:932)
==16785==    by 0x4C429CC: mama_open (mama.c:1223)
==16785==    by 0x403F15: initializeMama (mamalistenc.c:800)
==16785==    by 0x403251: main (mamalistenc.c:333)
==16785== 
```
Valgrind output is looking better