### PR TITLE
ENTRY POSITION SUPPORT

### DIFF
--- a/mamda/c_cpp/src/cpp/orderbooks/MamdaOrderBook.cpp
+++ b/mamda/c_cpp/src/cpp/orderbooks/MamdaOrderBook.cpp
@@ -204,6 +204,49 @@ namespace Wombat
             const MamaDateTime&             eventTime,
             MamdaOrderBookBasicDelta*       delta);
 
+        void addEntry (
+            PlMap&                          bookSide,
+            MamdaOrderBookEntry*            entry,
+            double                          price,
+            MamdaOrderBookPriceLevel::Side  side,
+            const MamaDateTime&             eventTime,
+            MamdaOrderBookBasicDelta*       delta,
+            mama_u32_t                      entryPosition);
+        
+        void addEntry (
+            PlMap&                          bookSide,
+            MamdaOrderBookEntry*            entry,
+            MamaPrice&                      price,
+            MamdaOrderBookPriceLevel::Side  side,
+            const MamaDateTime&             eventTime,
+            MamdaOrderBookBasicDelta*       delta,
+            mama_u32_t                      entryPosition);
+    
+        void addEntry (
+            const char*                     entryId,
+            mama_quantity_t                 entrySize,
+            double                          price,
+            MamdaOrderBookPriceLevel::Side  side,
+            const MamaDateTime&             eventTime,
+            const MamaSourceDerivative*     source,
+            MamdaOrderBookBasicDelta*       delta,
+            mama_u32_t                      entryPosition);
+    
+        void addEntryAndSetDelta(
+            MamdaOrderBookEntry*              entry,
+            const MamaDateTime&               eventTime,
+            MamdaOrderBookBasicDelta*         delta,
+            MamdaOrderBookPriceLevel::Action  plAction, 
+            MamdaOrderBookPriceLevel*         level,
+            mama_u32_t                        entryPosition);
+
+        void updateEntry (
+            MamdaOrderBookEntry*            entry,
+            mama_quantity_t                 size,
+            const MamaDateTime&             eventTime,
+            MamdaOrderBookBasicDelta*       delta,
+            mama_u32_t                      entryPosition);
+
         void updateEntry (
             MamdaOrderBookEntry*            entry,
             mama_quantity_t                 size,
@@ -239,7 +282,14 @@ namespace Wombat
                        mama_quantity_t                      plDeltaSize,
                        MamdaOrderBookPriceLevel::Action     plAction,
                        MamdaOrderBookEntry::Action          entryAction);
-
+        
+        void addDelta (MamdaOrderBookEntry*                 entry,
+                       MamdaOrderBookPriceLevel*            level,
+                       mama_quantity_t                      plDeltaSize,
+                       MamdaOrderBookPriceLevel::Action     plAction,
+                       MamdaOrderBookEntry::Action          entryAction,
+                       mama_u32_t                           entryPositon);
+        
         bool reevaluate (
             /*MamdaOrderBookBasicDeltaList*   delta*/);
 
@@ -846,6 +896,39 @@ namespace Wombat
                             eventTime, delta);
     }
 
+    void MamdaOrderBook::addEntry (
+        MamdaOrderBookEntry*            entry,
+        MamaPrice&                      price,
+        MamdaOrderBookPriceLevel::Side  side,
+        const MamaDateTime&             eventTime,
+        MamdaOrderBookBasicDelta*       delta,
+        mama_u32_t                      entryPosition)
+    {
+        if (side == MamdaOrderBookPriceLevel::MAMDA_BOOK_SIDE_BID)
+            mImpl.addEntry (mImpl.mBidLevels, entry, price, side,
+                            eventTime, delta, entryPosition);
+        else if (side == MamdaOrderBookPriceLevel::MAMDA_BOOK_SIDE_ASK)
+            mImpl.addEntry (mImpl.mAskLevels, entry, price, side,
+                            eventTime, delta, entryPosition);
+    }
+    
+    void MamdaOrderBook::addEntry (
+        MamdaOrderBookEntry*            entry,
+        double                          price,
+        MamdaOrderBookPriceLevel::Side  side,
+        const MamaDateTime&             eventTime,
+        MamdaOrderBookBasicDelta*       delta,
+        mama_u32_t                      entryPosition)
+    {
+        if (side == MamdaOrderBookPriceLevel::MAMDA_BOOK_SIDE_BID)
+            mImpl.addEntry (mImpl.mBidLevels, entry, price, side,
+                            eventTime, delta, entryPosition);
+        else if (side == MamdaOrderBookPriceLevel::MAMDA_BOOK_SIDE_ASK)
+            mImpl.addEntry (mImpl.mAskLevels, entry, price, side,
+                            eventTime, delta, entryPosition);
+    }
+
+
 
     MamdaOrderBookEntry* MamdaOrderBook::addEntry (
         const char*                     entryId,
@@ -883,6 +966,43 @@ namespace Wombat
         return entry;
     }
 
+    MamdaOrderBookEntry* MamdaOrderBook::addEntry (
+        const char*                     entryId,
+        mama_quantity_t                 entrySize,
+        MamaPrice&                      price,
+        MamdaOrderBookPriceLevel::Side  side,
+        const MamaDateTime&             eventTime,
+        const MamaSourceDerivative*     source,
+        MamdaOrderBookBasicDelta*       delta,
+        mama_u32_t                      entryPosition)
+    {
+        MamdaOrderBookEntry*  entry = 
+            new MamdaOrderBookEntry (entryId, entrySize,
+                                    MamdaOrderBookEntry::MAMDA_BOOK_ACTION_ADD,
+                                    eventTime,
+                                    source);
+        addEntry (entry, price, side, eventTime, delta, entryPosition);
+        return entry;
+    }
+
+    MamdaOrderBookEntry* MamdaOrderBook::addEntry (
+        const char*                     entryId,
+        mama_quantity_t                 entrySize,
+        double                          price,
+        MamdaOrderBookPriceLevel::Side  side,
+        const MamaDateTime&             eventTime,
+        const MamaSourceDerivative*     source,
+        MamdaOrderBookBasicDelta*       delta,
+        mama_u32_t                      entryPosition)
+    {
+        MamdaOrderBookEntry*  entry = 
+            new MamdaOrderBookEntry (entryId, entrySize,
+                                    MamdaOrderBookEntry::MAMDA_BOOK_ACTION_ADD,
+                                    eventTime,
+                                    source);
+        addEntry (entry, price, side, eventTime, delta, entryPosition);
+        return entry;
+    }
 
     void MamdaOrderBook::updateEntry (
         MamdaOrderBookEntry*            entry,
@@ -891,6 +1011,16 @@ namespace Wombat
         MamdaOrderBookBasicDelta*       delta)
     {
         mImpl.updateEntry (entry, size, eventTime, delta);
+    }
+    
+    void MamdaOrderBook::updateEntry (
+        MamdaOrderBookEntry*            entry,
+        mama_quantity_t                 size,
+        const MamaDateTime&             eventTime,
+        MamdaOrderBookBasicDelta*       delta,
+        mama_u32_t                      entryPosition)
+    {
+        mImpl.updateEntry (entry, size, eventTime, delta, entryPosition);
     }
 
     void MamdaOrderBook::deleteEntry (
@@ -1243,6 +1373,18 @@ namespace Wombat
 
     {
         return mImpl.addDelta(entry, level, plDeltaSize, plAction, entryAction);
+    }
+    
+    void MamdaOrderBook::addDelta (
+        MamdaOrderBookEntry*              entry,
+        MamdaOrderBookPriceLevel*         level,
+        mama_quantity_t                   plDeltaSize,
+        MamdaOrderBookPriceLevel::Action  plAction,
+        MamdaOrderBookEntry::Action       entryAction,
+        mama_u32_t                        entryPosition)
+
+    {
+        return mImpl.addDelta(entry, level, plDeltaSize, plAction, entryAction, entryPosition);
     }
 
     void MamdaOrderBook::dump(std::ostream& output) const
@@ -2519,6 +2661,106 @@ namespace Wombat
         }
     }
 
