### PR TITLE
Add cross platform docker builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,12 +7,14 @@ environment:
     PLATFORM: x86
     BUILD_TYPE: RelWithDebInfo
     JAVA_HOME: C:\Program Files (x86)\Java\jdk1.8.0
+    JAVA_HOME_TEST: C:\Program Files (x86)\Java\jdk1.8.0
 
   - GENERATOR: Visual Studio 15 2017 Win64
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     PLATFORM: x64
     BUILD_TYPE: RelWithDebInfo
     JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+    JAVA_HOME_TEST: C:\Program Files\Java\jdk1.8.0
 
   - APPVEYOR_BUILD_WORKER_IMAGE: ubuntu1804
     DOCKER_IMAGE: fedora:26
@@ -48,6 +50,7 @@ install:
 - cmd: set PATH=C:\ProgramData\chocolatey\bin;%JAVA_HOME%\bin;%PATH%
 - cmd: echo %PATH%
 - cmd: echo %JAVA_HOME%
+- cmd: echo %JAVA_HOME_TEST%
 # - cmd: |-
 #     cd "C:\Tools\vcpkg"
 #     git pull

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -51,18 +51,18 @@ install:
 - cmd: echo %PATH%
 - cmd: echo %JAVA_HOME%
 - cmd: echo %JAVA_HOME_TEST%
-# - cmd: |-
-#     cd "C:\Tools\vcpkg"
-#     git pull
-#     .\bootstrap-vcpkg.bat
-#     cd %appveyor_build_folder%
+- cmd: |-
+    cd "C:\Tools\vcpkg"
+    git pull
+    .\bootstrap-vcpkg.bat
+    cd %appveyor_build_folder%
 - sh: sudo apt-get update -qq
 - sh: sudo apt-get install -y docker python
 - sh: sudo pip install --upgrade cloudsmith-cli
 
 # Dependencies
-# before_build:
-# - cmd: vcpkg install qpid-proton:%PLATFORM%-windows libevent:%PLATFORM%-windows apr:%PLATFORM%-windows gtest:%PLATFORM%-windows
+before_build:
+- cmd: vcpkg install qpid-proton:%PLATFORM%-windows libevent:%PLATFORM%-windows apr:%PLATFORM%-windows gtest:%PLATFORM%-windows
 
 build_script:
   # Windows build
@@ -71,11 +71,9 @@ build_script:
     cd %APPVEYOR_BUILD_FOLDER%
     mkdir build
     cd build
-    REM cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_CSHARP=ON -DWITH_UNITTEST=ON -DWITH_JAVA=ON -DPROTON_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ -DGTEST_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ -DINSTALL_RUNTIME_DEPENDENCIES=ON -DCMAKE_INSTALL_PREFIX=%OPENMAMA_INSTALL_DIR% -G "%GENERATOR%" -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DAPR_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ ..
-    REM cmake --build . --config RelWithDebInfo --target install
+    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_CSHARP=ON -DWITH_UNITTEST=ON -DWITH_JAVA=ON -DPROTON_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ -DGTEST_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ -DINSTALL_RUNTIME_DEPENDENCIES=ON -DCMAKE_INSTALL_PREFIX=%OPENMAMA_INSTALL_DIR% -G "%GENERATOR%" -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DAPR_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ ..
+    cmake --build . --config RelWithDebInfo --target install
     cd ..
-    set JAVA_HOME=%JAVA_HOME_OVERRIDE%
-    echo %JAVA_HOME_OVERRIDE%
     python release_scripts\ci-run.py
 
   # Linux build

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -46,12 +46,19 @@ install:
 - cmd: choco install -y unzip gow wget gradle nunit-console-runner nunit-extension-nunit-v2-driver
 - cmd: refreshenv
 - cmd: set PATH=C:\ProgramData\chocolatey\bin;%PATH%
+- cmd: |-
+    cd "C:\Tools\vcpkg"
+    git pull
+    .\bootstrap-vcpkg.bat
+    cd %appveyor_build_folder%
 - sh: sudo apt-get update -qq
 - sh: sudo apt-get install -y docker python
 - sh: sudo pip install --upgrade cloudsmith-cli
 
 # build platform, i.e. x86, x64, Any CPU. This setting is optional.
-platform: x64
+platform:
+- x64
+- x86
 
 for:
 -

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -128,8 +128,8 @@ for:
   # to run your custom scripts instead of automatic MSBuild
   build_script:
   - sh: docker build -t omdocker -f release_scripts/Dockerfile . --build-arg IMAGE=$DOCKER_IMAGE
-  - sh: docker run -e VERSION=6.2.3 -v release:/apps/release --rm omdocker
-  - sh: find ./release
+  - sh: docker run -e VERSION=6.2.3 -v $(pwd):/apps/release --rm omdocker
+  - sh: ls -ltr
   - sh: cloudsmith whoami
 
   # The build script already tests as well and this one doesnt work for some reason anyway

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -64,7 +64,7 @@ build_script:
     cd %APPVEYOR_BUILD_FOLDER%
     mkdir build
     cd build
-    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_CSHARP=ON -DWITH_UNITTEST=ON -DWITH_JAVA=ON -DPROTON_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ -DINSTALL_RUNTIME_DEPENDENCIES=ON -DCMAKE_INSTALL_PREFIX=%OPENMAMA_INSTALL_DIR% -G "%GENERATOR%" -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake ..
+    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_CSHARP=ON -DWITH_UNITTEST=ON -DWITH_JAVA=ON -DPROTON_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ -DGTEST_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ -DINSTALL_RUNTIME_DEPENDENCIES=ON -DCMAKE_INSTALL_PREFIX=%OPENMAMA_INSTALL_DIR% -G "%GENERATOR%" -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake ..
     cmake --build . --config RelWithDebInfo --target install
     cd ..
     python release_scripts\ci-run.py

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -48,6 +48,7 @@ install:
 - cmd: set PATH=C:\ProgramData\chocolatey\bin;%PATH%
 - sh: sudo apt-get update -qq
 - sh: sudo apt-get install -y docker python
+- sh: sudo pip install --upgrade cloudsmith-cli
 
 # build platform, i.e. x86, x64, Any CPU. This setting is optional.
 platform: x64
@@ -129,6 +130,7 @@ for:
   - sh: docker build -t omdocker -f release_scripts/Dockerfile . --build-arg IMAGE=$DOCKER_IMAGE
   - sh: docker run -e VERSION=6.2.3 -v release:/apps/release --rm omdocker
   - sh: find ./release
+  - sh: cloudsmith whoami
 
   # The build script already tests as well and this one doesnt work for some reason anyway
   test: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -64,7 +64,7 @@ build_script:
     cd %APPVEYOR_BUILD_FOLDER%
     mkdir build
     cd build
-    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_CSHARP=ON -DWITH_UNITTEST=ON -DWITH_JAVA=ON -DPROTON_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ -DGTEST_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ -DINSTALL_RUNTIME_DEPENDENCIES=ON -DCMAKE_INSTALL_PREFIX=%OPENMAMA_INSTALL_DIR% -G "%GENERATOR%" -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake ..
+    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_CSHARP=ON -DWITH_UNITTEST=ON -DWITH_JAVA=ON -DPROTON_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ -DGTEST_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ -DINSTALL_RUNTIME_DEPENDENCIES=ON -DCMAKE_INSTALL_PREFIX=%OPENMAMA_INSTALL_DIR% -G "%GENERATOR%" -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DAPR_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ ..
     cmake --build . --config RelWithDebInfo --target install
     cd ..
     python release_scripts\ci-run.py

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -72,48 +72,48 @@ for:
   # scripts to run before build
   before_build:
   - cmd: vcpkg install qpid-proton:%PLATFORM%-windows libevent:%PLATFORM%-windows apr:%PLATFORM%-windows gtest:%PLATFORM%-windows
-  - cmd: |-
-      mkdir %APPVEYOR_BUILD_FOLDER%\qpid-proton
-      cd %APPVEYOR_BUILD_FOLDER%\qpid-proton
-      wget "https://github.com/apache/qpid-proton/archive/0.15.0.zip"
-      unzip 0.15.0.zip
-      cd qpid-proton-0.15.0
-      mkdir bld
-      cd bld
-      cmake -DBUILD_TESTING=OFF -DBUILD_JAVA=OFF -DBUILD_CPP=OFF .. -G %GENERATOR%
-      cmake --build . --config Release --target install
-  - cmd: |-
-      mkdir %APPVEYOR_BUILD_FOLDER%\googletest
-      cd %APPVEYOR_BUILD_FOLDER%\googletest
-      wget "https://github.com/google/googletest/archive/release-1.8.0.zip"
-      unzip release-1.8.0.zip
-      cd googletest-release-1.8.0
-      mkdir bld
-      cd bld
-      cmake -DCMAKE_CXX_FLAGS=-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING -DBUILD_SHARED_LIBS=ON -DBUILD_GTEST=ON -DBUILD_GMOCK=OFF -G %GENERATOR% ..
-      cmake --build . --config Release --target install
-  - cmd: |-
-      mkdir %APPVEYOR_BUILD_FOLDER%\..\libevent
-      cd %APPVEYOR_BUILD_FOLDER%\..\libevent
-      wget "https://github.com/libevent/libevent/archive/release-2.1.8-stable.tar.gz"
-      cmake -E tar xzf release-2.1.8-stable.tar.gz
-      cd libevent-release-2.1.8-stable
-      mkdir bld
-      cd bld
-      cmake -DEVENT__DISABLE_OPENSSL=ON -G %GENERATOR% ..
-      type include\event2\event-config.h
-      cmake --build . --config Release --target install
-  - cmd: |-
-      mkdir %APPVEYOR_BUILD_FOLDER%\apr
-      cd %APPVEYOR_BUILD_FOLDER%\apr
-      wget "https://github.com/apache/apr/archive/1.6.3.zip"
-      unzip 1.6.3.zip
-      dir
-      cd apr-1.6.3
-      mkdir bld
-      cd bld
-      cmake -G %GENERATOR% ..
-      cmake --build . --config Release --target install
+#  - cmd: |-
+#      mkdir %APPVEYOR_BUILD_FOLDER%\qpid-proton
+#      cd %APPVEYOR_BUILD_FOLDER%\qpid-proton
+#      wget "https://github.com/apache/qpid-proton/archive/0.15.0.zip"
+#      unzip 0.15.0.zip
+#      cd qpid-proton-0.15.0
+#      mkdir bld
+#      cd bld
+#      cmake -DBUILD_TESTING=OFF -DBUILD_JAVA=OFF -DBUILD_CPP=OFF .. -G %GENERATOR%
+#      cmake --build . --config Release --target install
+#  - cmd: |-
+#      mkdir %APPVEYOR_BUILD_FOLDER%\googletest
+#      cd %APPVEYOR_BUILD_FOLDER%\googletest
+#      wget "https://github.com/google/googletest/archive/release-1.8.0.zip"
+#      unzip release-1.8.0.zip
+#      cd googletest-release-1.8.0
+#      mkdir bld
+#      cd bld
+#      cmake -DCMAKE_CXX_FLAGS=-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING -DBUILD_SHARED_LIBS=ON -DBUILD_GTEST=ON -DBUILD_GMOCK=OFF -G %GENERATOR% ..
+#      cmake --build . --config Release --target install
+#  - cmd: |-
+#      mkdir %APPVEYOR_BUILD_FOLDER%\..\libevent
+#      cd %APPVEYOR_BUILD_FOLDER%\..\libevent
+#      wget "https://github.com/libevent/libevent/archive/release-2.1.8-stable.tar.gz"
+#      cmake -E tar xzf release-2.1.8-stable.tar.gz
+#      cd libevent-release-2.1.8-stable
+#      mkdir bld
+#      cd bld
+#      cmake -DEVENT__DISABLE_OPENSSL=ON -G %GENERATOR% ..
+#      type include\event2\event-config.h
+#      cmake --build . --config Release --target install
+#  - cmd: |-
+#      mkdir %APPVEYOR_BUILD_FOLDER%\apr
+#      cd %APPVEYOR_BUILD_FOLDER%\apr
+#      wget "https://github.com/apache/apr/archive/1.6.3.zip"
+#      unzip 1.6.3.zip
+#      dir
+#      cd apr-1.6.3
+#      mkdir bld
+#      cd bld
+#      cmake -G %GENERATOR% ..
+#      cmake --build . --config Release --target install
 
   # to run your custom scripts instead of automatic MSBuild
   build_script:
