### PR TITLE
Fix forcommon include files no longer being generated correctly from scons

### DIFF
--- a/common/c_cpp/src/c/SConscript
+++ b/common/c_cpp/src/c/SConscript
@@ -11,9 +11,11 @@ osname = env['host']['os']
 if osname == 'Linux':
     includePath.append('./linux')
     includePath.append('./linux/wombat')
+    InstWomPlatformHeaders = Glob('linux/wombat/*.h')
 elif osname == 'Darwin':
     includePath.append('./darwin')
     includePath.append('./darwin/wombat')
+    InstWomPlatformHeaders = Glob('darwin/wombat/*.h')
 
 includePath.append('./wombat')
 
@@ -57,4 +59,5 @@ lib = env.StaticLibrary('libwombatcommon', objects)
 Alias('install', env.Install('$libdir', lib))
 Alias('install', env.Install('$incdir', InstHeaders))
 Alias('install', env.Install('$incdir/wombat', InstWomHeaders))
+Alias('install', env.Install('$incdir/wombat', InstWomPlatformHeaders))
 


### PR DESCRIPTION
Signed-off-by: Chris Morgan <Christopher.Morgan@solacesystems.com>

# Fix for Issue #371 
## Summary
*Patch to common c SConscript to include header files*

## Areas Affected
*Place an 'x' within the braces to check the box*
- [ ] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [X] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
*See Issue #371 *
