### PR TITLE
PLAT-1449: Mamda app includes phantom bid

### DIFF
--- a/mamda/c_cpp/src/cpp/orderbooks/MamdaOrderBookListener.cpp
+++ b/mamda/c_cpp/src/cpp/orderbooks/MamdaOrderBookListener.cpp
@@ -1239,8 +1239,17 @@ namespace Wombat
     bool MamdaOrderBookListener::MamdaOrderBookListenerImpl::createDelta(
         bool  isRecap)
     {
-        if ((mBookMsgFields.mNumLevels == 0) &&
-            (!mBookMsgFields.mHasMarketOrders))
+        /* 
+         * Here we are checking for a blank initial and will stop processing
+         * the message at this point.
+         * As MAMDA is optimised (with default values) we also need to check
+         * for non optimised feedhandlers which will not send all the required
+         * fields that we rely on to reset our defaults.
+         */
+        if (((mBookMsgFields.mNumLevels == 0) &&
+            (!mBookMsgFields.mHasMarketOrders)) || 
+            ((mBookMsgFields.mNumLevels == 1) && (mBookMsgFields.mPriceLevelVector == NULL)) &&
+            (isRecap) && (!mBookMsgFields.mHasMarketOrders))
         {
             mama_log (MAMA_LOG_LEVEL_FINEST,
                         "MamdaOrderBookListener::createDelta:- No price levels in update");


### PR DESCRIPTION
# Mamda app includes phantom bid
## MAMDA application was showing a phantom bid before there have been any (valid) bid's/updates in the book for a symbol.

## Areas Affected
- [ ] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [x] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
The issue was that the source was not an optimised feed and therefore we were not receiving the required fields required to reset certain orderbook fields that we default (in particular `mBookMsgFields.mNumLevels`)

The solution was to add a check for a blank initial.

## Testing
Using a simple bookticker that is outputting `book.getNumBidLevels()` and `book.getNumAskLevels()` and subscribing to a non-existent book shows the issue:

Before:
```
RECAP!!!  (seq# 0)
Book for: bGARY.NYS
BID:
    Levels - 1       <<<<<<<<<<<<<<<
ASK:
    Levels - 0
        Time     Num    Size   Price Act | Act Price   Size    Num       Time
```

After:
```
RECAP!!!  (seq# 0)
Book for: bGARY.NYS
BID:
    Levels - 0
ASK:
    Levels - 0
        Time     Num    Size   Price Act | Act Price   Size    Num       Time
```