@@ -121,7 +121,7 @@ for:
       cd %APPVEYOR_BUILD_FOLDER%
       mkdir build
       cd build
-      cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_CSHARP=ON -DWITH_UNITTEST=ON -DWITH_JAVA=ON -DINSTALL_RUNTIME_DEPENDENCIES=ON -DCMAKE_INSTALL_PREFIX=%OPENMAMA_INSTALL_DIR% -G %GENERATOR% ..
+      cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_CSHARP=ON -DWITH_UNITTEST=ON -DWITH_JAVA=ON -DINSTALL_RUNTIME_DEPENDENCIES=ON -DCMAKE_INSTALL_PREFIX=%OPENMAMA_INSTALL_DIR% -G %GENERATOR% -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake ..
       cmake --build . --config RelWithDebInfo --target install
       cd ..
       python release_scripts\ci-run.py

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -74,7 +74,7 @@ build_script:
     cd %APPVEYOR_BUILD_FOLDER%
     mkdir build
     cd build
-    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_CSHARP=ON -DWITH_UNITTEST=ON -DWITH_JAVA=ON -DPROTON_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ -DGTEST_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ -DINSTALL_RUNTIME_DEPENDENCIES=ON -DCMAKE_INSTALL_PREFIX="%OPENMAMA_INSTALL_DIR%"" -G "%GENERATOR%" -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DAPR_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ ..
+    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_CSHARP=ON -DWITH_UNITTEST=ON -DWITH_JAVA=ON -DPROTON_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ -DGTEST_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ -DINSTALL_RUNTIME_DEPENDENCIES=ON -DCMAKE_INSTALL_PREFIX="%OPENMAMA_INSTALL_DIR%" -G "%GENERATOR%" -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DAPR_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ ..
     cmake --build . --config RelWithDebInfo --target install
     cd ..
     python release_scripts\ci-run.py

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -44,7 +44,7 @@ environment:
     DOCKER_IMAGE: centos:7
 
 init:
-- cmd: set OPENMAMA_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%\install
+- cmd: set OPENMAMA_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%\openmama-%VERSION%.win.%PLATFORM%
 # TODO: Make programatic
 - cmd: set VERSION=6.2.3
 - sh: export VERSION=6.2.3
@@ -74,8 +74,8 @@ build_script:
     cd %APPVEYOR_BUILD_FOLDER%
     mkdir build
     cd build
-    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_CSHARP=ON -DWITH_UNITTEST=ON -DWITH_JAVA=ON -DPROTON_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ -DGTEST_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ -DINSTALL_RUNTIME_DEPENDENCIES=ON -DCMAKE_INSTALL_PREFIX=%OPENMAMA_INSTALL_DIR% -G "%GENERATOR%" -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DAPR_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ ..
-    cmake --build . --config RelWithDebInfo --target openmama-%VERSION%.win.%PLATFORM%
+    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_CSHARP=ON -DWITH_UNITTEST=ON -DWITH_JAVA=ON -DPROTON_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ -DGTEST_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ -DINSTALL_RUNTIME_DEPENDENCIES=ON -DCMAKE_INSTALL_PREFIX=openmama-%VERSION%.win.%PLATFORM% -G "%GENERATOR%" -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DAPR_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ ..
+    cmake --build . --config RelWithDebInfo --target install
     cd ..
     python release_scripts\ci-run.py
     7z a openmama-%VERSION%.win.%PLATFORM%.zip %APPVEYOR_BUILD_FOLDER%\build\openmama-%VERSION%.win.%PLATFORM%

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -45,15 +45,15 @@ environment:
 
 init:
 - cmd: set OPENMAMA_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%\install
+# TODO: Make programatic
+- cmd: set VERSION=6.2.3
+- sh: export VERSION=6.2.3
 
 # Build chain tooling
 install:
 - cmd: choco install -y unzip gow wget gradle nunit-console-runner nunit-extension-nunit-v2-driver
 - cmd: refreshenv
-- cmd: set PATH=C:\ProgramData\chocolatey\bin;%JAVA_HOME%\bin;%PATH%
-- cmd: echo %PATH%
-- cmd: echo %JAVA_HOME%
-- cmd: echo %JAVA_HOME_TEST%
+- cmd: set PATH=C:\ProgramData\chocolatey\bin;%PATH%
 - cmd: |-
     cd "C:\Tools\vcpkg"
     git pull
@@ -75,14 +75,17 @@ build_script:
     mkdir build
     cd build
     cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_CSHARP=ON -DWITH_UNITTEST=ON -DWITH_JAVA=ON -DPROTON_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ -DGTEST_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ -DINSTALL_RUNTIME_DEPENDENCIES=ON -DCMAKE_INSTALL_PREFIX=%OPENMAMA_INSTALL_DIR% -G "%GENERATOR%" -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DAPR_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ ..
-    cmake --build . --config RelWithDebInfo --target install
+    cmake --build . --config RelWithDebInfo --target openmama-%VERSION%.win.%PLATFORM%
     cd ..
     python release_scripts\ci-run.py
+    7z a openmama-%VERSION%.win.%PLATFORM%.zip %APPVEYOR_BUILD_FOLDER%\build\openmama-%VERSION%.win.%PLATFORM%
 
   # Linux build
 - sh: docker build -t omdocker -f release_scripts/Dockerfile . --build-arg IMAGE=$DOCKER_IMAGE
-- sh: docker run -e VERSION=6.2.3 -v $(pwd):/apps/release --rm omdocker
-- sh: ls -ltr
-- sh: cloudsmith whoami
+- sh: docker run -e VERSION=$VERSION -v $(pwd):/apps/release --rm omdocker
+
+artifacts:
+  - path: openmama-*
+    name: OpenMAMA
 
 test: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,11 +6,13 @@ environment:
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     PLATFORM: x86
     BUILD_TYPE: RelWithDebInfo
+    JAVA_HOME: C:\Program Files (x86)\Java\jdk1.8.0
 
   - GENERATOR: Visual Studio 15 2017 Win64
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     PLATFORM: x64
     BUILD_TYPE: RelWithDebInfo
+    JAVA_HOME: C:\Program Files\Java\jdk1.8.0
 
   - APPVEYOR_BUILD_WORKER_IMAGE: ubuntu1804
     DOCKER_IMAGE: fedora:26
@@ -38,7 +40,6 @@ environment:
 
 init:
 - cmd: set OPENMAMA_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%\install
-- cmd: set JAVA_HOME=C:\Program Files\Java\jdk1.8.0
 
 # Build chain tooling
 install:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,7 +4,7 @@ environment:
 
   - GENERATOR: Visual Studio 15 2017
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    PLATFORM: Win32
+    PLATFORM: x86
     BUILD_TYPE: RelWithDebInfo
 
   - GENERATOR: Visual Studio 15 2017 Win64

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,13 +7,13 @@ environment:
   matrix:
   - DOCKER_IMAGE: none
   - DOCKER_IMAGE: fedora:26
-  - DOCKER_IMAGE: fedora:27
-  - DOCKER_IMAGE: fedora:28
-  - DOCKER_IMAGE: ubuntu:14.04
-  - DOCKER_IMAGE: ubuntu:16.04
-  - DOCKER_IMAGE: ubuntu:18.04
-  - DOCKER_IMAGE: centos:6
-  - DOCKER_IMAGE: centos:7
+  # - DOCKER_IMAGE: fedora:27
+  # - DOCKER_IMAGE: fedora:28
+  # - DOCKER_IMAGE: ubuntu:14.04
+  # - DOCKER_IMAGE: ubuntu:16.04
+  # - DOCKER_IMAGE: ubuntu:18.04
+  # - DOCKER_IMAGE: centos:6
+  # - DOCKER_IMAGE: centos:7
 
 matrix:
   exclude:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -64,7 +64,7 @@ build_script:
     cd %APPVEYOR_BUILD_FOLDER%
     mkdir build
     cd build
