### PR TITLE
MamdaOrderBookListener entry based deletes incorrectly add to bid/ask side maps

### DIFF
--- a/mamda/c_cpp/src/cpp/orderbooks/MamdaOrderBookListener.cpp
+++ b/mamda/c_cpp/src/cpp/orderbooks/MamdaOrderBookListener.cpp
@@ -1567,14 +1567,27 @@ namespace Wombat
             }
             else
             {
-                //Check if level exists
-                MamdaOrderBookPriceLevel::Action findLevelAction = plAction;
-                level = mFullBook->findOrCreateLevel (plPrice, plSide, findLevelAction);
-                if (plAction != findLevelAction)
+                if ((mBookMsgFields.mBookType == 1) &&
+                    (MamdaOrderBookEntry::MAMDA_BOOK_ACTION_DELETE == mBookMsgFields.mEntryAction))
                 {
-                    //Fix the level action for the delta
-                    plAction = findLevelAction;
-                    mBookMsgFields.mPlAction = findLevelAction;
+                    // We just need to find the level
+                    level = mFullBook->findLevel (plPrice, plSide);
+                    if (!level)
+                    {
+                        return;
+                    }
+                }
+                else
+                {
+                    //Check if level exists
+                    MamdaOrderBookPriceLevel::Action findLevelAction = plAction;
+                    level = mFullBook->findOrCreateLevel (plPrice, plSide, findLevelAction);
+                    if (plAction != findLevelAction)
+                    {
+                        //Fix the level action for the delta
+                        plAction = findLevelAction;
+                        mBookMsgFields.mPlAction = findLevelAction;
+                    }
                 }
             }
         }


### PR DESCRIPTION
# MamdaOrderBookListener entry based deletes issue with wirecache
## Summary
MamdaOrderBookListener entry based deletes incorrectly add to bid/ask side maps

## Areas Affected
- [ ] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [x] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
When the feedhandler is wirecache and the orderbooks are entry based, deletes were incorrectly
being added to the Ask/Bid side maps causing the functions getNumBidLevels() and
getNumAskLevels() to return incorrect values.
You can easily see this happen if you miss some price levels at the start and then later receive an entry delete for a non-existent price level.

## Testing
To test, modify a bookticker.cpp and put the following into the top of the prettyPrint() function:

```
        cout << "Book for: " << symbol << endl;

        cout << "BID:" << endl;
        cout << "    Levels - " << book.getNumBidLevels() << endl;
        cout << "ASK:"<< endl;
        cout << "    Levels - " << book.getNumAskLevels() << endl;

```

Subscribing to a V5 entry based orderbook, we can see the following message:

```
.CTA_V5.bHSBC.NYS Type: BOOK_UPDATE Status OK
  MdMsgType            |    1 |            U8 | 17
  MdMsgStatus          |    2 |            U8 | 0
  MdSeqNum             |   10 |           U32 | 72789
  MamaSenderId         |   20 |           U16 | 1234
  wIssueSymbol         |  305 |        STRING |
  wEntitleCode         |  496 |           U16 | 62
  wSeqNum              |  498 |           U32 | 215006
  wSrcTime             |  465 |          TIME | 2018-10-26 13:31:01.870000
  wSymbol              |  470 |        STRING | HSBC.NYS
  wLineTime            | 1174 |          TIME | 2014-05-07 13:30:25
  wBookTime            |  671 |          TIME | 00:00:00
  wBookType            | 4714 |            U8 | 1
  wPriceLevels         |  699 |    VECTOR_MSG |
  {
    wPlPrice             |  653 |           F64 | 50.640000
    wPlSide              |  654 |          CHAR | A
    wPlTime              |  658 |          TIME | 00:00:00
    wPlSizeChange        |  656 |           I64 | 0
    wPlNumEntries        |  657 |           U16 | 0
    wEntryId             |  681 |        STRING | B
    wEntryAction         |  683 |          CHAR | D
    wEntrySize           |  682 |           U32 | 0
    wEntryTime           |  685 |          TIME | 2018-10-26 13:31:01.870000
    wEntryReason         |  684 |          CHAR | Z
    wPlPrice             |  653 |           F64 | 50.650000
    wPlSide              |  654 |          CHAR | A
    wPlTime              |  658 |          TIME | 00:00:00
    wPlSizeChange        |  656 |           I64 | 0
    wPlNumEntries        |  657 |           U16 | 0
    wEntryId             |  681 |        STRING | B
    wEntryAction         |  683 |          CHAR | A
    wEntrySize           |  682 |           U32 | 3
    wEntryTime           |  685 |          TIME | 2018-10-26 13:31:01.870000
    wEntryReason         |  684 |          CHAR | Z
  }
```

Before the change:
```
RECAP!!!  (seq# 72788)
Book for: bHSBC.NYS
BID:
    Levels - 1
ASK:
    Levels - 0
ID/Num           Time     Position   Size   Price
  Bid     1           00:00:00       3   50.62
               P  13:31:01.554  1           3   50.62

DELTA!!!  (seq# 72789)      <<<<<<<<  Includes an entry delete
       0   50.65  A
Book for: bHSBC.NYS
BID:
    Levels - 1
ASK:
    Levels - 2      <<<<<<<<<<<<<<   Incorrect
ID/Num           Time     Position   Size   Price
  Bid     1           00:00:00       3   50.62
               P  13:31:01.554  1           3   50.62
  Ask     1           00:00:00       3   50.65
               B  13:31:01.870  1            3   50.65
```

After the change:

```
RECAP!!!  (seq# 72788)
Book for: bHSBC.NYS
BID:
    Levels - 1
ASK:
    Levels - 0
ID/Num           Time     Position   Size   Price
  Bid     1           00:00:00       3   50.62
               P  13:31:01.554  1           3   50.62

DELTA!!!  (seq# 72789)         <<<<<<<<  Includes an entry delete
       0   50.65  A
Book for: bHSBC.NYS
BID:
    Levels - 1
ASK:
    Levels - 1
ID/Num           Time     Position   Size   Price
  Bid     1           00:00:00       3   50.62
               P  13:31:01.554  1           3   50.62
  Ask     1           00:00:00       3   50.65
               B  13:31:01.870  1            3   50.65
```