### PR TITLE
PLAT-1453: MamaFieldCache::find( ) header update

### DIFF
--- a/mama/c_cpp/src/cpp/mama/fieldcache/MamaFieldCache.h
+++ b/mama/c_cpp/src/cpp/mama/fieldcache/MamaFieldCache.h
@@ -210,6 +210,9 @@ public:
 
     /**
      * Retrieve a field from the cache.
+     * Note that the field returned is a pointer to a reusable MamaFieldCacheField
+     *  field for the MamaFieldCache which will be overwritten each time the function
+     *  is called.
      * If the field is not found then NULL is returned.
      *
      * @param fid Field id of the field to look up.
@@ -221,6 +224,9 @@ public:
 
     /**
      * Retrieve a field from the cache.
+     * Note that the field returned is a pointer to a reusable MamaFieldCacheField
+     *  field for the MamaFieldCache which will be overwritten each time the function
+     *  is called.
      * If the field is not found then NULL is returned.
      *
      * @param fid Field id of the field to look up.


### PR DESCRIPTION
# MamaFieldCache::find( ) header update
## To clear up some confusion as to how the MamaFieldCache::find( ) function works

## Areas Affected
- [ ] MAMAC
- [x] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
Updated the headers for the find() functions to more accurately reflect what
happens in the function.

## Testing
N/A