-    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_CSHARP=ON -DWITH_UNITTEST=ON -DWITH_JAVA=ON -DPROTON_ROOT=C:/tools/vcpkg/installed -DINSTALL_RUNTIME_DEPENDENCIES=ON -DCMAKE_INSTALL_PREFIX=%OPENMAMA_INSTALL_DIR% -G "%GENERATOR%" -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake ..
+    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_CSHARP=ON -DWITH_UNITTEST=ON -DWITH_JAVA=ON -DPROTON_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ -DINSTALL_RUNTIME_DEPENDENCIES=ON -DCMAKE_INSTALL_PREFIX=%OPENMAMA_INSTALL_DIR% -G "%GENERATOR%" -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake ..
     cmake --build . --config RelWithDebInfo --target install
     cd ..
     python release_scripts\ci-run.py

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -38,7 +38,6 @@ environment:
 
 init:
 - cmd: set OPENMAMA_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%\install
-- cmd: set GENERATOR="Visual Studio 15 2017 Win64"
 - cmd: set JAVA_HOME=C:\Program Files\Java\jdk1.8.0
 
 # Build chain tooling

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,49 +1,47 @@
 # Build worker image (VM template)
-image:
-- ubuntu1804
-- Visual Studio 2017
-
 environment:
   matrix:
-  - DOCKER_IMAGE: none
-  - DOCKER_IMAGE: fedora:26
-  - DOCKER_IMAGE: fedora:27
-  - DOCKER_IMAGE: fedora:28
-  - DOCKER_IMAGE: ubuntu:14.04
-  - DOCKER_IMAGE: ubuntu:16.04
-  - DOCKER_IMAGE: ubuntu:18.04
-  - DOCKER_IMAGE: centos:6
-  - DOCKER_IMAGE: centos:7
 
-matrix:
-  exclude:
-    - image: Visual Studio 2017
-      DOCKER_IMAGE: fedora:26
-    - image: Visual Studio 2017
-      DOCKER_IMAGE: fedora:27
-    - image: Visual Studio 2017
-      DOCKER_IMAGE: fedora:28
-    - image: Visual Studio 2017
-      DOCKER_IMAGE: ubuntu:14.04
-    - image: Visual Studio 2017
-      DOCKER_IMAGE: ubuntu:16.04
-    - image: Visual Studio 2017
-      DOCKER_IMAGE: ubuntu:18.04
-    - image: Visual Studio 2017
-      DOCKER_IMAGE: centos:6
-    - image: Visual Studio 2017
-      DOCKER_IMAGE: centos:7
-    - image: ubuntu1804
-      DOCKER_IMAGE: none
-    - image: ubuntu1804
-      platform: x86
+  - GENERATOR: Visual Studio 15 2017
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    PLATFORM: Win32
+    BUILD_TYPE: RelWithDebInfo
+
+  - GENERATOR: Visual Studio 15 2017 Win64
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    PLATFORM: x64
+    BUILD_TYPE: RelWithDebInfo
+
+  - APPVEYOR_BUILD_WORKER_IMAGE: ubuntu1804
+    DOCKER_IMAGE: fedora:26
+
+  - APPVEYOR_BUILD_WORKER_IMAGE: ubuntu1804
+    DOCKER_IMAGE: fedora:27
+
+  - APPVEYOR_BUILD_WORKER_IMAGE: ubuntu1804
+    DOCKER_IMAGE: fedora:28
+
+  - APPVEYOR_BUILD_WORKER_IMAGE: ubuntu1804
+    DOCKER_IMAGE: ubuntu:14.04
+
+  - APPVEYOR_BUILD_WORKER_IMAGE: ubuntu1804
+    DOCKER_IMAGE: ubuntu:16.04
+
+  - APPVEYOR_BUILD_WORKER_IMAGE: ubuntu1804
+    DOCKER_IMAGE: ubuntu:18.04
+
+  - APPVEYOR_BUILD_WORKER_IMAGE: ubuntu1804
+    DOCKER_IMAGE: centos:6
+
+  - APPVEYOR_BUILD_WORKER_IMAGE: ubuntu1804
+    DOCKER_IMAGE: centos:7
 
 init:
 - cmd: set OPENMAMA_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%\install
 - cmd: set GENERATOR="Visual Studio 15 2017 Win64"
 - cmd: set JAVA_HOME=C:\Program Files\Java\jdk1.8.0
 
-# scripts that run after cloning repository
+# Build chain tooling
 install:
 - cmd: choco install -y unzip gow wget gradle nunit-console-runner nunit-extension-nunit-v2-driver
 - cmd: refreshenv
@@ -57,89 +55,25 @@ install:
 - sh: sudo apt-get install -y docker python
 - sh: sudo pip install --upgrade cloudsmith-cli
 
-# build platform, i.e. x86, x64, Any CPU. This setting is optional.
-platform:
-- x64
-- x86
+# Dependencies
+before_build:
+- cmd: vcpkg install qpid-proton:%PLATFORM%-windows libevent:%PLATFORM%-windows apr:%PLATFORM%-windows gtest:%PLATFORM%-windows
 
-for:
--
-  matrix:
-    only:
-    - image: Visual Studio 2017
-      DOCKER_IMAGE: none
+build_script:
+  # Windows build
+- cmd: |-
+    cd %APPVEYOR_BUILD_FOLDER%
+    mkdir build
+    cd build
+    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_CSHARP=ON -DWITH_UNITTEST=ON -DWITH_JAVA=ON -DINSTALL_RUNTIME_DEPENDENCIES=ON -DCMAKE_INSTALL_PREFIX=%OPENMAMA_INSTALL_DIR% -G %GENERATOR% -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake ..
+    cmake --build . --config RelWithDebInfo --target install
+    cd ..
+    python release_scripts\ci-run.py
 
-  # scripts to run before build
-  before_build:
-  - cmd: vcpkg install qpid-proton:%PLATFORM%-windows libevent:%PLATFORM%-windows apr:%PLATFORM%-windows gtest:%PLATFORM%-windows
-#  - cmd: |-
-#      mkdir %APPVEYOR_BUILD_FOLDER%\qpid-proton
-#      cd %APPVEYOR_BUILD_FOLDER%\qpid-proton
-#      wget "https://github.com/apache/qpid-proton/archive/0.15.0.zip"
-#      unzip 0.15.0.zip
-#      cd qpid-proton-0.15.0
-#      mkdir bld
-#      cd bld
-#      cmake -DBUILD_TESTING=OFF -DBUILD_JAVA=OFF -DBUILD_CPP=OFF .. -G %GENERATOR%
-#      cmake --build . --config Release --target install
-#  - cmd: |-
-#      mkdir %APPVEYOR_BUILD_FOLDER%\googletest
-#      cd %APPVEYOR_BUILD_FOLDER%\googletest
-#      wget "https://github.com/google/googletest/archive/release-1.8.0.zip"
-#      unzip release-1.8.0.zip
-#      cd googletest-release-1.8.0
-#      mkdir bld
-#      cd bld
-#      cmake -DCMAKE_CXX_FLAGS=-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING -DBUILD_SHARED_LIBS=ON -DBUILD_GTEST=ON -DBUILD_GMOCK=OFF -G %GENERATOR% ..
-#      cmake --build . --config Release --target install
-#  - cmd: |-
-#      mkdir %APPVEYOR_BUILD_FOLDER%\..\libevent
-#      cd %APPVEYOR_BUILD_FOLDER%\..\libevent
-#      wget "https://github.com/libevent/libevent/archive/release-2.1.8-stable.tar.gz"
-#      cmake -E tar xzf release-2.1.8-stable.tar.gz
-#      cd libevent-release-2.1.8-stable
-#      mkdir bld
-#      cd bld
-#      cmake -DEVENT__DISABLE_OPENSSL=ON -G %GENERATOR% ..
-#      type include\event2\event-config.h
-#      cmake --build . --config Release --target install
-#  - cmd: |-
-#      mkdir %APPVEYOR_BUILD_FOLDER%\apr
-#      cd %APPVEYOR_BUILD_FOLDER%\apr
-#      wget "https://github.com/apache/apr/archive/1.6.3.zip"
-#      unzip 1.6.3.zip
-#      dir
-#      cd apr-1.6.3
-#      mkdir bld
-#      cd bld
-#      cmake -G %GENERATOR% ..
-#      cmake --build . --config Release --target install
-
-  # to run your custom scripts instead of automatic MSBuild
-  build_script:
-  - cmd: |-
-      cd %APPVEYOR_BUILD_FOLDER%
-      mkdir build
-      cd build
-      cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_CSHARP=ON -DWITH_UNITTEST=ON -DWITH_JAVA=ON -DINSTALL_RUNTIME_DEPENDENCIES=ON -DCMAKE_INSTALL_PREFIX=%OPENMAMA_INSTALL_DIR% -G %GENERATOR% -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake ..
-      cmake --build . --config RelWithDebInfo --target install
-      cd ..
-      python release_scripts\ci-run.py
-
-  # The build script already tests as well and this one doesnt work for some reason anyway
-  test: off
-
--
-  matrix:
-    only:
-    - image: ubuntu1804
-
-  # to run your custom scripts instead of automatic MSBuild
-  build_script:
+  # Linux build
   - sh: docker build -t omdocker -f release_scripts/Dockerfile . --build-arg IMAGE=$DOCKER_IMAGE
   - sh: docker run -e VERSION=6.2.3 -v $(pwd):/apps/release --rm omdocker
   - sh: ls -ltr
   - sh: cloudsmith whoami
 
-  # The build script already tests as well and this one doesnt work for some reason anyway
-  test: off
+test: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,13 +7,13 @@ environment:
   matrix:
   - DOCKER_IMAGE: none
   - DOCKER_IMAGE: fedora:26
-  # - DOCKER_IMAGE: fedora:27
-  # - DOCKER_IMAGE: fedora:28
-  # - DOCKER_IMAGE: ubuntu:14.04
-  # - DOCKER_IMAGE: ubuntu:16.04
-  # - DOCKER_IMAGE: ubuntu:18.04
-  # - DOCKER_IMAGE: centos:6
-  # - DOCKER_IMAGE: centos:7
+  - DOCKER_IMAGE: fedora:27
+  - DOCKER_IMAGE: fedora:28
+  - DOCKER_IMAGE: ubuntu:14.04
+  - DOCKER_IMAGE: ubuntu:16.04
+  - DOCKER_IMAGE: ubuntu:18.04
+  - DOCKER_IMAGE: centos:6
+  - DOCKER_IMAGE: centos:7
 
 matrix:
   exclude:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,15 +6,15 @@ environment:
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     PLATFORM: x86
     BUILD_TYPE: RelWithDebInfo