+    void MamdaOrderBook::MamdaOrderBookImpl::addEntry (
+        PlMap&                          bookSide,
+        MamdaOrderBookEntry*            entry,
+        MamaPrice&                      price,
+        MamdaOrderBookPriceLevel::Side  side,
+        const MamaDateTime&             eventTime,
+        MamdaOrderBookBasicDelta*       delta,
+        mama_u32_t                      entryPosition)
+    {
+        MamdaOrderBookPriceLevel::Action  plAction;
+        MamdaOrderBookPriceLevel* level = findOrCreateLevel (
+                                            bookSide, price, side, plAction);
+
+        addEntryAndSetDelta(entry, eventTime, delta, plAction, level, entryPosition);
+    }
+    void MamdaOrderBook::MamdaOrderBookImpl::addEntry (
+        PlMap&                          bookSide,
+        MamdaOrderBookEntry*            entry,
+        double                          price,
+        MamdaOrderBookPriceLevel::Side  side,
+        const MamaDateTime&             eventTime,
+        MamdaOrderBookBasicDelta*       delta,
+        mama_u32_t                      entryPosition)
+    {
+        MamdaOrderBookPriceLevel::Action  plAction;
+        MamdaOrderBookPriceLevel* level = findOrCreateLevel (
+                                                bookSide, price, side, plAction);
+
+        addEntryAndSetDelta(entry, eventTime, delta, plAction, level, entryPosition);
+    }
+
+    void MamdaOrderBook::MamdaOrderBookImpl::addEntryAndSetDelta(
+        MamdaOrderBookEntry*              entry,
+        const MamaDateTime&               eventTime,
+        MamdaOrderBookBasicDelta*         delta,
+        MamdaOrderBookPriceLevel::Action  plAction,
+        MamdaOrderBookPriceLevel*         level,
+        mama_u32_t                        entryPosition)
+    {
+        mama_quantity_t plSizeDelta = 0.0;
+        if (!mCheckVisibility || entry->isVisible())
+        {
+            plSizeDelta = entry->getSize();
+            level->setTime (eventTime);
+        }
+        
+        //add entry to level - this will add delta to publishing list
+        level->addEntry (entry,
+                        entryPosition);
+
+        if (delta)
+        {
+            delta->set (entry, level, plSizeDelta, plAction,
+                        MamdaOrderBookEntry::MAMDA_BOOK_ACTION_ADD);
+        }
+    }
+
+    void MamdaOrderBook::MamdaOrderBookImpl::updateEntry (
+        MamdaOrderBookEntry*            entry,
+        mama_quantity_t                 size,
+        const MamaDateTime&             eventTime,
+        MamdaOrderBookBasicDelta*       delta,
+        mama_u32_t                      entryPosition)
+    {
+        MamdaOrderBookPriceLevel* level = entry->getPriceLevel();
+        if (!level)
+            throw MamdaOrderBookInvalidEntry (entry,
+                                              "MamdaOrderBook::updateEntry()");
+        mama_quantity_t plSizeDelta = 0.0;
+        if (size != entry->getSize())
+        {
+            // For some reason, we can get updates that do not change the
+            // size and so we also don't want to change the time.
+            if (!mCheckVisibility || entry->isVisible())
+            {
+                plSizeDelta = size - entry->getSize();
+                level->setSize (level->getSize() + plSizeDelta);
+                level->setTime (eventTime);
+            }
+            entry->setSize (size);
+            entry->setTime (eventTime);
+        }
+
+        if (delta)
+        {
+            delta->set (entry, level, plSizeDelta,
+                        MamdaOrderBookPriceLevel::MAMDA_BOOK_ACTION_UPDATE,
+                        MamdaOrderBookEntry::MAMDA_BOOK_ACTION_UPDATE,
+                        entryPosition);
+        }
+
+        if (mGenerateDeltas)
+        {
+            addDelta(entry, level, plSizeDelta,
+                     MamdaOrderBookPriceLevel::MAMDA_BOOK_ACTION_UPDATE,
+                     MamdaOrderBookEntry::MAMDA_BOOK_ACTION_UPDATE,
+                     entryPosition);
+        }
+    }
+
     void MamdaOrderBook::MamdaOrderBookImpl::updateEntry (
         MamdaOrderBookEntry*            entry,
         mama_quantity_t                 size,
@@ -2661,6 +2903,38 @@ namespace Wombat
             /* This is number greater than two, so add the current delta. */
             mPublishComplexDelta->add (
                 entry, level, plDeltaSize, plAction, entryAction);
+        }
+    }
+    
+    void MamdaOrderBook::MamdaOrderBookImpl::addDelta (
+        MamdaOrderBookEntry*              entry,
+        MamdaOrderBookPriceLevel*         level,
+        mama_quantity_t                   plDeltaSize,
+        MamdaOrderBookPriceLevel::Action  plAction,
+        MamdaOrderBookEntry::Action       entryAction,
+        mama_u32_t                        entryPosition)
+    {
+        ++mCurrentDeltaCount;
+        if (1 == mCurrentDeltaCount)
+        {
+            /* This is number one, so save the "simple" delta. */
+            mPublishSimpleDelta->set (
+                entry, level, plDeltaSize, plAction, entryAction, entryPosition);
+        }
+        else if (2 == mCurrentDeltaCount)
+        {
+            /* This is number two, so copy the saved "simple" delta to the
+             * "complex" delta and add the current one. */
+            mPublishComplexDelta->clear();
+            mPublishComplexDelta->add (*mPublishSimpleDelta);
+            mPublishComplexDelta->add (
+                entry, level, plDeltaSize, plAction, entryAction, entryPosition);
+        }
+        else
+        {
+            /* This is number greater than two, so add the current delta. */
+            mPublishComplexDelta->add (
+                entry, level, plDeltaSize, plAction, entryAction, entryPosition);
         }
     }
 

