### PR TITLE
Restored conditional in listenermsgcallback.c

### DIFF
--- a/mama/c_cpp/src/c/listenermsgcallback.c
+++ b/mama/c_cpp/src/c/listenermsgcallback.c
@@ -390,8 +390,13 @@ listenerMsgCallback_processMsg( listenerMsgCallback callback, mamaMsg msg,
         case MAMA_MSG_TYPE_BOOK_RECAP:
             if(!isDqEnabled)
             {
-               mamaSubscription_stopWaitForResponse (subscription, ctx);
+               if (!mamaSubscription_getAcceptMultipleInitials (subscription))
+               {
+                    mamaSubscription_stopWaitForResponse (subscription, ctx);
+               }
+
                mamaSubscription_forwardMsg(subscription, msg);
+
             }
             break;
         case MAMA_MSG_TYPE_REFRESH:


### PR DESCRIPTION
Signed-off-by: Aaron Sneddon <asneddon@velatt.com>

# Restored conditional in listenermsgcallback.c
## Summary
This change restores a conditional that was removed with the dqstrategyplugin change. The conditional was removed from  listenermsgcallback.c and without it, a crash was experienced with multiple initial snapshots for a group subscription, and dqstrategy disabled.


## Areas Affected
*Place an 'x' within the braces to check the box*
- [X] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
The dqstrategyplugin change removed a conditional from line 158 in listenermsgcallback.c. The functionality containing this line was moved to dqstrategyplugin.c and down in listenermsgcallback.c into processMsg. The problem is: when the functionality was added to dqstrategyplugin, the conditional guarding stopWaitForResponse was kept, but in processMsg that function call was unguarded with dqstrategy disabled.
This lead to a crash because the response object is getting destroyed after the first initial, and when handling a second initial, an attempt is made to destroy the object again, causing a crash.

## Testing
This change was tested by giving a .diff file to Igor Kovalenko who confirmed that it fixed the issue. 
In house testing was impossible as this crash was not reproducible, so it was necessary to confirm the change with Igor, who reported the problem in the first place. 