-    JAVA_HOME: C:\Progra~2\Java\jdk1.8.0
-    JAVA_HOME_TEST: C:\Program Files (x86)\Java\jdk1.8.0
+    # NB Can't use JAVA_HOME because appveyor trashes it
+    JAVA_HOME_OVERRIDE: C:\Program Files (x86)\Java\jdk1.8.0
 
   - GENERATOR: Visual Studio 15 2017 Win64
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     PLATFORM: x64
     BUILD_TYPE: RelWithDebInfo
-    JAVA_HOME: C:\Progra~1\Java\jdk1.8.0
-    JAVA_HOME_TEST: C:\Program Files\Java\jdk1.8.0
+    # NB Can't use JAVA_HOME because appveyor trashes it
+    JAVA_HOME_OVERRIDE: C:\Program Files\Java\jdk1.8.0
 
   - APPVEYOR_BUILD_WORKER_IMAGE: ubuntu1804
     DOCKER_IMAGE: fedora:26
@@ -66,6 +66,7 @@ install:
 
 build_script:
   # Windows build
+- cmd: set PATH=%JAVA_HOME_OVERRIDE%\bin;%PATH%
 - cmd: |-
     cd %APPVEYOR_BUILD_FOLDER%
     mkdir build
@@ -73,6 +74,8 @@ build_script:
     REM cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_CSHARP=ON -DWITH_UNITTEST=ON -DWITH_JAVA=ON -DPROTON_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ -DGTEST_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ -DINSTALL_RUNTIME_DEPENDENCIES=ON -DCMAKE_INSTALL_PREFIX=%OPENMAMA_INSTALL_DIR% -G "%GENERATOR%" -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DAPR_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ ..
     REM cmake --build . --config RelWithDebInfo --target install
     cd ..
+    set JAVA_HOME=%JAVA_HOME_OVERRIDE%
+    echo %JAVA_HOME_OVERRIDE%
     python release_scripts\ci-run.py
 
   # Linux build

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -45,7 +45,7 @@ init:
 install:
 - cmd: choco install -y unzip gow wget gradle nunit-console-runner nunit-extension-nunit-v2-driver
 - cmd: refreshenv
-- cmd: set PATH=C:\ProgramData\chocolatey\bin;%PATH%
+- cmd: set PATH=C:\ProgramData\chocolatey\bin;%JAVA_HOME%\bin;%PATH%
 # - cmd: |-
 #     cd "C:\Tools\vcpkg"
 #     git pull

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,6 +35,8 @@ matrix:
       DOCKER_IMAGE: centos:7
     - image: ubuntu1804
       DOCKER_IMAGE: none
+    - image: ubuntu1804
+      platform: x86
 
 init:
 - cmd: set OPENMAMA_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%\install

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,6 +33,8 @@ matrix:
       DOCKER_IMAGE: centos:6
     - image: Visual Studio 2017
       DOCKER_IMAGE: centos:7
+    - image: ubuntu1804
+      DOCKER_IMAGE: none
 
 init:
 - cmd: set OPENMAMA_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%\install

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,14 +1,12 @@
 # Build worker image (VM template)
 image:
 - ubuntu1804
-- Visual Studio 2017
+#- Visual Studio 2017
 
 init:
 - cmd: set OPENMAMA_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%\install
 - cmd: set GENERATOR="Visual Studio 15 2017 Win64"
 - cmd: set JAVA_HOME=C:\Program Files\Java\jdk1.8.0
-- sh: export OPENMAMA_INSTALL_DIR=$APPVEYOR_BUILD_FOLDER/install
-- sh: export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 
 # scripts that run after cloning repository
 install:
@@ -16,7 +14,7 @@ install:
 - cmd: refreshenv
 - cmd: set PATH=C:\ProgramData\chocolatey\bin;%PATH%
 - sh: sudo apt-get update -qq
-- sh: sudo apt-get install -y scons git flex uuid-dev libevent-dev cmake git libzmq3-dev openjdk-8-jdk ncurses-dev ant unzip valgrind libapr1-dev
+- sh: sudo apt-get install -y docker python
 
 # build platform, i.e. x86, x64, Any CPU. This setting is optional.
 platform: x64
@@ -65,26 +63,7 @@ before_build:
     cd bld
     cmake -G %GENERATOR% ..
     cmake --build . --config Release --target install
-- sh: |-
-    mkdir $APPVEYOR_BUILD_FOLDER/googletest
-    cd $APPVEYOR_BUILD_FOLDER/googletest
-    wget "https://github.com/google/googletest/archive/release-1.8.0.zip"
-    unzip release-1.8.0.zip
-    cd googletest-release-1.8.0
-    mkdir bld
-    cd bld
-    cmake -DBUILD_TESTING:BOOL=OFF -DBUILD_JAVA:BOOL=OFF -DCMAKE_INSTALL_PREFIX=/usr ..
-    sudo cmake --build . --config Release --target install
-- sh: |-
-    mkdir $APPVEYOR_BUILD_FOLDER\qpid-proton
-    cd $APPVEYOR_BUILD_FOLDER\qpid-proton
-    wget "https://github.com/apache/qpid-proton/archive/0.24.0.zip"
-    unzip 0.24.0.zip
-    cd qpid-proton-0.24.0
-    mkdir bld
-    cd bld
-    cmake -DBUILD_TESTING:BOOL=OFF -DBUILD_CPP:BOOL=OFF -DCMAKE_INSTALL_PREFIX=/usr ..
-    sudo cmake --build . --config Release --target install
+- sh: echo running before build
 
 # to run your custom scripts instead of automatic MSBuild
 build_script:
@@ -96,14 +75,7 @@ build_script:
       cmake --build . --config RelWithDebInfo --target install
       cd ..
       python release_scripts\ci-run.py
-  - sh: |-
-      cd $APPVEYOR_BUILD_FOLDER
-      mkdir build
-      cd build
-      cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_UNITTEST=ON -DWITH_JAVA=ON -DINSTALL_RUNTIME_DEPENDENCIES=ON -DCMAKE_INSTALL_PREFIX=$OPENMAMA_INSTALL_DIR -DCMAKE_CXX_FLAGS=-Werror -DCMAKE_C_FLAGS=-Werror -DJAVA_HOME=$JAVA_HOME ..
-      cmake --build . --config RelWithDebInfo --target install
-      cd ..
-      python release_scripts/ci-run.py
+  - sh: echo running before script
 
 # The build script already tests as well and this one doesnt work for some reason anyway
 test: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,18 @@
 # Build worker image (VM template)
 image:
 - ubuntu1804
-#- Visual Studio 2017
+- Visual Studio 2017
+
+environment:
+  matrix:
+  - DOCKER_IMAGE: fedora:26
+  - DOCKER_IMAGE: fedora:27
+  - DOCKER_IMAGE: fedora:28
+  - DOCKER_IMAGE: ubuntu:14.04
+  - DOCKER_IMAGE: ubuntu:16.04
+  - DOCKER_IMAGE: ubuntu:18.04
+  - DOCKER_IMAGE: centos:6
+  - DOCKER_IMAGE: centos:7
 
 init:
 - cmd: set OPENMAMA_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%\install
@@ -19,54 +30,59 @@ install:
 # build platform, i.e. x86, x64, Any CPU. This setting is optional.
 platform: x64
 
-# scripts to run before build
-before_build:
-- cmd: |-
-    mkdir %APPVEYOR_BUILD_FOLDER%\qpid-proton
-    cd %APPVEYOR_BUILD_FOLDER%\qpid-proton
-    wget "https://github.com/apache/qpid-proton/archive/0.15.0.zip"
-    unzip 0.15.0.zip
-    cd qpid-proton-0.15.0
-    mkdir bld
-    cd bld
-    cmake -DBUILD_TESTING=OFF -DBUILD_JAVA=OFF -DBUILD_CPP=OFF .. -G %GENERATOR%
-    cmake --build . --config Release --target install
-- cmd: |-
-    mkdir %APPVEYOR_BUILD_FOLDER%\googletest
-    cd %APPVEYOR_BUILD_FOLDER%\googletest
-    wget "https://github.com/google/googletest/archive/release-1.8.0.zip"
-    unzip release-1.8.0.zip
-    cd googletest-release-1.8.0
-    mkdir bld
-    cd bld
-    cmake -DCMAKE_CXX_FLAGS=-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING -DBUILD_SHARED_LIBS=ON -DBUILD_GTEST=ON -DBUILD_GMOCK=OFF -G %GENERATOR% ..
-    cmake --build . --config Release --target install
-- cmd: |-
-    mkdir %APPVEYOR_BUILD_FOLDER%\..\libevent
-    cd %APPVEYOR_BUILD_FOLDER%\..\libevent
-    wget "https://github.com/libevent/libevent/archive/release-2.1.8-stable.tar.gz"
-    cmake -E tar xzf release-2.1.8-stable.tar.gz
-    cd libevent-release-2.1.8-stable
-    mkdir bld
-    cd bld
-    cmake -DEVENT__DISABLE_OPENSSL=ON -G %GENERATOR% ..
-    type include\event2\event-config.h
-    cmake --build . --config Release --target install
-- cmd: |-
-    mkdir %APPVEYOR_BUILD_FOLDER%\apr
-    cd %APPVEYOR_BUILD_FOLDER%\apr
-    wget "https://github.com/apache/apr/archive/1.6.3.zip"
-    unzip 1.6.3.zip
-    dir
-    cd apr-1.6.3
-    mkdir bld
-    cd bld
-    cmake -G %GENERATOR% ..
-    cmake --build . --config Release --target install
-- sh: echo running before build
+for:
+-
+  matrix:
+    only:
+     - image: Visual Studio 2017
 
