### PR TITLE
Fix for mamapublisherc core on exit

### DIFF
--- a/mama/c_cpp/src/examples/c/mamapublisherc.c
+++ b/mama/c_cpp/src/examples/c/mamapublisherc.c
@@ -453,6 +453,8 @@ timerCallback (mamaTimer timer, void *closure)
     if (gCount && ++count >= gCount)
     {
         mamaPublisher_destroy (gPublisher);
+        mamaTimer_destroy (gTimer);
+        mamaSubscription_destroy (gSubscription);
         sleep (1);    /* to see all queued events */
         mama_stop (gMamaBridge);
     }


### PR DESCRIPTION
# Fix for mamapublisherc core on exit
## Summary
*The example mamapublisherc cores during shutdown from not destroy the timer when finished publishing.*

## Areas Affected
*Place an 'x' within the braces to check the box*
- [ ] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [X] Examples

## Details
The example application mamapublisherc cores when when given the argument `-c <n>` to exit after n messages published. Based on the back trace:
```
(gdb) bt
#0  0x00007f6ba949f0e0 in ?? ()
#1  0x00007f6bab81195f in mamaMsg_clear () from /home/cmorgan/cvs/gitProjects/openmama/fork/build/mama/c_cpp/src/c/libmama.so
#2  0x0000000000401b9a in publishMessage ()
#3  0x00000000004020a0 in timerCallback ()
#4  0x00007f6bab35b6e9 in wombatQueue_dispatchInt ()
   from /home/cmorgan/cvs/gitProjects/openmama/fork/build/common/c_cpp/src/c/libwombatcommon.so
#5  0x00007f6bab35b76a in wombatQueue_timedDispatch ()
   from /home/cmorgan/cvs/gitProjects/openmama/fork/build/common/c_cpp/src/c/libwombatcommon.so
#6  0x00007f6bab11c525 in qpidBridgeMamaQueue_timedDispatch (queue=<optimized out>, timeout=10)
    at mama/c_cpp/src/c/bridge/qpid/queue.c:302
#7  0x00007f6bab825eb3 in mamaQueue_timedDispatch ()
   from /home/cmorgan/cvs/gitProjects/openmama/fork/build/mama/c_cpp/src/c/libmama.so
#8  0x00007f6bab8258a5 in mamaQueue_destroyTimedWait ()
   from /home/cmorgan/cvs/gitProjects/openmama/fork/build/mama/c_cpp/src/c/libmama.so
#9  0x00007f6bab1199f0 in qpidBridge_close (bridgeImpl=0x1fbf1a0) at mama/c_cpp/src/c/bridge/qpid/bridge.c:176
#10 0x00007f6bab80e4cc in mama_closeCount () from /home/cmorgan/cvs/gitProjects/openmama/fork/build/mama/c_cpp/src/c/libmama.so
#11 0x00007f6bab80e68a in mama_close () from /home/cmorgan/cvs/gitProjects/openmama/fork/build/mama/c_cpp/src/c/libmama.so
#12 0x00000000004016b1 in main ()
```

It looks like the timer callback is being called during mama_close since the `gTimer` was not destroyed. This patch to *mamapublisherc* destroys the timer once the gCount limit is reached. I also added a subscription destroy for `gSubscription` as I notice the default event queue was not getting cleaned up as well.

Command to reproduce:
```
./mamapublisherc -tport <tport_name> -m qpid -i 1.0 -c 2 -s foo
```

## Testing
Verified the example does not core with the changes.