--- a/mamda/c_cpp/src/cpp/orderbooks/MamdaOrderBookBasicDelta.cpp
+++ b/mamda/c_cpp/src/cpp/orderbooks/MamdaOrderBookBasicDelta.cpp
@@ -29,20 +29,22 @@ namespace Wombat
     MamdaOrderBookBasicDelta::MamdaOrderBookBasicDelta(
         const MamdaOrderBookBasicDelta&  copy)
     {
-        mPriceLevel  = copy.mPriceLevel;
-        mEntry       = copy.mEntry;
-        mPlDeltaSize = copy.mPlDeltaSize;
-        mPlAction    = copy.mPlAction;
-        mEntryAction = copy.mEntryAction;
+        mPriceLevel    = copy.mPriceLevel;
+        mEntry         = copy.mEntry;
+        mPlDeltaSize   = copy.mPlDeltaSize;
+        mPlAction      = copy.mPlAction;
+        mEntryAction   = copy.mEntryAction;
+        mEntryPosition = copy.mEntryPosition;
     }
 
     void MamdaOrderBookBasicDelta::clear()
     {
-        mPriceLevel  = NULL;
-        mEntry       = NULL;
-        mPlDeltaSize = 0.0;
-        mPlAction    = MamdaOrderBookPriceLevel::MAMDA_BOOK_ACTION_UNKNOWN;
-        mEntryAction = MamdaOrderBookEntry::MAMDA_BOOK_ACTION_UNKNOWN;
+        mPriceLevel    = NULL;
+        mEntry         = NULL;
+        mPlDeltaSize   = 0.0;
+        mPlAction      = MamdaOrderBookPriceLevel::MAMDA_BOOK_ACTION_UNKNOWN;
+        mEntryAction   = MamdaOrderBookEntry::MAMDA_BOOK_ACTION_UNKNOWN;
+        mEntryPosition = 0;
     }
 
     void MamdaOrderBookBasicDelta::set (
@@ -51,13 +53,60 @@ namespace Wombat
         mama_quantity_t                   plDeltaSize,
         MamdaOrderBookPriceLevel::Action  plAction,
         MamdaOrderBookEntry::Action       entryAction)
+    { 
+        mPriceLevel    = level;
+        mEntry         = entry;
+
+        if (plDeltaSize) 
+        {
+            mPlDeltaSize = plDeltaSize;
+        }
+        else 
+        {
+            mPlDeltaSize = 0.0;
+        }
+
+        mPlAction      = plAction;
+        mEntryAction   = entryAction;
+    }
+
+    void MamdaOrderBookBasicDelta::set (
+        MamdaOrderBookEntry*              entry,
+        MamdaOrderBookPriceLevel*         level,
+        mama_quantity_t                   plDeltaSize,
+        MamdaOrderBookPriceLevel::Action  plAction,
+        MamdaOrderBookEntry::Action       entryAction,
+        mama_u32_t                        entryPosition)
+    { 
+        mPriceLevel    = level;
+        mEntry         = entry;
+
+        if (plDeltaSize) 
+        {
+            mPlDeltaSize = plDeltaSize;
+        }
+        else 
+        {
+            mPlDeltaSize = 0.0;
+        }
+        if (entryPosition > 0)
+        {
+            entry->setEntryPositionReceived(entryPosition);
+        }
+            
+        mPlAction      = plAction;
+        mEntryAction   = entryAction;
+        mEntryPosition = entryPosition;
+    }
+    
+    mama_u32_t MamdaOrderBookBasicDelta::getEntryPosition () const
     {
-        mPriceLevel  = level;
-        mEntry       = entry;
-        if (plDeltaSize) mPlDeltaSize = plDeltaSize;
-            else mPlDeltaSize = 0.0;
-        mPlAction    = plAction;
-        mEntryAction = entryAction;
+        if(NULL != mEntry)
+        {
+            return mEntry->getEntryPositionInPriceLevel();
+        }
+        
+        return 0;
     }
 
     const MamdaOrderBook* MamdaOrderBookBasicDelta::getOrderBook () const
@@ -70,14 +119,15 @@ namespace Wombat
 
     void MamdaOrderBookBasicDelta::dump (std::ostream&  output) const
     {
-        output << "Price="           << mPriceLevel->getPrice()
-               << ", Side="          << (char)mPriceLevel->getSide()
-               << ", PlDeltaAction=" << (char)mPlAction
-               << ", EntryId="       << (mEntry ? mEntry->getId(): "NULL")
-               << ", EntryAction="   << (char)mEntryAction
-               << ", PlSize = "      << mPriceLevel->getSize()
+        output << "Price="                << mPriceLevel->getPrice()
+               << ", Side="               << (char)mPriceLevel->getSide()
+               << ", PlDeltaAction="      << (char)mPlAction
+               << ", EntryId="            << (mEntry ? mEntry->getId(): "NULL")
+               << ", EntryAction="        << (char)mEntryAction
+               << ", PlSize = "           << mPriceLevel->getSize()
                << ", NumEntriesTotal = "  << mPriceLevel->getNumEntriesTotal()
-               << ", EntrySize = "   << (mEntry ? mEntry->getSize(): 0)
+               << ", EntrySize = "        << (mEntry ? mEntry->getSize(): 0)
+               << ", EntryPosition = "    << (mEntry ? mEntry->getEntryPositionInPriceLevel(): 0)
                << "\n";
     }
 

--- a/mamda/c_cpp/src/cpp/orderbooks/MamdaOrderBookConcreteComplexDelta.cpp
+++ b/mamda/c_cpp/src/cpp/orderbooks/MamdaOrderBookConcreteComplexDelta.cpp
@@ -31,7 +31,7 @@ namespace Wombat
                                           : public MamdaConcreteBasicEvent
     {
     };
