### PR TITLE
Fixed warnings coming up from recent contributions

### DIFF
--- a/common/c_cpp/src/c/linux/machine.c
+++ b/common/c_cpp/src/c/linux/machine.c
@@ -591,13 +591,21 @@ long getTotalSystemMem(void)
 
 void getSystemTime(double* upTime,double* idleTime)
 {
+    int matching_args = 0;
     FILE* fp;
     *upTime = 0;
     *idleTime = 0;
     fp = fopen("/proc/uptime", "r");
     if (fp==NULL)
         return;
-    fscanf (fp, "%lf %lf\n", upTime, idleTime);
+    matching_args = fscanf (fp, "%lf %lf\n", upTime, idleTime);
+    switch (matching_args) {
+	case 0:
+	    *upTime = 0.0;
+	case 1:
+	    *idleTime = 0.0;
+	    break;
+    }
     fclose (fp);
 }
 

--- a/mama/c_cpp/src/c/conflation/connection.c
+++ b/mama/c_cpp/src/c/conflation/connection.c
@@ -178,11 +178,11 @@ mamaConnection_toString (mamaConnection connection)
     mamaConnectionImpl* impl = (mamaConnectionImpl*)connection;
 
     /* Clear the buffer first */
-    memset(impl->mStrVal, 0, MAX_STR_LEN);
+    memset(impl->mStrVal, 0, sizeof(impl->mStrVal));
 
     /* Format the string and print it into the mStrVal buffer */
     /* uint16_t = max 5 digits, uint32_t = max 10 digits */
