### PR TITLE
Windows Capture Corrupt

### DIFF
--- a/mama/c_cpp/src/c/playback/playbackcapture.c
+++ b/mama/c_cpp/src/c/playback/playbackcapture.c
@@ -127,7 +127,7 @@ int mamaCapture_openFile(mamaPlaybackCapture* mamaCapture,
         mama_log (MAMA_LOG_LEVEL_FINE,
                   "mamaCapture_openFile: opening file: %s",
                   impl->myPlayBackFileName);
-        myPlaybackFile = fopen(impl->myPlayBackFileName,"w");
+        myPlaybackFile = fopen(impl->myPlayBackFileName,"wb");
 
         mama_log (MAMA_LOG_LEVEL_FINE,
                   "mamaCapture_openFile: file  %s succesfully opened.",


### PR DESCRIPTION
# Windows Capture File Corrupted
## Trying to replay a capture file created on windows is failing.

## Areas Affected
- [x] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
If we try to create a playback, on Windows, using the `capturec` example application everything seems fine, but then trying to replay the file with `capturereplayc` fails with the error:

```2018-05-17 15:22:40: wmsgPayload_setByteBuffer(): wombatmsg_setNewBuffer() Failed. [3]```

The solution is to open the file for capture with the binary flag which is compatible with both Windows and Linux.

## Testing
Replaying the playback works as expected (on both Windows and Linux).