-
+    
     MamdaOrderBookConcreteComplexDelta::MamdaOrderBookConcreteComplexDelta ()
         : mImpl (*new OrderBookConcreteComplexDeltaImpl)
     {
@@ -132,8 +132,6 @@ namespace Wombat
     {
         return mImpl.getEventTimeFieldState();
     }
-
-
 
     void MamdaOrderBookConcreteComplexDelta::setSymbol (const char* value)
     {

--- a/mamda/c_cpp/src/cpp/orderbooks/MamdaOrderBookEntry.cpp
+++ b/mamda/c_cpp/src/cpp/orderbooks/MamdaOrderBookEntry.cpp
@@ -37,33 +37,35 @@ namespace Wombat
 {
 
     MamdaOrderBookEntry::MamdaOrderBookEntry()
-        : mId          (NULL)
-        , mUniqueId    (NULL)
-        , mSize        (0)
-        , mPriceLevel  (NULL)
-        , mManager     (NULL)
-        , mSourceDeriv (NULL)
-        , mClosure     (NULL)
-        , mQuality     (MAMA_QUALITY_OK)
-        , mAction      (MAMDA_BOOK_ACTION_ADD)
-        , mStatus      (0)
-        , mReason      (MamdaOrderBookTypes::MAMDA_BOOK_REASON_UNKNOWN)
+        : mId            (NULL)
+        , mUniqueId      (NULL)
+        , mSize          (0)
+        , mPriceLevel    (NULL)
+        , mManager       (NULL)
+        , mSourceDeriv   (NULL)
+        , mClosure       (NULL)
+        , mQuality       (MAMA_QUALITY_OK)
+        , mAction        (MAMDA_BOOK_ACTION_ADD)
+        , mStatus        (0)
+        , mReason        (MamdaOrderBookTypes::MAMDA_BOOK_REASON_UNKNOWN)
+        , mEntryPosition (false)
     {
     }
 
     MamdaOrderBookEntry::MamdaOrderBookEntry(const MamdaOrderBookEntry& copy)
-        : mId          (NULL)
-        , mUniqueId    (NULL)
-        , mSize        (copy.mSize)
-        , mTime        (copy.mTime)
-        , mPriceLevel  (NULL)
-        , mManager     (NULL)
-        , mSourceDeriv (copy.mSourceDeriv)
-        , mClosure     (copy.mClosure)
-        , mQuality     (copy.mQuality)
-        , mAction      (copy.mAction)
-        , mStatus      (0)
-        , mReason      (copy.mReason)
+        : mId            (NULL)
+        , mUniqueId      (NULL)
+        , mSize          (copy.mSize)
+        , mTime          (copy.mTime)
+        , mPriceLevel    (NULL)
+        , mManager       (NULL)
+        , mSourceDeriv   (copy.mSourceDeriv)
+        , mClosure       (copy.mClosure)
+        , mQuality       (copy.mQuality)
+        , mAction        (copy.mAction)
+        , mStatus        (0)
+        , mReason        (copy.mReason)
+        , mEntryPosition (copy.mEntryPosition)
     {
         setId (copy.mId);
         setUniqueId (copy.mUniqueId);
@@ -87,6 +89,31 @@ namespace Wombat
         , mAction      (action)
         , mStatus      (0)
         , mReason      (MamdaOrderBookTypes::MAMDA_BOOK_REASON_MODIFY)
+        , mEntryPosition (false)
+    {
+        setId (entryId);
+    }
+
+    MamdaOrderBookEntry::MamdaOrderBookEntry(
+        const char*                  entryId,
+        mama_quantity_t              size,
+        Action                       action,
+        const MamaDateTime&          entryTime,
+        const MamaSourceDerivative*  deriv,
+        mama_u32_t                   entryPosition)
+        : mId          (NULL)
+        , mUniqueId    (NULL)
+        , mSize        (size)
+        , mTime        (entryTime)
+        , mPriceLevel  (NULL)
+        , mManager     (NULL)
+        , mSourceDeriv (deriv)
+        , mClosure     (NULL)
+        , mQuality     (MAMA_QUALITY_OK)
+        , mAction      (action)
+        , mStatus      (0)
+        , mReason      (MamdaOrderBookTypes::MAMDA_BOOK_REASON_MODIFY)
+        , mEntryPosition (entryPosition)
     {
         setId (entryId);
     }
@@ -117,18 +144,19 @@ namespace Wombat
         // Now clear everything
         delete[] mId;
         delete[] mUniqueId;
-        mId          = NULL;
-        mUniqueId    = NULL;
-        mSize        = 0;
+        mId            = NULL;
+        mUniqueId      = NULL;
+        mSize          = 0;
         mTime.clear();
-        mPriceLevel  = NULL;
-        mManager     = NULL;
-        mSourceDeriv = NULL;
-        mClosure     = NULL;
-        mQuality     = MAMA_QUALITY_OK;
-        mAction      = MAMDA_BOOK_ACTION_ADD;
-        mStatus      = 0;
-        mReason      = MamdaOrderBookTypes::MAMDA_BOOK_REASON_UNKNOWN;
+        mPriceLevel    = NULL;
+        mManager       = NULL;
+        mSourceDeriv   = NULL;
+        mClosure       = NULL;
+        mQuality       = MAMA_QUALITY_OK;
+        mAction        = MAMDA_BOOK_ACTION_ADD;
+        mStatus        = 0;
+        mReason        = MamdaOrderBookTypes::MAMDA_BOOK_REASON_UNKNOWN;
+        mEntryPosition = false;
     }
 
     void MamdaOrderBookEntry::copy(const MamdaOrderBookEntry& copy)
@@ -145,6 +173,7 @@ namespace Wombat
         mAction      = copy.mAction;
         mStatus      = copy.mStatus;
         mReason      = copy.mReason;
+        mEntryPosition = copy.mEntryPosition;
     }
 
     void MamdaOrderBookEntry::setId (const char*  id)
@@ -343,6 +372,14 @@ namespace Wombat
             "MamdaOrderBookEntry::getPosition() (not found)");
     }
 
+    mama_u32_t  MamdaOrderBookEntry::getEntryPositionInPriceLevel () const
+    {
+        if (!mPriceLevel)
+            return 0;
+
+        return mPriceLevel->getEntryPositionInPriceLevel (mId);
+    }
+
     bool MamdaOrderBookEntry::operator== (
         const MamdaOrderBookEntry& rhs) const
     {
@@ -485,4 +522,13 @@ namespace Wombat
         sStrictChecking = strict;
     }
 
+    bool MamdaOrderBookEntry::getEntryPositionReceived () const
+    {
+        return mEntryPositionRecieved;
+    }
+
+    void MamdaOrderBookEntry::setEntryPositionReceived (bool position)
+    {
+        mEntryPositionRecieved = position;
+    }
 }

--- a/mamda/c_cpp/src/cpp/orderbooks/MamdaOrderBookFields.cpp
+++ b/mamda/c_cpp/src/cpp/orderbooks/MamdaOrderBookFields.cpp
@@ -58,6 +58,7 @@ namespace Wombat
     const MamaFieldDescriptor*  MamdaOrderBookFields::ENTRY_SIZE          = NULL;
     const MamaFieldDescriptor*  MamdaOrderBookFields::ENTRY_TIME          = NULL;
     const MamaFieldDescriptor*  MamdaOrderBookFields::ENTRY_STATUS        = NULL;
+    const MamaFieldDescriptor*  MamdaOrderBookFields::ENTRY_POSITION      = NULL;
     const MamaFieldDescriptor*  MamdaOrderBookFields::ENTRY_PROPERTIES    = NULL;
     const MamaFieldDescriptor*  MamdaOrderBookFields::ENTRY_PROP_MSG_TYPE = NULL;
     const MamaFieldDescriptor*  MamdaOrderBookFields::BID_MARKET_ORDERS   = NULL;
@@ -106,6 +107,7 @@ namespace Wombat
         ENTRY_SIZE         = dictionary.getFieldByName ("wEntrySize");
         ENTRY_TIME         = dictionary.getFieldByName ("wEntryTime");
         ENTRY_STATUS       = dictionary.getFieldByName ("wEntryStatus");
+        ENTRY_POSITION     = dictionary.getFieldByName ("wEntryPosition");
         ENTRY_PROPERTIES   = dictionary.getFieldByName ("wEntryPropFids");
         ENTRY_PROP_MSG_TYPE= dictionary.getFieldByName ("wEntryPropMsgType");
         BID_MARKET_ORDERS  = dictionary.getFieldByName ("wBidMarketOrders");
@@ -203,6 +205,7 @@ namespace Wombat
         ENTRY_SIZE         = NULL;
         ENTRY_TIME         = NULL;
         ENTRY_STATUS       = NULL;
+        ENTRY_POSITION     = NULL;
         ENTRY_PROPERTIES   = NULL;
         ENTRY_PROP_MSG_TYPE= NULL;
         BID_MARKET_ORDERS  = NULL;

--- a/mamda/c_cpp/src/cpp/orderbooks/MamdaOrderBookPriceLevel.cpp
+++ b/mamda/c_cpp/src/cpp/orderbooks/MamdaOrderBookPriceLevel.cpp
@@ -1289,11 +1289,9 @@ namespace Wombat
         MamdaOrderBookEntry*  entry = new MamdaOrderBookEntry;
         entry->setId (id);
         entry->setAction (MamdaOrderBookEntry::MAMDA_BOOK_ACTION_ADD);