-# to run your custom scripts instead of automatic MSBuild
-build_script:
+  # scripts to run before build
+  before_build:
+  - cmd: |-
+      mkdir %APPVEYOR_BUILD_FOLDER%\qpid-proton
+      cd %APPVEYOR_BUILD_FOLDER%\qpid-proton
+      wget "https://github.com/apache/qpid-proton/archive/0.15.0.zip"
+      unzip 0.15.0.zip
+      cd qpid-proton-0.15.0
+      mkdir bld
+      cd bld
+      cmake -DBUILD_TESTING=OFF -DBUILD_JAVA=OFF -DBUILD_CPP=OFF .. -G %GENERATOR%
+      cmake --build . --config Release --target install
+  - cmd: |-
+      mkdir %APPVEYOR_BUILD_FOLDER%\googletest
+      cd %APPVEYOR_BUILD_FOLDER%\googletest
+      wget "https://github.com/google/googletest/archive/release-1.8.0.zip"
+      unzip release-1.8.0.zip
+      cd googletest-release-1.8.0
+      mkdir bld
+      cd bld
+      cmake -DCMAKE_CXX_FLAGS=-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING -DBUILD_SHARED_LIBS=ON -DBUILD_GTEST=ON -DBUILD_GMOCK=OFF -G %GENERATOR% ..
+      cmake --build . --config Release --target install
+  - cmd: |-
+      mkdir %APPVEYOR_BUILD_FOLDER%\..\libevent
+      cd %APPVEYOR_BUILD_FOLDER%\..\libevent
+      wget "https://github.com/libevent/libevent/archive/release-2.1.8-stable.tar.gz"
+      cmake -E tar xzf release-2.1.8-stable.tar.gz
+      cd libevent-release-2.1.8-stable
+      mkdir bld
+      cd bld
+      cmake -DEVENT__DISABLE_OPENSSL=ON -G %GENERATOR% ..
+      type include\event2\event-config.h
+      cmake --build . --config Release --target install
+  - cmd: |-
+      mkdir %APPVEYOR_BUILD_FOLDER%\apr
+      cd %APPVEYOR_BUILD_FOLDER%\apr
+      wget "https://github.com/apache/apr/archive/1.6.3.zip"
+      unzip 1.6.3.zip
+      dir
+      cd apr-1.6.3
+      mkdir bld
+      cd bld
+      cmake -G %GENERATOR% ..
+      cmake --build . --config Release --target install
+
+  # to run your custom scripts instead of automatic MSBuild
+  build_script:
   - cmd: |-
       cd %APPVEYOR_BUILD_FOLDER%
       mkdir build
@@ -75,7 +91,22 @@ build_script:
       cmake --build . --config RelWithDebInfo --target install
       cd ..
       python release_scripts\ci-run.py
-  - sh: echo running before script
 
-# The build script already tests as well and this one doesnt work for some reason anyway
-test: off
+  # The build script already tests as well and this one doesnt work for some reason anyway
+  test: off
+
+-
+  matrix:
+    only:
+    - image: ubuntu1804
+
+  # scripts to run before build
+  before_build:
+  - sh: echo before_build
+
+  # to run your custom scripts instead of automatic MSBuild
+  build_script:
+  - sh: echo build_script
+
+  # The build script already tests as well and this one doesnt work for some reason anyway
+  test: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -61,7 +61,7 @@ for:
 
   # scripts to run before build
   before_build:
-  - cmd: vcpkg install qpid-proton libevent apr gtest
+  - cmd: vcpkg install qpid-proton:%PLATFORM%-windows libevent:%PLATFORM%-windows apr:%PLATFORM%-windows gtest:%PLATFORM%-windows
   - cmd: |-
       mkdir %APPVEYOR_BUILD_FOLDER%\qpid-proton
       cd %APPVEYOR_BUILD_FOLDER%\qpid-proton
@@ -127,7 +127,7 @@ for:
   # to run your custom scripts instead of automatic MSBuild
   build_script:
   - sh: docker build -t omdocker -f release_scripts/Dockerfile . --build-arg IMAGE=$DOCKER_IMAGE
-  - sh: docker run -e VERSION=6.2.3 -v release:/apps/release --rm -it omdocker
+  - sh: docker run -e VERSION=6.2.3 -v release:/apps/release --rm omdocker
   - sh: find ./release
 
   # The build script already tests as well and this one doesnt work for some reason anyway

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,3 +1,6 @@
+services:
+- docker
+
 # Build worker image (VM template)
 environment:
   matrix:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -65,8 +65,8 @@ build_script:
     cd %APPVEYOR_BUILD_FOLDER%
     mkdir build
     cd build
-    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_CSHARP=ON -DWITH_UNITTEST=ON -DWITH_JAVA=ON -DPROTON_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ -DGTEST_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ -DINSTALL_RUNTIME_DEPENDENCIES=ON -DCMAKE_INSTALL_PREFIX=%OPENMAMA_INSTALL_DIR% -G "%GENERATOR%" -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DAPR_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ ..
-    cmake --build . --config RelWithDebInfo --target install
+    # cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_CSHARP=ON -DWITH_UNITTEST=ON -DWITH_JAVA=ON -DPROTON_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ -DGTEST_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ -DINSTALL_RUNTIME_DEPENDENCIES=ON -DCMAKE_INSTALL_PREFIX=%OPENMAMA_INSTALL_DIR% -G "%GENERATOR%" -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DAPR_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ ..
+    # cmake --build . --config RelWithDebInfo --target install
     cd ..
     python release_scripts\ci-run.py
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -56,8 +56,8 @@ install:
 - sh: sudo pip install --upgrade cloudsmith-cli
 
 # Dependencies
-before_build:
-- cmd: vcpkg install qpid-proton:%PLATFORM%-windows libevent:%PLATFORM%-windows apr:%PLATFORM%-windows gtest:%PLATFORM%-windows
+# before_build:
+# - cmd: vcpkg install qpid-proton:%PLATFORM%-windows libevent:%PLATFORM%-windows apr:%PLATFORM%-windows gtest:%PLATFORM%-windows
 
 build_script:
   # Windows build

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,6 +15,25 @@ environment:
   - DOCKER_IMAGE: centos:6
   - DOCKER_IMAGE: centos:7
 
+matrix:
+  exclude:
+    - image: Visual Studio 2017
+      DOCKER_IMAGE: fedora:26
+    - image: Visual Studio 2017
+      DOCKER_IMAGE: fedora:27
+    - image: Visual Studio 2017
+      DOCKER_IMAGE: fedora:28
+    - image: Visual Studio 2017
+      DOCKER_IMAGE: ubuntu:14.04
+    - image: Visual Studio 2017
+      DOCKER_IMAGE: ubuntu:16.04
+    - image: Visual Studio 2017
+      DOCKER_IMAGE: ubuntu:18.04
+    - image: Visual Studio 2017
+      DOCKER_IMAGE: centos:6
+    - image: Visual Studio 2017
+      DOCKER_IMAGE: centos:7
+
 init:
 - cmd: set OPENMAMA_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%\install
 - cmd: set GENERATOR="Visual Studio 15 2017 Win64"
@@ -101,8 +120,6 @@ for:
   matrix:
     only:
     - image: ubuntu1804
-    exclude:
-    - DOCKER_IMAGE: none
 
   # scripts to run before build
   before_build:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -61,6 +61,7 @@ for:
 
   # scripts to run before build
   before_build:
+  - cmd: vcpkg install qpid-proton libevent apr gtest
   - cmd: |-
       mkdir %APPVEYOR_BUILD_FOLDER%\qpid-proton
       cd %APPVEYOR_BUILD_FOLDER%\qpid-proton
@@ -123,13 +124,11 @@ for:
     only:
     - image: ubuntu1804
 
-  # scripts to run before build
-  before_build:
-  - sh: echo before_build
-
   # to run your custom scripts instead of automatic MSBuild
   build_script:
-  - sh: echo build_script
+  - sh: docker build -t omdocker -f release_scripts/Dockerfile . --build-arg IMAGE=$DOCKER_IMAGE
+  - sh: docker run -e VERSION=6.2.3 -v release:/apps/release --rm -it omdocker
+  - sh: find ./release
 
   # The build script already tests as well and this one doesnt work for some reason anyway
   test: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -46,6 +46,8 @@ install:
 - cmd: choco install -y unzip gow wget gradle nunit-console-runner nunit-extension-nunit-v2-driver
 - cmd: refreshenv
 - cmd: set PATH=C:\ProgramData\chocolatey\bin;%JAVA_HOME%\bin;%PATH%
+- cmd: echo %PATH%
+- cmd: echo %JAVA_HOME%
 # - cmd: |-
 #     cd "C:\Tools\vcpkg"
 #     git pull

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -78,7 +78,7 @@ build_script:
     cmake --build . --config RelWithDebInfo --target install
     cd ..
     python release_scripts\ci-run.py
-    7z a openmama-%VERSION%.win.%PLATFORM%.zip %APPVEYOR_BUILD_FOLDER%\build\openmama-%VERSION%.win.%PLATFORM%
+    7z a openmama-%VERSION%.win.%PLATFORM%.zip "%OPENMAMA_INSTALL_DIR%"
 
   # Linux build
 - sh: docker build -t omdocker -f release_scripts/Dockerfile . --build-arg IMAGE=$DOCKER_IMAGE

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -64,7 +64,7 @@ build_script:
     cd %APPVEYOR_BUILD_FOLDER%
     mkdir build
     cd build
-    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_CSHARP=ON -DWITH_UNITTEST=ON -DWITH_JAVA=ON -DINSTALL_RUNTIME_DEPENDENCIES=ON -DCMAKE_INSTALL_PREFIX=%OPENMAMA_INSTALL_DIR% -G %GENERATOR% -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake ..
+    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_CSHARP=ON -DWITH_UNITTEST=ON -DWITH_JAVA=ON -DINSTALL_RUNTIME_DEPENDENCIES=ON -DCMAKE_INSTALL_PREFIX=%OPENMAMA_INSTALL_DIR% -G "%GENERATOR%" -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake ..
     cmake --build . --config RelWithDebInfo --target install
     cd ..
     python release_scripts\ci-run.py

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,14 +6,14 @@ environment:
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     PLATFORM: x86
     BUILD_TYPE: RelWithDebInfo