-    snprintf (impl->mStrVal, (MAX_STR_LEN - 1), "%s %d %s %s %u %u %u %u",
+    snprintf (impl->mStrVal, sizeof(impl->mStrVal), "%s %d %s %s %u %u %u %u",
               impl->mIpAddress,
               impl->mPort,
               impl->mAppName,

--- a/mama/c_cpp/src/c/conflation/connection_int.h
+++ b/mama/c_cpp/src/c/conflation/connection_int.h
@@ -30,7 +30,7 @@
 extern "C" {
 #endif
 
-#define MAX_STR_LEN 67
+#define MAX_STR_LEN 1024
 #define MAX_USER_STR_LEN 256
 
 #define MAMACONNECTION_MAX_IP_ADDRESS_LEN INET_ADDRSTRLEN    

--- a/mama/c_cpp/src/c/playback/playbackpublisher.c
+++ b/mama/c_cpp/src/c/playback/playbackpublisher.c
@@ -271,7 +271,7 @@ mamaPlayback_findOrCreatePublisher (mamaPlaybackPublisher mamaPlayback,
 {
     char*         temp         = NULL;
     int           nPos         = 0;
-    char          topic          [BUFFER_SIZE];
+    char          topic          [BUFFER_SIZE*3];
     char          keyCopy        [BUFFER_SIZE];
     mamaTransport transport    = NULL;
     int           result       = 1;
@@ -312,7 +312,7 @@ mamaPlayback_findOrCreatePublisher (mamaPlaybackPublisher mamaPlayback,
             return -1;
         }
 
-        sprintf(topic,"%s.%s", impl->mySource, impl->mySymbol); /**use fastCopyAndSlide*/
+        sprintf(topic, "%s.%s", impl->mySource, impl->mySymbol); /**use fastCopyAndSlide*/
         mamaPlayback_createPublisher (impl, &transport,
                                       publisher,
                                       topic);

--- a/mama/c_cpp/src/c/transport.c
+++ b/mama/c_cpp/src/c/transport.c
@@ -188,7 +188,7 @@ typedef struct transportImpl_
 static mama_status
 init (transportImpl* transport, int createResponder)
 {
-    char        searchName[256];
+    char        searchName[512];
     const char* searchResult;
     const char* middleware               = NULL;
     const char* propertyVal              = NULL;
@@ -389,11 +389,11 @@ static int mamaTransportInternal_cmResponderEnabled (transportImpl *impl,
 static void setPreInitialStrategy (mamaTransport transport)
 {
     const char* propValue     = NULL;
-    char propNameBuf[256];
+    char propNameBuf[512];
 
     if (!self) return;
 
-    snprintf (propNameBuf, 256, "mama.transport.%s.preinitialstrategy", self->mName);
+    snprintf (propNameBuf, sizeof(propNameBuf), "mama.transport.%s.preinitialstrategy", self->mName);
 
     propValue = properties_Get (mamaInternal_getProperties (),
                                propNameBuf);
@@ -421,11 +421,11 @@ static void setPreInitialStrategy (mamaTransport transport)
 static void setDQStrategy (mamaTransport transport)
 {
     const char* propValue     = NULL;
-    char propNameBuf[256];
+    char propNameBuf[512];
 
     if (!self) return;
 
-    snprintf (propNameBuf, 256, "mama.transport.%s.dqstrategy", self->mName);
+    snprintf (propNameBuf, sizeof(propNameBuf), "mama.transport.%s.dqstrategy", self->mName);
 
     propValue = properties_Get(mamaInternal_getProperties(),
                                propNameBuf);
@@ -460,11 +460,11 @@ static void setDQStrategy (mamaTransport transport)
 static void setFtStrategy (mamaTransport transport)
 {
     const char* propValue     = NULL;
-    char propNameBuf[256];
+    char propNameBuf[512];
 
     if (!self) return;
 
-    snprintf (propNameBuf, 256, "mama.transport.%s.ftstrategy", self->mName);
+    snprintf (propNameBuf, sizeof(propNameBuf), "mama.transport.%s.ftstrategy", self->mName);
 
     propValue = properties_Get(mamaInternal_getProperties(),
                                propNameBuf);
@@ -492,11 +492,11 @@ static void setFtStrategy (mamaTransport transport)
 
 static void enablePreRecapCache (mamaTransport transport, const char* middleware)
 {
-    char propNameBuf[256];
+    char propNameBuf[512];
 
     if (!self) return;
 
-    snprintf (propNameBuf, 256, "mama.%s.transport.%s.prerecapcache.enable", middleware, self->mName);
+    snprintf (propNameBuf, sizeof(propNameBuf), "mama.%s.transport.%s.prerecapcache.enable", middleware, self->mName);
 
     self->mPreRecapCacheEnabled = strtobool (mama_getProperty (propNameBuf));
 
@@ -572,11 +572,11 @@ static int mamaTransportImpl_disableDisconnectCb (const char* transportName)
 static void setDeactivateOnError (mamaTransport transport)
 {
     const char* propValue     = NULL;
-    char propNameBuf[256];
+    char propNameBuf[MAX_PROP_STRING];
 
     if (!self) return;
 
-    snprintf (propNameBuf, 256, "mama.transport.%s.deactivateonerror", self->mName);
+    snprintf (propNameBuf, sizeof(propNameBuf), "mama.transport.%s.deactivateonerror", self->mName);
     /*Check for a user specified activity timer value*/
     propValue = properties_Get (mamaInternal_getProperties (),
                                propNameBuf);
@@ -593,13 +593,13 @@ static void setDeactivateOnError (mamaTransport transport)
 static void setGroupSizeHint (mamaTransport transport, const char* middleware)
 {
     const char* propValue   = NULL;
-    char propNameBuf[256];
-    char propNameBufMw[256];
+    char propNameBuf[MAX_PROP_STRING];
+    char propNameBufMw[MAX_PROP_STRING];
 
     if (!self) return;
 
     /* Check for mama.middleware.transport[...] first */
-    snprintf (propNameBufMw, 256, "mama.%s.transport.%s.groupsizehint",
+    snprintf (propNameBufMw, sizeof(propNameBufMw), "mama.%s.transport.%s.groupsizehint",
                 middleware, self->mName);
     propValue = properties_Get (mamaInternal_getProperties (),
                                propNameBufMw);
@@ -607,7 +607,7 @@ static void setGroupSizeHint (mamaTransport transport, const char* middleware)
     /* Only use mama.transport[...] if not found with middleware */
     if (NULL == propValue)
     {
-        snprintf (propNameBuf, 256, "mama.transport.%s.groupsizehint", self->mName);
+        snprintf (propNameBuf, sizeof(propNameBuf), "mama.transport.%s.groupsizehint", self->mName);
         propValue = properties_Get (mamaInternal_getProperties (),
                                    propNameBuf);
     }
@@ -644,7 +644,7 @@ mamaTransport_create (mamaTransport transport,
     int           i;
     int           numTransports;
     int           isLoadBalanced;
-    char          loadBalanceName[MAX_TPORT_NAME_LEN];
+    char          loadBalanceName[MAX_TPORT_NAME_LEN * 2];
     const char*   bridgeName       = NULL;
     const char*   sharedObjectName = NULL;
     mamaQueue     defaultQueue     = NULL;
@@ -652,7 +652,7 @@ mamaTransport_create (mamaTransport transport,
     mama_status   status;
     const char*   middleware  = NULL;
     const char*   throttleInt = NULL;
-    char          propNameBuf[256];
+    char          propNameBuf[MAX_PROP_STRING];
     const char*   entBridgeName;
     const char*   propValue;
 
@@ -851,7 +851,7 @@ mamaTransport_create (mamaTransport transport,
 
         for (i = 0; i < self->mNumTransports; ++i)
         {
-            snprintf (loadBalanceName, MAX_TPORT_NAME_LEN,
+            snprintf (loadBalanceName, sizeof(loadBalanceName),
                     "%s.lb%d", self->mName, i);
             loadBalanceName[MAX_TPORT_NAME_LEN-1] = '\0';
             bridgeName = loadBalanceName;
@@ -877,7 +877,7 @@ mamaTransport_create (mamaTransport transport,
 
         if (isLoadBalanced)
         {
-            snprintf (loadBalanceName, MAX_TPORT_NAME_LEN,
+            snprintf (loadBalanceName, sizeof(loadBalanceName),
                       "%s.lb%d", self->mName, self->mCurTransportIndex);
             loadBalanceName[MAX_TPORT_NAME_LEN-1] = '\0';
             bridgeName = loadBalanceName;
@@ -938,7 +938,7 @@ mamaTransport_create (mamaTransport transport,
 
     if (strlen((char*)gEntitlementBridges))   /* If entitlement bridges were built in at compile time. */
     {
-        snprintf (propNameBuf, 256, "mama.transport.%s.entitlementBridge", self->mName);
+        snprintf (propNameBuf, sizeof(propNameBuf), "mama.transport.%s.entitlementBridge", self->mName);
         propValue = properties_Get (mamaInternal_getProperties (), propNameBuf);
         if (NULL != propValue)
         {

--- a/mama/c_cpp/src/examples/cpp/mamalistencachedcpp.cpp
+++ b/mama/c_cpp/src/examples/cpp/mamalistencachedcpp.cpp
@@ -813,11 +813,11 @@ void  MamaListen::subscribeToSymbols ()
     {
         for (index=0; index<mThreads; index++)
         {
-            char queueNameBuf[12];
+            char queueNameBuf[56];
 
             MamaQueue* queue = mQueueGroup->getNextQueue ();
 
-            snprintf (queueNameBuf, 12, "QUEUE %d", index);
+            snprintf (queueNameBuf, sizeof(queueNameBuf), "QUEUE %d", index);
 
             printf ("Setting monitor for %s\n", queueNameBuf);
 

--- a/mama/c_cpp/src/examples/cpp/mamalistencpp.cpp
+++ b/mama/c_cpp/src/examples/cpp/mamalistencpp.cpp
@@ -787,11 +787,11 @@ void  MamaListen::subscribeToSymbols ()
     {
         for (index=0; index<mThreads; index++)
         {
-            char queueNameBuf[12];
+            char queueNameBuf[56];
 
             MamaQueue* queue = mQueueGroup->getNextQueue ();
 
-            snprintf (queueNameBuf, 12, "QUEUE %d", index);
+            snprintf (queueNameBuf, sizeof(queueNameBuf), "QUEUE %d", index);
 
             printf ("Setting monitor for %s\n", queueNameBuf);
 

--- a/mamda/c_cpp/src/cpp/MamdaQuoteListener.cpp
+++ b/mamda/c_cpp/src/cpp/MamdaQuoteListener.cpp
@@ -1967,7 +1967,7 @@ namespace Wombat
                        const MamaMsgField&                          field)
         {
             impl.mQuoteCache.mTmpQuoteCount = field.getU32();
-            impl.mQuoteCache.mGotQuoteCount = (bool)MODIFIED;
+            impl.mQuoteCache.mGotQuoteCount = true;
             impl.mQuoteCache.mTmpQuoteCountFieldState = MODIFIED;
         }
     };

--- a/mamda/c_cpp/src/cpp/MamdaSubscription.cpp
+++ b/mamda/c_cpp/src/cpp/MamdaSubscription.cpp
@@ -453,18 +453,15 @@ namespace Wombat
 
     void MamdaSubscription::MamdaSubscriptionImpl::destroy ()
     {
-        if (this != NULL)
+        if (implValid)
         {
-            if (implValid)
-            {
-                *implValid = false;
-            }
-
-            mSubscription.deactivate ();
-            clearMsgListeners        ();
-            clearErrorListeners      ();
-            clearQualityListeners    ();
+            *implValid = false;
         }
+
+        mSubscription.deactivate ();
+        clearMsgListeners        ();
+        clearErrorListeners      ();
+        clearQualityListeners    ();
     }
 
     void MamdaSubscription::MamdaSubscriptionImpl::clearMsgListeners ()

--- a/mamda/c_cpp/src/cpp/orderbooks/MamdaBookAtomicListener.cpp
+++ b/mamda/c_cpp/src/cpp/orderbooks/MamdaBookAtomicListener.cpp
@@ -640,8 +640,7 @@ namespace Wombat
                 mPriceLevelEntrySize,
                 (MamdaOrderBookEntry::Action)mPriceLevelEntryAction,
                 mPriceLevelEntryTime,
-                (const MamaSourceDerivative*) NULL),
-                mPriceLevelEntryPosition;
+                (const MamaSourceDerivative*) NULL);
 
         mEntry->setReason((MamdaOrderBookTypes::Reason)mPriceLevelEntryReason);
         mEntry->setClosure((void*)entryMsg);

--- a/mamda/c_cpp/src/cpp/orderbooks/MamdaOrderBook.cpp
+++ b/mamda/c_cpp/src/cpp/orderbooks/MamdaOrderBook.cpp
@@ -3606,11 +3606,12 @@ namespace Wombat
                 {
                     char msg[1000];
                     const char* sourceId = "none";
-                    if (mSourceDeriv)
+                    if (mSourceDeriv) {
                         sourceId = mSourceDeriv->getBaseSource()->getDisplayId();
-                        snprintf (msg, 1000,"MamdaOrderBook::detach(%s:%s) attempted to detach"
-                                  " MARKET order price level %g with an unknown side",
-                                  sourceId, mSymbol.c_str(), level->getPrice());
+                    }
+                    snprintf (msg, 1000,"MamdaOrderBook::detach(%s:%s) attempted to detach"
+                                        " MARKET order price level %g with an unknown side",
+                                        sourceId, mSymbol.c_str(), level->getPrice());
 
                     return;
                 }

--- a/mamda/c_cpp/src/cpp/orderbooks/MamdaOrderBookEntry.cpp
+++ b/mamda/c_cpp/src/cpp/orderbooks/MamdaOrderBookEntry.cpp
@@ -47,8 +47,8 @@ namespace Wombat
         , mQuality       (MAMA_QUALITY_OK)
         , mAction        (MAMDA_BOOK_ACTION_ADD)
         , mStatus        (0)
+        , mEntryPosition (0)
         , mReason        (MamdaOrderBookTypes::MAMDA_BOOK_REASON_UNKNOWN)
-        , mEntryPosition (false)
     {
     }
 
@@ -64,8 +64,8 @@ namespace Wombat
         , mQuality       (copy.mQuality)
         , mAction        (copy.mAction)
         , mStatus        (0)
-        , mReason        (copy.mReason)
         , mEntryPosition (copy.mEntryPosition)
+        , mReason        (copy.mReason)
     {
         setId (copy.mId);
         setUniqueId (copy.mUniqueId);
@@ -88,8 +88,8 @@ namespace Wombat
         , mQuality     (MAMA_QUALITY_OK)
         , mAction      (action)
         , mStatus      (0)
+        , mEntryPosition (0)
         , mReason      (MamdaOrderBookTypes::MAMDA_BOOK_REASON_MODIFY)
-        , mEntryPosition (false)
     {
         setId (entryId);
     }
@@ -112,8 +112,8 @@ namespace Wombat
         , mQuality     (MAMA_QUALITY_OK)
         , mAction      (action)
         , mStatus      (0)
-        , mReason      (MamdaOrderBookTypes::MAMDA_BOOK_REASON_MODIFY)
         , mEntryPosition (entryPosition)
+        , mReason      (MamdaOrderBookTypes::MAMDA_BOOK_REASON_MODIFY)
     {
         setId (entryId);
     }
@@ -156,7 +156,7 @@ namespace Wombat
         mAction        = MAMDA_BOOK_ACTION_ADD;
         mStatus        = 0;
         mReason        = MamdaOrderBookTypes::MAMDA_BOOK_REASON_UNKNOWN;
-        mEntryPosition = false;
+        mEntryPosition = 0;
     }
 
     void MamdaOrderBookEntry::copy(const MamdaOrderBookEntry& copy)


### PR DESCRIPTION
Mostly in the MAMDA area. While I was there I also fixed some warnings
introduced by newer versions of gcc around string buffer length checks
to prevent overflows.

Signed-off-by: Frank Quinn <fquinn@cascadium.io>