### PR TITLE
Restore mamaSubscription RecoverGaps functions

### DIFF
--- a/mama/c_cpp/src/c/mama/subscription.h
+++ b/mama/c_cpp/src/c/mama/subscription.h
@@ -745,6 +745,23 @@ mamaSubscription_getReceivedInitial(
     int *receivedInitial);
 
 /**
+ * @brief Whether the specified subscription will attempt to recover from sequence
+ * number gaps.
+ *
+ * @param[in] subscription The subscription
+ * @param[out] doesRecover 0 - does not recover, 1 - does attempt to recover
+ *
+ * @return mama_status return code can be one of:
+ *              MAMA_STATUS_NULL_ARG
+ *              MAMA_STATUS_OK
+ */
+MAMAExpDLL
+extern mama_status
+mamaSubscription_getRecoverGaps (
+    mamaSubscription subscription,
+    int *doesRecover);
+
+/**
  * @brief Returns a value of 1 or 0 indicating whether this subscription is
  * interested in initial values.
  *
@@ -1146,6 +1163,24 @@ extern mama_status
 mamaSubscription_setPreIntitialCacheSize(
     mamaSubscription subscription,
     int cacheSize);
+
+/**
+ * @brief Whether a subscription should attempt to recover from
+ * sequence number gaps.
+ *
+ * @param[in] subscription The subscription
+ * @param[out] doesRecover 0 indicates not to recover. 1 The subscription will
+ * attempt to recover via a recap request.
+ *
+ * @return mama_status return code can be one of:
+ *              MAMA_STATUS_NULL_ARG
+ *              MAMA_STATUS_OK
+ */
+MAMAExpDLL
+extern mama_status
+mamaSubscription_setRecoverGaps (
+    mamaSubscription subscription,
+    int              doesRecover);
 
 /**
  * @brief Whether an initial value is required for the specified subscription.

--- a/mama/c_cpp/src/c/subscription.c
+++ b/mama/c_cpp/src/c/subscription.c
@@ -1123,10 +1123,22 @@ mamaSubscription_hasWildcards (mamaSubscription subscription)
 }
 
 mama_status
+mamaSubscription_setRecoverGaps (mamaSubscription subscription, int doesRecover)
+{
+    return dqStrategy_setRecoverGaps(mamaSubscription_getDqStrategy(subscription), doesRecover);
+}
+
+mama_status
 mamaSubscription_setGroupSizeHint (mamaSubscription subscription, int groupSizeHint)
 {
     self->mGroupSizeHint = groupSizeHint;
     return MAMA_STATUS_OK;
+}
+
+mama_status
+mamaSubscription_getRecoverGaps (mamaSubscription subscription, int* result)
+{
+    return dqStrategy_getRecoverGaps(mamaSubscription_getDqStrategy(subscription), result);
 }
 
 SubjectContext *


### PR DESCRIPTION
Signed-off-by: Chris Morgan <Christopher.Morgan@solacesystems.com>

# Restore _mamaSubscription setRecoverGaps_ and _mamaSubscription getRecoverGaps_
## Summary
*Restores `mamaSubscription_setRecoverGaps` and `mamaSubscription_getRecoverGaps` functions using the new DqStrategy functions*

## Areas Affected
*Place an 'x' within the braces to check the box*
- [X] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
*This PR fixes the issue #370. The functions, `mamaSubscription_setRecoverGaps` and `mamaSubscription_getRecoverGaps` were removed in the latest release of OpenMAMA version 6.2.2. They seemed to be replaced by internal only functions `Dqstrategy_setRecoverGaps` and `Dqstrategy_getRecoverGaps` as a part of commit 1160121444b0fa5a8df6ebbe048583c7466a4b66.*

## Testing
*Built the solace bridge which is dependent on the missing functions on the following platforms, linux: x86_64, i386; windows: Win32 and Win64. Ran Openmama bridge integration tests and solace bridge unit tests on linux x86_64 platform.*