-    JAVA_HOME: C:\Program Files (x86)\Java\jdk1.8.0
+    JAVA_HOME: C:\Progra~2\Java\jdk1.8.0
     JAVA_HOME_TEST: C:\Program Files (x86)\Java\jdk1.8.0
 
   - GENERATOR: Visual Studio 15 2017 Win64
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     PLATFORM: x64
     BUILD_TYPE: RelWithDebInfo
-    JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+    JAVA_HOME: C:\Progra~1\Java\jdk1.8.0
     JAVA_HOME_TEST: C:\Program Files\Java\jdk1.8.0
 
   - APPVEYOR_BUILD_WORKER_IMAGE: ubuntu1804

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,6 +5,7 @@ image:
 
 environment:
   matrix:
+  - DOCKER_IMAGE: none
   - DOCKER_IMAGE: fedora:26
   - DOCKER_IMAGE: fedora:27
   - DOCKER_IMAGE: fedora:28
@@ -35,6 +36,7 @@ for:
   matrix:
     only:
      - image: Visual Studio 2017
+       DOCKER_IMAGE: none
 
   # scripts to run before build
   before_build:
@@ -99,6 +101,8 @@ for:
   matrix:
     only:
     - image: ubuntu1804
+    except:
+    - DOCKER_IMAGE: none
 
   # scripts to run before build
   before_build:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -64,7 +64,7 @@ build_script:
     cd %APPVEYOR_BUILD_FOLDER%
     mkdir build
     cd build
-    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_CSHARP=ON -DWITH_UNITTEST=ON -DWITH_JAVA=ON -DINSTALL_RUNTIME_DEPENDENCIES=ON -DCMAKE_INSTALL_PREFIX=%OPENMAMA_INSTALL_DIR% -G "%GENERATOR%" -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake ..
+    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_CSHARP=ON -DWITH_UNITTEST=ON -DWITH_JAVA=ON -DPROTON_ROOT=C:/tools/vcpkg/installed -DINSTALL_RUNTIME_DEPENDENCIES=ON -DCMAKE_INSTALL_PREFIX=%OPENMAMA_INSTALL_DIR% -G "%GENERATOR%" -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake ..
     cmake --build . --config RelWithDebInfo --target install
     cd ..
     python release_scripts\ci-run.py

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -71,9 +71,9 @@ build_script:
     python release_scripts\ci-run.py
 
   # Linux build
-  - sh: docker build -t omdocker -f release_scripts/Dockerfile . --build-arg IMAGE=$DOCKER_IMAGE
-  - sh: docker run -e VERSION=6.2.3 -v $(pwd):/apps/release --rm omdocker
-  - sh: ls -ltr
-  - sh: cloudsmith whoami
+- sh: docker build -t omdocker -f release_scripts/Dockerfile . --build-arg IMAGE=$DOCKER_IMAGE
+- sh: docker run -e VERSION=6.2.3 -v $(pwd):/apps/release --rm omdocker
+- sh: ls -ltr
+- sh: cloudsmith whoami
 
 test: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -46,11 +46,11 @@ install:
 - cmd: choco install -y unzip gow wget gradle nunit-console-runner nunit-extension-nunit-v2-driver
 - cmd: refreshenv
 - cmd: set PATH=C:\ProgramData\chocolatey\bin;%PATH%
-- cmd: |-
-    cd "C:\Tools\vcpkg"
-    git pull
-    .\bootstrap-vcpkg.bat
-    cd %appveyor_build_folder%
+# - cmd: |-
+#     cd "C:\Tools\vcpkg"
+#     git pull
+#     .\bootstrap-vcpkg.bat
+#     cd %appveyor_build_folder%
 - sh: sudo apt-get update -qq
 - sh: sudo apt-get install -y docker python
 - sh: sudo pip install --upgrade cloudsmith-cli
@@ -65,8 +65,8 @@ build_script:
     cd %APPVEYOR_BUILD_FOLDER%
     mkdir build
     cd build
-    # cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_CSHARP=ON -DWITH_UNITTEST=ON -DWITH_JAVA=ON -DPROTON_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ -DGTEST_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ -DINSTALL_RUNTIME_DEPENDENCIES=ON -DCMAKE_INSTALL_PREFIX=%OPENMAMA_INSTALL_DIR% -G "%GENERATOR%" -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DAPR_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ ..
-    # cmake --build . --config RelWithDebInfo --target install
+    REM cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_CSHARP=ON -DWITH_UNITTEST=ON -DWITH_JAVA=ON -DPROTON_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ -DGTEST_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ -DINSTALL_RUNTIME_DEPENDENCIES=ON -DCMAKE_INSTALL_PREFIX=%OPENMAMA_INSTALL_DIR% -G "%GENERATOR%" -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DAPR_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ ..
+    REM cmake --build . --config RelWithDebInfo --target install
     cd ..
     python release_scripts\ci-run.py
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,8 +35,8 @@ for:
 -
   matrix:
     only:
-     - image: Visual Studio 2017
-       DOCKER_IMAGE: none
+    - image: Visual Studio 2017
+      DOCKER_IMAGE: none
 
   # scripts to run before build
   before_build:
@@ -101,7 +101,7 @@ for:
   matrix:
     only:
     - image: ubuntu1804
-    except:
+    exclude:
     - DOCKER_IMAGE: none
 
   # scripts to run before build

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -44,10 +44,10 @@ environment:
     DOCKER_IMAGE: centos:7
 
 init:
-- cmd: set OPENMAMA_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%\openmama-%VERSION%.win.%PLATFORM%
 # TODO: Make programatic
 - cmd: set VERSION=6.2.3
 - sh: export VERSION=6.2.3
+- cmd: set OPENMAMA_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%\openmama-%VERSION%.win.%PLATFORM%
 
 # Build chain tooling
 install:
@@ -74,7 +74,7 @@ build_script:
     cd %APPVEYOR_BUILD_FOLDER%
     mkdir build
     cd build
-    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_CSHARP=ON -DWITH_UNITTEST=ON -DWITH_JAVA=ON -DPROTON_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ -DGTEST_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ -DINSTALL_RUNTIME_DEPENDENCIES=ON -DCMAKE_INSTALL_PREFIX=openmama-%VERSION%.win.%PLATFORM% -G "%GENERATOR%" -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DAPR_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ ..
+    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_CSHARP=ON -DWITH_UNITTEST=ON -DWITH_JAVA=ON -DPROTON_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ -DGTEST_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ -DINSTALL_RUNTIME_DEPENDENCIES=ON -DCMAKE_INSTALL_PREFIX="%OPENMAMA_INSTALL_DIR%"" -G "%GENERATOR%" -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DAPR_ROOT=C:/tools/vcpkg/installed/%PLATFORM%-windows/ ..
     cmake --build . --config RelWithDebInfo --target install
     cd ..
     python release_scripts\ci-run.py

--- a/cmake/FindAPR.cmake
+++ b/cmake/FindAPR.cmake
@@ -38,7 +38,7 @@ FIND_PATH(APR_INCLUDE_DIR apr.h
     /usr/local/apr/include/apr-1
 )
 