-        //addEntry (entry, entryPosition);   
-        entry->setPriceLevel (&mLevel);
-        mEntries->push_back (entry);
-        mNumEntries++;
-        mNumEntriesTotal++;
+
+        addEntry (entry, entryPosition);   
+
         newEntry = true;
  
  

--- a/mamda/c_cpp/src/cpp/orderbooks/MamdaOrderBookPriceLevel.cpp
+++ b/mamda/c_cpp/src/cpp/orderbooks/MamdaOrderBookPriceLevel.cpp
@@ -299,14 +299,21 @@ namespace Wombat
 
                 for (mama_u32_t ii (1) ; iter != endIter; ++ii, ++iter)
                 {
-                    if (ii == targetEntryPosition)
-                        targetIter = iter;
+                    const char *rhs ((*iter)->getId ());
 
-                    if (!strcmp (id, (*iter)->getId ()))
+                    if (ii == targetEntryPosition)
+                    {
+                        targetIter = iter;
+                    }
+                    
+
+                    if (id && rhs && !strcmp (id, rhs))
                     {
                         // Entry is at correct position
                         if (targetEntryPosition == ii)
+                        {
                             break;
+                        }
 
                         curPos = ii;
                         entryIter = iter;
@@ -477,13 +484,18 @@ namespace Wombat
         for (mama_u32_t pos (0); iter != endIter; ++iter)
         {
             MamdaOrderBookEntry *entry (*iter);
+            const char          *rhs   (entry->getId ());
 
             if (checkState && !entry->isVisible())
+            {
                 continue;
+            }
             else
+            {
                 ++pos;
+            }
 
-            if (!strcmp (id, entry->getId ()))
+            if (id && rhs && !strcmp (id, rhs))
                 return pos;
             }
 

--- a/mamda/c_cpp/src/cpp/orderbooks/MamdaOrderBookWriter.cpp
+++ b/mamda/c_cpp/src/cpp/orderbooks/MamdaOrderBookWriter.cpp
@@ -447,6 +447,17 @@ namespace Wombat
         msg.addU32 (NULL, MamdaOrderBookFields::ENTRY_SIZE->getFid(),
                     (mama_u32_t)entry->getSize());
 
+        if(entry->getEntryPositionReceived())
+        {
+            mama_u32_t position = entry->getEntryPositionInPriceLevel();
+            if (position > 0)
+            {
+                msg.addU32 (NULL, MamdaOrderBookFields::ENTRY_POSITION->getFid(),
+                            position);
+            }
+
+        }
+
         if ((NULL == plTime) || (plTime->compare(entry->getTime())!=0 ))
         {
             msg.addDateTime (NULL, MamdaOrderBookFields::ENTRY_TIME->getFid(),

--- a/mamda/c_cpp/src/cpp/orderbooks/mamda/MamdaBookAtomicLevelEntry.h
+++ b/mamda/c_cpp/src/cpp/orderbooks/mamda/MamdaBookAtomicLevelEntry.h
@@ -111,6 +111,14 @@ namespace Wombat
         virtual mama_u64_t           getPriceLevelEntrySize()       const = 0;
 
         /**
+        * Return the order book entry position. Value 0 indicates that
+        * it is undefined.
+        * 
+        * @return Order book entry position.
+        */
+        virtual mama_u32_t           getPriceLevelEntryPosition()   const = 0;
+
+        /**
          * Return the time of order book entry update.
          *
          * @return Time of order book entry update.

--- a/mamda/c_cpp/src/cpp/orderbooks/mamda/MamdaBookAtomicListener.h
+++ b/mamda/c_cpp/src/cpp/orderbooks/mamda/MamdaBookAtomicListener.h
@@ -115,7 +115,8 @@ namespace Wombat
         char                 getPriceLevelEntryAction    () const;
         char                 getPriceLevelEntryReason    () const;
         const char*          getPriceLevelEntryId        () const;
-        mama_u64_t           getPriceLevelEntrySize      () const;  
+        mama_u64_t           getPriceLevelEntrySize      () const;
+        mama_u32_t           getPriceLevelEntryPosition  () const;  
         const MamaDateTime&  getPriceLevelEntryTime      () const;
 
         MamdaOrderBookTypes::OrderType getOrderType      () const;

--- a/mamda/c_cpp/src/cpp/orderbooks/mamda/MamdaOrderBook.h
+++ b/mamda/c_cpp/src/cpp/orderbooks/mamda/MamdaOrderBook.h
@@ -396,6 +396,7 @@ namespace Wombat
         bool operator!= (const MamdaOrderBook&  rhs) const
         { return ! operator== (rhs); }
 
+
         /**
          * Add an entry to the order book and (if "delta" is not NULL)
          * record information about the delta related to this action.
@@ -417,7 +418,7 @@ namespace Wombat
             MamdaOrderBookPriceLevel::Side  side,
             const MamaDateTime&             eventTime,
             MamdaOrderBookBasicDelta*       delta);
-            
+
         /**
          * Add an entry to the order book and (if "delta" is not NULL)
          * record information about the delta related to this action.  The
@@ -445,7 +446,61 @@ namespace Wombat
             const MamaDateTime&             eventTime,
             const MamaSourceDerivative*     sourceDeriv,
             MamdaOrderBookBasicDelta*       delta);
-            
+    
+        /**
+        * Add an entry to the order book  at a specified position and 
+        * (if "delta" is not NULL) record information about the delta
+        * related to this action.
+        */
+        void addEntry (
+            MamdaOrderBookEntry*            entry,
+            MamaPrice&                      price,
+            MamdaOrderBookPriceLevel::Side  side,
+            const MamaDateTime&             eventTime,
+            MamdaOrderBookBasicDelta*       delta,
+            mama_u32_t                      entryPosition);
+        
+        void addEntry (
+            MamdaOrderBookEntry*            entry,
+            double                          price,
+            MamdaOrderBookPriceLevel::Side  side,
+            const MamaDateTime&             eventTime,
+            MamdaOrderBookBasicDelta*       delta,
+            mama_u32_t                      entryPosition);
+        
+        void addEntryAndSetDelta(
+            MamdaOrderBookEntry*              entry,
+            const MamaDateTime&               eventTime,
+            MamdaOrderBookBasicDelta*         delta,
+            MamdaOrderBookPriceLevel::Action  plAction, 
+            MamdaOrderBookPriceLevel*         level,
+            mama_u32_t                        entryPosition);
+
+        /**
+        * Add an entry to the order book at a specified position
+        * and (if "delta" is not NULL) record information about
+        * the delta related to this action.  The new entry is returned.
+        */
+        MamdaOrderBookEntry* addEntry (
+            const char*                     entryId,
+            mama_quantity_t                 entrySize,
+            MamaPrice&                      price,
+            MamdaOrderBookPriceLevel::Side  side,
+            const MamaDateTime&             eventTime,
+            const MamaSourceDerivative*     source,
+            MamdaOrderBookBasicDelta*       delta,
+            mama_u32_t                      entryPosition);
+        
+        MamdaOrderBookEntry* addEntry (
+            const char*                     entryId,
+            mama_quantity_t                 entrySize,
+            double                          price,
+            MamdaOrderBookPriceLevel::Side  side,
+            const MamaDateTime&             eventTime,
+            const MamaSourceDerivative*     source,
+            MamdaOrderBookBasicDelta*       delta,
+            mama_u32_t                      entryPosition);
+        
         /**
          * Update an entry in the order book and (if "delta" is not NULL)
          * record information about the delta related to this action.  If
@@ -457,6 +512,13 @@ namespace Wombat
             mama_quantity_t                 size,
             const MamaDateTime&             eventTime,
             MamdaOrderBookBasicDelta*       delta);
+        
+        void updateEntry (
+            MamdaOrderBookEntry*            entry,
+            mama_quantity_t                 size,
+            const MamaDateTime&             eventTime,
+            MamdaOrderBookBasicDelta*       delta,
+            mama_u32_t                      entryPosition);
 
         /**
          * Delete an entry in the order book and (if "delta" is not NULL)
@@ -774,6 +836,23 @@ namespace Wombat
                        mama_quantity_t                   plDeltaSize,
                        MamdaOrderBookPriceLevel::Action  plAction,
                        MamdaOrderBookEntry::Action       entAction);
+        /**
+         * For book delta generation. 
+         * Add a delta to the order book delta list for the publishing of
+         * order book data
+         * @param entry MamdaOrderBookEntry where change occurred.
+         * @param level MamdaOrderBookPriceLevel where change occurred.
+         * @param plDeltaSize Pricelevel size change.
+         * @param plAction Pricelevel action.
+         * @param entAction Entry action.     
+         * @param entryPosition Entry position.
+         */ 
+        void addDelta (MamdaOrderBookEntry*              entry,
+                       MamdaOrderBookPriceLevel*         level,
+                       mama_quantity_t                   plDeltaSize,
+                       MamdaOrderBookPriceLevel::Action  plAction,
+                       MamdaOrderBookEntry::Action       entAction,
+                       mama_u32_t                        entryPosition);
                        
         /**
          * clear the delta list using for storing generated deltas

--- a/mamda/c_cpp/src/cpp/orderbooks/mamda/MamdaOrderBookBasicDelta.h
+++ b/mamda/c_cpp/src/cpp/orderbooks/mamda/MamdaOrderBookBasicDelta.h
@@ -61,6 +61,15 @@ namespace Wombat
                           mama_quantity_t                   plDeltaSize,
                           MamdaOrderBookPriceLevel::Action  plAction,
                           MamdaOrderBookEntry::Action       entryAction);
+        /**
+         * Set the delta info with entry position.
+         */
+        virtual void set (MamdaOrderBookEntry*              entry,
+                          MamdaOrderBookPriceLevel*         level,
+                          mama_quantity_t                   plDeltaSize,
+                          MamdaOrderBookPriceLevel::Action  plAction,
+                          MamdaOrderBookEntry::Action       entryAction,
+                          mama_u32_t                        entryPosition);
 
         /**
          * Set the MamdaOrderBookPriceLevel object to which this entry
@@ -153,6 +162,15 @@ namespace Wombat
         virtual const MamdaOrderBook* getOrderBook() const;
 
         /**
+         * Get the entry position of the entry.
+         * 
+         * Return 0 if entry is null.
+         *
+         * @return The entry position of the entry
+         */
+        mama_u32_t getEntryPosition () const;
+
+        /**
          * Dump the simple update to the output stream.
          *
          * @param output The <code>ostream</code> to write the update to.
@@ -165,6 +183,7 @@ namespace Wombat
         mama_quantity_t                   mPlDeltaSize;
         MamdaOrderBookPriceLevel::Action  mPlAction;
         MamdaOrderBookEntry::Action       mEntryAction;
+        mama_u32_t                        mEntryPosition;
 
     private:
         // No copy constructor nor assignment operator.

--- a/mamda/c_cpp/src/cpp/orderbooks/mamda/MamdaOrderBookBasicDeltaList.h
+++ b/mamda/c_cpp/src/cpp/orderbooks/mamda/MamdaOrderBookBasicDeltaList.h
@@ -86,6 +86,16 @@ namespace Wombat
                   mama_quantity_t                   plDeltaSize,
                   MamdaOrderBookPriceLevel::Action  plAction,
                   MamdaOrderBookEntry::Action       entryAction);
+        /**
+         * Add a basic delta.  This method adds a MamdaOrderBookBasicDelta
+         * to the list, with an entry position.
+         */
+        void add (MamdaOrderBookEntry*              entry,
+                  MamdaOrderBookPriceLevel*         level,
+                  mama_quantity_t                   plDeltaSize,
+                  MamdaOrderBookPriceLevel::Action  plAction,
+                  MamdaOrderBookEntry::Action       entryAction,
+                  mama_u32_t                        entryPosition);
 
         /**
          * Add a basic delta.  This method adds a copy of the

--- a/mamda/c_cpp/src/cpp/orderbooks/mamda/MamdaOrderBookEntry.h
+++ b/mamda/c_cpp/src/cpp/orderbooks/mamda/MamdaOrderBookEntry.h
@@ -79,6 +79,13 @@ namespace Wombat
                              Action                       action,
                              const MamaDateTime&          entryTime,
                              const MamaSourceDerivative*  deriv);
+        
+        MamdaOrderBookEntry (const char*                  entryId,
+                             mama_quantity_t              size,
+                             Action                       action,
+                             const MamaDateTime&          entryTime,
+                             const MamaSourceDerivative*  deriv,
+                             mama_u32_t                   entryPosition);
 
         ~MamdaOrderBookEntry ();
 
@@ -94,16 +101,17 @@ namespace Wombat
          * Copy an order book entry.  Note that the associated price level
          * of the original copy is not copied.
          */
-        void copy          (const MamdaOrderBookEntry&  copy);
+        void        copy                (const MamdaOrderBookEntry&  copy);
 
-        void setId         (const char*          id);
-        void setUniqueId   (const char*          id);
-        void setSize       (mama_quantity_t      size);
-        void setAction     (Action               action);
-        void setReason     (MamdaOrderBookTypes::Reason reason);
-        void setTime       (const MamaDateTime&  time);
-        void setStatus     (mama_u16_t           status);
-        void setDetails    (const MamdaOrderBookEntry&  copy);
+        void        setId               (const char*          id);
+        void        setUniqueId         (const char*          id);
+        void        setSize             (mama_quantity_t      size);
+        void        setAction           (Action               action);
+        void        setReason           (MamdaOrderBookTypes::Reason reason);
+        void        setTime             (const MamaDateTime&  time);
+        void        setStatus           (mama_u16_t           status);
+        void        setDetails          (const MamdaOrderBookEntry&  copy);
+        mama_u32_t  getEntryPosition    ();
 
         /**
          * If supported, Order book entry ID (order ID, participant ID,
@@ -196,6 +204,16 @@ namespace Wombat
          * @return  The position of this entry in the order book.
          */
         mama_u32_t  getPosition (mama_u32_t  maxPos = 0) const;
+        
+        /**
+         * Get the position of the Entry in the Price Level. The index
+         * starts from 1. A value of 0 may be returned if the Entry is
+         * detached from the Price Level.
+         *
+         * @return  The position of this entry in the Price Level.
+         * @throw   none.
+         */
+        mama_u32_t  getEntryPositionInPriceLevel () const;
 
         /**
          * Whether two participant ids are equal.
@@ -372,6 +390,22 @@ namespace Wombat
          */
         static void setStrictChecking (bool strict);
 
+        /**
+        * Get if Entry position has been received.
+        *
+        * @return If entry position has been received.
+        */
+        bool getEntryPositionReceived () const;
+
+        /**
+        * Confirm if entry position has been received. This setting is automatically
+        * updated by MamdaOrderBookEntry::setEntryPositionReceived().
+        *
+        * @param position Whether entry position has been received.
+        */
+        void setEntryPositionReceived (bool position);
+
+
     private:
         char*                        mId;
         char*                        mUniqueId;
@@ -384,6 +418,8 @@ namespace Wombat
         mamaQuality                  mQuality;
         Action                       mAction;
         mama_u16_t                   mStatus;
+        bool                         mEntryPositionRecieved;
+        mama_u32_t                   mEntryPosition;
 
         MamdaOrderBookTypes::Reason  mReason;
     };

--- a/mamda/c_cpp/src/cpp/orderbooks/mamda/MamdaOrderBookFields.h
+++ b/mamda/c_cpp/src/cpp/orderbooks/mamda/MamdaOrderBookFields.h
@@ -64,6 +64,7 @@ namespace Wombat
         static const MamaFieldDescriptor*  ENTRY_REASON;
         static const MamaFieldDescriptor*  ENTRY_SIZE;
         static const MamaFieldDescriptor*  ENTRY_TIME;
+        static const MamaFieldDescriptor*  ENTRY_POSITION;
         static const MamaFieldDescriptor*  ENTRY_STATUS;
         static const MamaFieldDescriptor*  ENTRY_PROPERTIES;
         static const MamaFieldDescriptor*  ENTRY_PROP_MSG_TYPE;

--- a/mamda/c_cpp/src/cpp/orderbooks/mamda/MamdaOrderBookPriceLevel.h
+++ b/mamda/c_cpp/src/cpp/orderbooks/mamda/MamdaOrderBookPriceLevel.h
@@ -145,10 +145,22 @@ namespace Wombat
         void addEntry (MamdaOrderBookEntry*  entry);
 
         /**
+        * Add an entry to the level at a specific position
+        */
+        void addEntry (MamdaOrderBookEntry*  entry,
+                       mama_u32_t            entryPosition);
+
+        /**
          * Update an entry by copying the information from another entry.
          */
         void updateEntry (const MamdaOrderBookEntry&  entry);
-
+    
+        /**
+         * Update the position of an Entry within the list of Entries.
+         */
+        void updateEntryPosition (const char *id,
+                                   mama_u32_t targetEntryPosition);
+      
         /**
          * Remove an entry based on the entry ID information from another entry.
          */
@@ -365,6 +377,20 @@ namespace Wombat
             bool&        newEntry);
 
         /**
+         * Return the order book entry with ID "id" in the price level,
+         * creating one if necessary.
+         *
+         * @param id  The ID of the order book entry.
+         * @param newEntry  Boolean reference indicating entry creation.
+         * @param entryPosition  The entry position for the price level.
+         * @return The order book entry found or created.
+         */
+        MamdaOrderBookEntry* findOrCreateEntry (
+            const char*  id,
+            bool&        newEntry,
+            mama_u32_t entryPosition);
+
+        /**
          * Return the order book entry at position "pos" in the price level.
          *
          * @param pos  The position of the order book entry.
@@ -392,7 +418,18 @@ namespace Wombat
          * @return The order type of the level.
          */
         OrderType getOrderType () const;
-        
+    
+         /**      
+         * Return the position of an Entry within the Price Level. This
+         * index starts from 1.
+         *
+         * @param id  The entry Id.
+         * @return The Entry position or 0 if the Entry is not found.
+         * @throw none
+         */
+        mama_u32_t getEntryPositionInPriceLevel (
+        const char *id) const;
+
         /**
          * Set the order type for this level.
          * @param orderType The order type of the level.

--- a/mamda/c_cpp/src/examples/orderbooks/atomicbookticker.cpp
+++ b/mamda/c_cpp/src/examples/orderbooks/atomicbookticker.cpp
@@ -203,9 +203,19 @@ public:
         char        entryAction   = levelEntry.getPriceLevelEntryAction ();
         const char* entryId       = levelEntry.getPriceLevelEntryId ();
         long        entrySize     = levelEntry.getPriceLevelEntrySize ();
+        unsigned int entryPosition = levelEntry.getPriceLevelEntryPosition ();
 
         cout << "\tENTRY | " << symbol << " | " << actNumEntries << " | ";
-        cout << entryAction << " | " << entryId << " | " << entrySize << endl;
+        cout << entryAction << " | " << entryId << " | " << entrySize;
+        cout << entryAction << " | " << entryId << " | " << entrySize;
+                
+        if( 0 != entryPosition )
+        {
+            cout << " | " << entryPosition;
+        }
+         
+        cout << std::endl;
+        
         flush (cout);
     }
 

--- a/mamda/c_cpp/src/examples/orderbooks/bookticker.cpp
+++ b/mamda/c_cpp/src/examples/orderbooks/bookticker.cpp
@@ -185,7 +185,7 @@ public:
     void prettyPrintEntries (const MamdaOrderBook&  book)
     {
         printf ("%s\n",
-            "     ID/Num           Time       Size   Price");
+            "ID/Num           Time     Position   Size   Price");
         MamdaOrderBook::constBidIterator bidIter = book.bidBegin ();
         MamdaOrderBook::constBidIterator bidEnd  = book.bidEnd ();
         MamdaOrderBook::constAskIterator askIter = book.askBegin ();
@@ -260,11 +260,12 @@ public:
             {
                 const MamdaOrderBookEntry* entry = *i;
                 const char*      id    = entry->getId ();
+                mama_u32_t       position = entry->getEntryPositionInPriceLevel();
                 mama_quantity_t  size  = entry->getSize ();
                 double           price = bidLevel->getPrice ();
                 entry->getTime().getAsFormattedString (timeStr, 32, "%T%;");
-                printf ("  %14s  %12s %7g %7.*f\n",
-                        id, timeStr, size, mPrecision, price);
+                printf ("  %14s  %12s  %u     %7g %7.*f\n",
+                        id, timeStr, position, size, mPrecision, price);
                 ++i;
             }
             ++bidIter;
@@ -286,11 +287,12 @@ public:
             {
                 const MamdaOrderBookEntry* entry = *i;
                 const char*      id    = entry->getId ();
+                mama_u32_t       position = entry->getEntryPositionInPriceLevel();
                 mama_quantity_t  size  = entry->getSize ();
                 double           price = askLevel->getPrice ();
                 entry->getTime().getAsFormattedString (timeStr, 32, "%T%;");
-                printf ("  %14s  %12s %7g %7.*f\n",
-                        id, timeStr, size, mPrecision, price);
+                printf ("  %14s  %12s  %u      %7g %7.*f\n",
+                        id, timeStr, position, size, mPrecision, price);
                 ++i;
             }
             ++askIter;

--- a/mamda/java/src/main/java/com/wombat/mamda/examples/MamdaBookTicker.java
+++ b/mamda/java/src/main/java/com/wombat/mamda/examples/MamdaBookTicker.java
@@ -544,7 +544,7 @@ public class MamdaBookTicker
             }
             if (mQuietModeLevel<1)
             {
-                System.out.println ("     ID/Num           Time       Size   Price");
+                System.out.println ("              ID/Num    Pos          Time    Size     Price");
             }
             
             if (mQuietModeLevel<1)
@@ -592,10 +592,10 @@ public class MamdaBookTicker
         {
             if (mQuietModeLevel<1)
             {
-                System.out.print ("  " + side + "  ");
+                System.out.print ("  " + side + "           ");
                 paddedPrint (String.valueOf((long)level.getNumEntries ()), 4,
                              false);
-                System.out.print ("       ");
+                System.out.print ("         ");
                 paddedPrint (level.getTime ().getTimeAsString (), 12, false);
                 System.out.print (" ");
                 paddedPrint (String.valueOf ((long)level.getSize ()), 7,
@@ -612,12 +612,15 @@ public class MamdaBookTicker
             {
                 MamdaOrderBookEntry entry = (MamdaOrderBookEntry) i.next ();
                 String      id    = entry.getId ();
+                long        pos   = entry.getEntryPositionInPriceLevel ();
                 double      size  = entry.getSize ();
                 double      price = level.getPrice ().getValue ();
                 if (mQuietModeLevel<1)
                 {
                     System.out.print ("  ");
                     paddedPrint (id, 18, false);
+                    System.out.print ("  ");
+                    paddedPrint (pos, 5, false);
                     System.out.print ("  ");
                     paddedPrint (entry.getTime().getTimeAsString (), 12, false);
                     System.out.print (" ");
@@ -651,6 +654,15 @@ public class MamdaBookTicker
             paddedPrint (new BigDecimal (value).setScale (prec,BigDecimal.ROUND_HALF_UP).toString (),
                          width, padAfter);
 
+        }
+
+        private void paddedPrint (long value,
+                                  int width,
+                                  boolean padAfter)
+        {
+            paddedPrint (new Long (value).toString (),
+                         width,
+                         padAfter);
         }
 
         private void paddedPrint (String val, int padLen, boolean padAfter)

--- a/mamda/java/src/main/java/com/wombat/mamda/orderbook/MamdaOrderBookEntry.java
+++ b/mamda/java/src/main/java/com/wombat/mamda/orderbook/MamdaOrderBookEntry.java
@@ -414,6 +414,21 @@ public class MamdaOrderBookEntry
     }
 
 
+    /**
+     * Get the position of the Entry in the Price Level. The value
+     * is indexed from 1. A value of 0 may be returned if the
+     * Entry is detached from the Price Level.
+     *
+     * @return  The position of this entry in the Price Level.
+     */
+    public long getEntryPositionInPriceLevel ()
+    {
+        if (mPriceLevel == null)
+            return 0;
+
+        return mPriceLevel.getEntryPositionInPriceLevel (mId);
+    }
+
     public int hashCode ()
     {
         /* From Effective Java */

--- a/mamda/java/src/main/java/com/wombat/mamda/orderbook/MamdaOrderBookFields.java
+++ b/mamda/java/src/main/java/com/wombat/mamda/orderbook/MamdaOrderBookFields.java
@@ -60,6 +60,7 @@ public class MamdaOrderBookFields extends MamdaFields
     public  static MamaFieldDescriptor   ENTRY_SIZE          = null;
     public  static MamaFieldDescriptor   ENTRY_TIME          = null;
     public  static MamaFieldDescriptor   ENTRY_STATUS        = null;
+    public  static MamaFieldDescriptor   ENTRY_POSITION      = null;
     public  static MamaFieldDescriptor   ENTRY_PROPERTIES    = null;
     public  static MamaFieldDescriptor   ENTRY_PROP_MSG_TYPE = null;
     public  static MamaFieldDescriptor[] PRICE_LEVEL         = null;
@@ -150,6 +151,8 @@ public class MamdaOrderBookFields extends MamdaFields
                                                     "wEntryTime");
         String wEntryStatus      = lookupFieldName (properties,
                                                     "wEntryStatus");
+        String wEntryPosition    = lookupFieldName (properties,
+                                                    "wEntryPosition");
         String wEntryPropFids    = lookupFieldName (properties,
                                                     "wEntryPropFids");
         String wEntryPropMsgType = lookupFieldName (properties,
@@ -187,6 +190,7 @@ public class MamdaOrderBookFields extends MamdaFields
         ENTRY_SIZE         = dictionary.getFieldByName (wEntrySize);
         ENTRY_TIME         = dictionary.getFieldByName (wEntryTime);
         ENTRY_STATUS       = dictionary.getFieldByName (wEntryStatus);
+        ENTRY_POSITION     = dictionary.getFieldByName (wEntryPosition);
         ENTRY_PROPERTIES   = dictionary.getFieldByName (wEntryPropFids);
         ENTRY_PROP_MSG_TYPE= dictionary.getFieldByName (wEntryPropMsgType);
         BID_MARKET_ORDERS  = dictionary.getFieldByName (wBidMarketOrders);
@@ -317,6 +321,7 @@ public class MamdaOrderBookFields extends MamdaFields
         ENTRY_SIZE         = null;
         ENTRY_TIME         = null;
         ENTRY_STATUS       = null;
+        ENTRY_POSITION     = null;
         ENTRY_PROPERTIES   = null;
         ENTRY_PROP_MSG_TYPE= null;
         BID_MARKET_ORDERS  = null;

--- a/mamda/java/src/main/java/com/wombat/mamda/orderbook/MamdaOrderBookListener.java
+++ b/mamda/java/src/main/java/com/wombat/mamda/orderbook/MamdaOrderBookListener.java
@@ -1465,7 +1465,7 @@ public class MamdaOrderBookListener
         entry.setTime   (entryTime);
         entry.setStatus (status);
         entry.setId     (id);
-        
+
         //Apply new position
         if (entryPosition > 0 &&
            MamdaOrderBookEntry.ACTION_UPDATE == entryAction)

--- a/mamda/java/src/main/java/com/wombat/mamda/orderbook/MamdaOrderBookWriter.java
+++ b/mamda/java/src/main/java/com/wombat/mamda/orderbook/MamdaOrderBookWriter.java
@@ -445,11 +445,19 @@ class MamdaOrderBookWriter
             msg.addDateTime (null, MamdaOrderBookFields.ENTRY_TIME.getFid(),
                              entry.getTime());
         }
-        
+
         if (entry.getStatus() != 0)
         {
             msg.addU16 (null, MamdaOrderBookFields.ENTRY_STATUS.getFid(),
                         (short)entry.getStatus());
+        }
+
+        long entryPosition = entry.getEntryPositionInPriceLevel ();
+
+        if (entryPosition > 0)
+        {
+            msg.addU32 (null, MamdaOrderBookFields.ENTRY_POSITION.getFid(),
+                        entryPosition);
         }
     }
 


### PR DESCRIPTION
# ENTRY POSITION SUPPORT
## Summary
This change allows us to set the entry position inside a price level for an entry. This is achieved using wEntryPosition field.

## Areas Affected
*Place an 'x' within the braces to check the box*
- [ ] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [X] MAMDACPP
- [ ] MAMDADOTNET
- [X] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
these changes allow entries in a book to be stored in an order based on the value of the wEntryPosition field received in incoming messages.  If no wEntryPosition is received the orders will be stored as they normally are.  Added functions to retrieve entry position from entries.

## Testing
Tested these changes by using an order injector connected to a publisher which supports publishing of entry positions. 