-SET(APR_NAMES ${APR_NAMES} apr-1)
+SET(APR_NAMES ${APR_NAMES} libapr-1 apr-1)
 FIND_LIBRARY(APR_LIBRARY
   NAMES ${APR_NAMES}
   PATHS
@@ -47,7 +47,6 @@ FIND_LIBRARY(APR_LIBRARY
     /usr/local/lib
     /usr/local/apr/lib
     /usr/lib/x86_64-linux-gnu
-  NO_DEFAULT_PATH
 )
 
 IF (APR_LIBRARY AND APR_INCLUDE_DIR)

--- a/common/c_cpp/src/gunittest/c/CMakeLists.txt
+++ b/common/c_cpp/src/gunittest/c/CMakeLists.txt
@@ -38,6 +38,9 @@ install(TARGETS UnitTestCommonC
 # Install any dependant libraries
 if (INSTALL_RUNTIME_DEPENDENCIES)
 	if (GTEST_ROOT)
-		install (DIRECTORY ${GTEST_ROOT}/lib/ DESTINATION bin FILES_MATCHING PATTERN "*.dll")
+		if (WIN32)
+			install (DIRECTORY ${GTEST_ROOT}/lib/ DESTINATION bin FILES_MATCHING PATTERN "*gtest*.dll")
+			install (DIRECTORY ${GTEST_ROOT}/bin/ DESTINATION bin FILES_MATCHING PATTERN "*gtest*.dll")
+		endif()
 	endif()
 endif()

--- a/common/c_cpp/src/gunittest/c/strutilstest.cpp
+++ b/common/c_cpp/src/gunittest/c/strutilstest.cpp
@@ -61,20 +61,20 @@ TEST_F (CommonStrutilsTestC, replaceEnvironmentVariableValidBrackets)
     const char* baseDir     = "/tmp";
     const char* logfileName = "/test/logfile.log";
     char*       outputStr   = NULL;
-    char        inputString[30];
-    char        expectedStr[30];
+    char        inputString[41];
+    char        expectedStr[41];
 
     environment_setVariable("TMPDIR", baseDir);
 
     inputString[0] = '\0';
-    strncat (inputString, envVar, 9);
-    strncat (inputString, logfileName, 17);
+    strncat (inputString, envVar, 20);
+    strncat (inputString, logfileName, 20);
 
     outputStr = strReplaceEnvironmentVariable (inputString);
 
     expectedStr[0] = '\0';
-    strncat (expectedStr, baseDir, 4);
-    strncat (expectedStr, logfileName, 17);
+    strncat (expectedStr, baseDir, 20);
+    strncat (expectedStr, logfileName, 20);
 
     ASSERT_STREQ (outputStr, expectedStr);
 
@@ -87,20 +87,20 @@ TEST_F (CommonStrutilsTestC, replaceEnvironmentVariableValidBracketsAlternative)
     const char* baseDir     = "/tmp";
     const char* logfileName = "/test/logfile.log";
     char*       outputStr   = NULL;
-    char        inputString[30];
-    char        expectedStr[30];
+    char        inputString[41];
+    char        expectedStr[41];
 
     environment_setVariable("TMPDIR", baseDir);
 
     inputString[0] = '\0';
-    strncat (inputString, envVar, 9);
-    strncat (inputString, logfileName, 17);
+    strncat (inputString, envVar, 20);
+    strncat (inputString, logfileName, 20);
 
     outputStr = strReplaceEnvironmentVariable (inputString);
 
     expectedStr[0] = '\0';
-    strncat (expectedStr, baseDir, 4);
-    strncat (expectedStr, logfileName, 17);
+    strncat (expectedStr, baseDir, 20);
+    strncat (expectedStr, logfileName, 20);
 
     ASSERT_STREQ (outputStr, expectedStr);
 
@@ -113,13 +113,13 @@ TEST_F (CommonStrutilsTestC, replaceEnvironmentVariableValidMixedBrackets)
     const char* baseDir     = "/tmp";
     const char* logfileName = "/test/logfile.log";
     char*       outputStr   = NULL;
-    char        inputString[30];
+    char        inputString[41];
 
     environment_setVariable("TMPDIR", baseDir);
 
     inputString[0] = '\0';
-    strncat (inputString, envVar, 9);
-    strncat (inputString, logfileName, 17);
+    strncat (inputString, envVar, 20);
+    strncat (inputString, logfileName, 20);
 
     outputStr = strReplaceEnvironmentVariable (inputString);
 
@@ -134,13 +134,13 @@ TEST_F (CommonStrutilsTestC, replaceEnvironmentVariableValidMixedBracketsReverse
     const char* baseDir     = "/tmp";
     const char* logfileName = "/test/logfile.log";
     char*       outputStr   = NULL;
-    char        inputString[30];
+    char        inputString[41];
 
     environment_setVariable("TMPDIR", baseDir);
 
     inputString[0] = '\0';
-    strncat (inputString, envVar, 9);
-    strncat (inputString, logfileName, 17);
+    strncat (inputString, envVar, 20);
+    strncat (inputString, logfileName, 20);
 
     outputStr = strReplaceEnvironmentVariable (inputString);
 
@@ -153,10 +153,10 @@ TEST_F (CommonStrutilsTestC, replaceEnvironmentVariableNoEnvVar)
 {
     const char* logfileName = "/test/logfile.log";
     char*       outputStr   = NULL;
-    char        inputString[20];
+    char        inputString[41];
 
     inputString[0] = '\0';
-    strncat (inputString, logfileName, 17);
+    strncat (inputString, logfileName, 20);
 
     outputStr = strReplaceEnvironmentVariable (inputString);
 
@@ -177,13 +177,13 @@ TEST_F (CommonStrutilsTestC, replaceEnvironmentVariableLargeLogfileStr)
     environment_setVariable("TMPDIR", baseDir);
 
     inputString[0] = '\0';
-    strncat (inputString, envVar, 9);
+    strncat (inputString, envVar, 14);
     strncat (inputString, logfileName, 795);
 
     outputStr = strReplaceEnvironmentVariable (inputString);
 
     expectedStr[0] = '\0';
-    strncat (expectedStr, baseDir, 4);
+    strncat (expectedStr, baseDir, 14);
     strncat (expectedStr, logfileName, 795);
 
     ASSERT_STREQ (outputStr, expectedStr);
@@ -203,13 +203,13 @@ TEST_F (CommonStrutilsTestC, replaceEnvironmentVariableLargePathStr)
     environment_setVariable ("TMPDIR", baseDir);
 
     inputString[0] = '\0';
-    strncat (inputString, envVar, 9);
+    strncat (inputString, envVar, 24);
     strncat (inputString, logfileName,515);
 
     outputStr = strReplaceEnvironmentVariable (inputString);
 
     expectedStr[0] = '\0';
-    strncat (expectedStr, baseDir, 4);
+    strncat (expectedStr, baseDir, 24);
     strncat (expectedStr, logfileName, 515);
 
     ASSERT_STREQ (outputStr, expectedStr);
@@ -223,7 +223,7 @@ TEST_F (CommonStrutilsTestC, replaceMultipleEnvironmentVariableValid)
     const char* baseDir     = "/tmp";
     const char* logfileName = "/test/logfile.log";
     char*       outputStr   = NULL;
-    char        expectedStr[30];
+    char        expectedStr[41];
 
     environment_setVariable("TMPDIR", baseDir);
     environment_setVariable("TMPLOGFILE", logfileName);
@@ -231,8 +231,8 @@ TEST_F (CommonStrutilsTestC, replaceMultipleEnvironmentVariableValid)
     outputStr = strReplaceEnvironmentVariable (envVar);
 
     expectedStr[0] = '\0';
-    strncat (expectedStr, baseDir, 4);
-    strncat (expectedStr, logfileName, 17);
+    strncat (expectedStr, baseDir, 20);
+    strncat (expectedStr, logfileName, 20);
 
     ASSERT_STREQ (outputStr, expectedStr);
 
@@ -247,7 +247,7 @@ TEST_F (CommonStrutilsTestC, replaceMultipleEmbeddedEnvironmentVariableValid)
     const char* secondDir   = "/for";
     const char* logfileName = "/test/logfile.log";
     char*       outputStr   = NULL;
-    char        expectedStr[30];
+    char        expectedStr[41];
 
     environment_setVariable("TMPDIR", baseDirEx);
     environment_setVariable("TMPSECONDDIR", secondDir);
@@ -256,9 +256,9 @@ TEST_F (CommonStrutilsTestC, replaceMultipleEmbeddedEnvironmentVariableValid)
     outputStr = strReplaceEnvironmentVariable (envVar);
 
     expectedStr[0] = '\0';
-    strncat (expectedStr, baseDir, 4);
-    strncat (expectedStr, secondDir, 4);
-    strncat (expectedStr, logfileName, 17);
+    strncat (expectedStr, baseDir, 10);
+    strncat (expectedStr, secondDir, 10);
+    strncat (expectedStr, logfileName, 20);
 
     ASSERT_STREQ (outputStr, expectedStr);
 

--- a/mama/c_cpp/src/c/CMakeLists.txt
+++ b/mama/c_cpp/src/c/CMakeLists.txt
@@ -142,3 +142,9 @@ endif()
 install(DIRECTORY mama/ DESTINATION include/mama)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/mama/version.h" DESTINATION include/mama)
 
+# Install any dependant libraries
+if (INSTALL_RUNTIME_DEPENDENCIES)
+	if (WIN32)
+		install (DIRECTORY ${APR_ROOT}/bin/ DESTINATION bin FILES_MATCHING PATTERN "*apr*.dll")
+	endif()
+endif()

--- a/mama/c_cpp/src/c/dictionary.c
+++ b/mama/c_cpp/src/c/dictionary.c
@@ -829,11 +829,8 @@ checkForDuplicateNames (mamaDictionary dictionary)
 
 char* copyString (const char*  str)
 {
-    /* Windows does not like strdup */
-    size_t len = strlen (str) + 1;
-    char* result = (char*)calloc (len, sizeof (char));
-    strncpy (result, str, len);
-    return result;
+    // Legacy abstraction from when windows did not like strdup, so just strdup now
+    return strdup(str);
 }
 
 void checkFree (char**  str)

--- a/mama/c_cpp/src/c/fielddesc.c
+++ b/mama/c_cpp/src/c/fielddesc.c
@@ -46,9 +46,7 @@ mamaFieldDescriptor_create (
     if(name == NULL) name = "";
     impl->mFid  = fid;
     impl->mType = wType;
-    impl->mName = (char *)calloc (strlen (name)+1, sizeof (char));
-    strncpy (impl->mName, name, strlen (name) + 1);
-
+    impl->mName = strdup(name);
     if (!impl->mName)
     {
         free(impl);

--- a/release_scripts/Dockerfile
+++ b/release_scripts/Dockerfile
@@ -42,8 +42,8 @@ RUN cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
           -DWITH_JAVA=ON \
           -DWITH_UNITTEST=$WITH_UNITTEST \
           -DINSTALL_RUNTIME_DEPENDENCIES=ON \
-          -DCMAKE_CXX_FLAGS="-Werror -Wno-error=strict-prototypes" \
-          -DCMAKE_C_FLAGS="-Werror -Wno-error=strict-prototypes" \
+          -DCMAKE_CXX_FLAGS="-Werror -Wno-error=strict-prototypes -Wno-deprecated-declarations" \
+          -DCMAKE_C_FLAGS="-Werror -Wno-error=strict-prototypes -Wno-deprecated-declarations" \
           ..
 
 # Perform the build and install

--- a/release_scripts/Dockerfile
+++ b/release_scripts/Dockerfile
@@ -36,7 +36,7 @@ ADD . $SRC_DIR
 WORKDIR $SRC_DIR/build
 
 # Configure the build. SDKMAN needs bash. Note strict-prototypes is temporary for cmake on centos bug with -Werror.
-RUN cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+RUN . /etc/profile && cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
           -DBIN_GRADLE=$SDKMAN_DIR/candidates/gradle/current/bin/gradle \
           -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR \
           -DWITH_JAVA=ON \

--- a/release_scripts/Dockerfile
+++ b/release_scripts/Dockerfile
@@ -35,15 +35,15 @@ ADD . $SRC_DIR
 # Run out-of-source builds
 WORKDIR $SRC_DIR/build
 
-# Configure the build. SDKMAN needs bash.
+# Configure the build. SDKMAN needs bash. Note strict-prototypes is temporary for cmake on centos bug with -Werror.
 RUN cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
           -DBIN_GRADLE=$SDKMAN_DIR/candidates/gradle/current/bin/gradle \
           -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR \
           -DWITH_JAVA=ON \
           -DWITH_UNITTEST=$WITH_UNITTEST \
           -DINSTALL_RUNTIME_DEPENDENCIES=ON \
-          -DCMAKE_CXX_FLAGS=-Werror \
-          -DCMAKE_C_FLAGS=-Werror \
+          -DCMAKE_CXX_FLAGS="-Werror -Wno-error=strict-prototypes" \
+          -DCMAKE_C_FLAGS="-Werror -Wno-error=strict-prototypes" \
           ..
 
 # Perform the build and install

--- a/release_scripts/ci-run.py
+++ b/release_scripts/ci-run.py
@@ -76,24 +76,6 @@ if os.name != "nt" and "JAVA_HOME" not in env_var:
 
 if "JAVA_HOME" in env_var:
     scons_cmd.append("java_home=%s" % env_var["JAVA_HOME"])
-    env_var["PATH"] = os.path.join(env_var["JAVA_HOME"], 'bin') + os.pathsep + env_var["PATH"]
-    java_bin = os.path.join(env_var["JAVA_HOME"], 'bin', 'java')
-    print("PATH={}".format(env_var["PATH"]))
-else:
-    print("UNTAINTED PATH={}".format(env_var["PATH"]))
-    java_bin = "java"
-
-run_command(args=["java",
-                  "-version"],
-            fatal_error=True,
-            shell=shell,
-            env=env_var)
-
-run_command(args=[java_bin,
-                  "-version"],
-            fatal_error=True,
-            shell=shell,
-            env=env_var)
 
 if "OPENMAMA_INSTALL_DIR" not in env_var:
     # Fire off the build

--- a/release_scripts/ci-run.py
+++ b/release_scripts/ci-run.py
@@ -77,6 +77,23 @@ if os.name != "nt" and "JAVA_HOME" not in env_var:
 if "JAVA_HOME" in env_var:
     scons_cmd.append("java_home=%s" % env_var["JAVA_HOME"])
     env_var["PATH"] = os.path.join(env_var["JAVA_HOME"], 'bin') + os.pathsep + env_var["PATH"]
+    java_bin = os.path.join(env_var["JAVA_HOME"], 'bin', 'java')
+    print("PATH={}".format(env_var["PATH"]))
+else:
+    print("UNTAINTED PATH={}".format(env_var["PATH"]))
+    java_bin = "java"
+
+run_command(args=["java",
+                  "-version"],
+            fatal_error=True,
+            shell=shell,
+            env=env_var)
+
+run_command(args=[java_bin,
+                  "-version"],
+            fatal_error=True,
+            shell=shell,
+            env=env_var)
 
 if "OPENMAMA_INSTALL_DIR" not in env_var:
     # Fire off the build

--- a/release_scripts/ci-run.py
+++ b/release_scripts/ci-run.py
@@ -76,6 +76,7 @@ if os.name != "nt" and "JAVA_HOME" not in env_var:
 
 if "JAVA_HOME" in env_var:
     scons_cmd.append("java_home=%s" % env_var["JAVA_HOME"])
+    env_var["PATH"] = os.path.join(env_var["JAVA_HOME"], 'bin') os.pathsep + env_var["PATH"]
 
 if "OPENMAMA_INSTALL_DIR" not in env_var:
     # Fire off the build

--- a/release_scripts/ci-run.py
+++ b/release_scripts/ci-run.py
@@ -76,7 +76,7 @@ if os.name != "nt" and "JAVA_HOME" not in env_var:
 
 if "JAVA_HOME" in env_var:
     scons_cmd.append("java_home=%s" % env_var["JAVA_HOME"])
-    env_var["PATH"] = os.path.join(env_var["JAVA_HOME"], 'bin') os.pathsep + env_var["PATH"]
+    env_var["PATH"] = os.path.join(env_var["JAVA_HOME"], 'bin') + os.pathsep + env_var["PATH"]
 
 if "OPENMAMA_INSTALL_DIR" not in env_var:
     # Fire off the build

--- a/release_scripts/ci-run.py
+++ b/release_scripts/ci-run.py
@@ -174,7 +174,7 @@ nunit_console = "C:\\Program Files (x86)\\NUnit 2.6.4\\bin\\nunit-console.exe"
 if not os.path.exists(nunit_console):
     nunit_console = "nunit3-console"
 
-if os.name == "nt":
+if os.name == "nt" and ('PLATFORM' not in env_var or env_var['PLATFORM'] == 'x64'):
     env_var["middlewareName"] = middleware
     env_var["transportName"] = "pub"
     run_command(args=[

--- a/release_scripts/install-dependencies.sh
+++ b/release_scripts/install-dependencies.sh
@@ -71,19 +71,38 @@ then
 	    libevent ncurses apr valgrind python
 fi
 
+# General ubuntu packages
 if [ "$DISTRIB_ID" = "$UBUNTU" ]
 then
     apt-get update -qq
-    apt-get install -qq -y ruby ruby-dev rubygems build-essential \
+    apt-get install -qq -y ruby ruby-dev build-essential \
 	    zip unzip curl git flex uuid-dev libevent-dev \
-	    cmake git libzmq3-dev openjdk-8-jdk ncurses-dev \
-	    unzip valgrind libapr1-dev python
+	    cmake git libzmq3-dev ncurses-dev \
+	    unzip valgrind libapr1-dev python libz-dev
+fi
+
+# Ubuntu 18 specific software
+if [ "$DISTRIB_ID" = "$UBUNTU" ] && [ "${DISTRIB_RELEASE:0:2}" = "18" ]
+then
+    apt-get install -qq -y rubygems openjdk-8-jdk
+fi
+
+# Ubuntu 16 specific software
+if [ "$DISTRIB_ID" = "$UBUNTU" ] && [ "${DISTRIB_RELEASE:0:2}" = "16" ]
+then
+    apt-get install -qq -y openjdk-8-jdk
+fi
+
+# Ubuntu 16 specific software
+if [ "$DISTRIB_ID" = "$UBUNTU" ] && [ "${DISTRIB_RELEASE:0:2}" = "14" ]
+then
+    apt-get install -qq -y openjdk-7-jdk
 fi
 
 test -d $DEPS_DIR || mkdir -p $DEPS_DIR
 
-# Centos version specific dependencies (ruby is too old for FPM)
-if [ "$DISTRIB_ID" = "$RHEL" ] && [ "${DISTRIB_RELEASE:0:1}"  = "6" ]
+# Centos and old ubuntu version specific dependencies (ruby is too old for FPM)
+if [[ ("$DISTRIB_ID" = "$RHEL" && "${DISTRIB_RELEASE:0:1}" = "6") || ("$DISTRIB_ID" = "$UBUNTU" && "${DISTRIB_RELEASE:0:2}" != "18") ]]
 then
     cd $DEPS_DIR
     curl -sL http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.2.tar.gz | tar xz

--- a/release_scripts/install-dependencies.sh
+++ b/release_scripts/install-dependencies.sh
@@ -91,14 +91,14 @@ fi
 if [ "$DISTRIB_ID" = "$UBUNTU" ] && [ "${DISTRIB_RELEASE:0:2}" = "16" ]
 then
     apt-get install -y openjdk-8-jdk libssl-dev
-    echo "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64" > /etc/profile.d/profile.jni
+    echo "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64" > /etc/profile.d/profile.jni.sh
 fi
 
 # Ubuntu 16 specific software
 if [ "$DISTRIB_ID" = "$UBUNTU" ] && [ "${DISTRIB_RELEASE:0:2}" = "14" ]
 then
     apt-get install -y openjdk-7-jdk libssl-dev
-    echo "export JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64" > /etc/profile.d/profile.jni
+    echo "export JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64" > /etc/profile.d/profile.jni.sh
 fi
 
 test -d $DEPS_DIR || mkdir -p $DEPS_DIR

--- a/release_scripts/install-dependencies.sh
+++ b/release_scripts/install-dependencies.sh
@@ -75,7 +75,7 @@ fi
 if [ "$DISTRIB_ID" = "$UBUNTU" ]
 then
     apt-get update -qq
-    apt-get install -qq -y ruby ruby-dev build-essential \
+    apt-get install -y ruby ruby-dev build-essential \
 	    zip unzip curl git flex uuid-dev libevent-dev \
 	    cmake git libzmq3-dev ncurses-dev \
 	    unzip valgrind libapr1-dev python libz-dev
@@ -84,19 +84,19 @@ fi
 # Ubuntu 18 specific software
 if [ "$DISTRIB_ID" = "$UBUNTU" ] && [ "${DISTRIB_RELEASE:0:2}" = "18" ]
 then
-    apt-get install -qq -y rubygems openjdk-8-jdk
+    apt-get install -y rubygems openjdk-8-jdk
 fi
 
 # Ubuntu 16 specific software
 if [ "$DISTRIB_ID" = "$UBUNTU" ] && [ "${DISTRIB_RELEASE:0:2}" = "16" ]
 then
-    apt-get install -qq -y openjdk-8-jdk
+    apt-get install -y openjdk-8-jdk libssl-dev
 fi
 
 # Ubuntu 16 specific software
 if [ "$DISTRIB_ID" = "$UBUNTU" ] && [ "${DISTRIB_RELEASE:0:2}" = "14" ]
 then
-    apt-get install -qq -y openjdk-7-jdk
+    apt-get install -y openjdk-7-jdk libssl-dev
 fi
 
 test -d $DEPS_DIR || mkdir -p $DEPS_DIR

--- a/release_scripts/install-dependencies.sh
+++ b/release_scripts/install-dependencies.sh
@@ -53,7 +53,7 @@ fi
 if [ "$DISTRIB_ID" = "$FEDORA" ]
 then
     echo "Installing fedora specific dependencies"
-    yum install -y libnsl2-devel libffi-devel ruby-devel rubygems redhat-rpm-config
+    yum install -y libnsl2-devel libffi-devel ruby-devel rubygems redhat-rpm-config rpm-build
 fi
 
 if [ "$DISTRIB_ID" = "$RHEL" ]

--- a/release_scripts/install-dependencies.sh
+++ b/release_scripts/install-dependencies.sh
@@ -91,12 +91,14 @@ fi
 if [ "$DISTRIB_ID" = "$UBUNTU" ] && [ "${DISTRIB_RELEASE:0:2}" = "16" ]
 then
     apt-get install -y openjdk-8-jdk libssl-dev
+    echo "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64" > /etc/profile.d/profile.jni
 fi
 
 # Ubuntu 16 specific software
 if [ "$DISTRIB_ID" = "$UBUNTU" ] && [ "${DISTRIB_RELEASE:0:2}" = "14" ]
 then
     apt-get install -y openjdk-7-jdk libssl-dev
+    echo "export JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64" > /etc/profile.d/profile.jni
 fi
 
 test -d $DEPS_DIR || mkdir -p $DEPS_DIR


### PR DESCRIPTION
This will open up the possibility to prepare RPMs from a standard machine, as well as add support for ubuntu. This will create appveyor archives which can then be uploaded to github releases or cloudsmith package managers.