### PR TITLE
Wtable destroy

### DIFF
--- a/common/c_cpp/src/c/thread.c
+++ b/common/c_cpp/src/c/thread.c
@@ -121,6 +121,12 @@ wombatThread_destroy (const char* name)
     /* Remove from Thread Dictionary */
     wtable_remove (gWombatThreadDict, name);
 
+    if (wtable_get_count(gWombatThreadDict) == 0)
+    {
+        wtable_destroy(gWombatThreadDict);
+        gWombatThreadDict = NULL;
+    }
+
     wthread_static_mutex_unlock(&gWombatThreadsMutex);
 
     // Attempt to join the thread to ensure it has terminated

--- a/mama/c_cpp/src/c/mama.c
+++ b/mama/c_cpp/src/c/mama.c
@@ -1538,7 +1538,7 @@ mama_closeCount (unsigned int* count)
 
         }
 
-        /* Once the libraries have been unloaded, clear down the wtable. */
+        /* Once the libraries have been unloaded, clear down and destroy the wtable. */
         wtable_clear (gImpl.payloads.table);
         wtable_destroy(gImpl.payloads.table);
         gImpl.payloads.table = NULL;
@@ -1633,7 +1633,11 @@ mama_closeCount (unsigned int* count)
         mama_freeAppContext(&appContext);
 
     }
-    wInterlocked_decrement(&gImpl.init);
+
+    if (0 < wInterlocked_read(&gImpl.init))
+    {
+        wInterlocked_decrement(&gImpl.init);
+    }
 
     if (count)
         *count = gImpl.myRefCount;

--- a/mama/c_cpp/src/c/mama.c
+++ b/mama/c_cpp/src/c/mama.c
@@ -1369,6 +1369,8 @@ mama_closeCount (unsigned int* count)
 
         /* Once the libraries have been unloaded, clear down the wtable. */
         wtable_clear (gImpl.entitlements.table);
+        wtable_destroy(gImpl.entitlements.table);
+        gImpl.entitlements.table = NULL;
 
         /* Reset the count of loaded entitlements libraries */
         gImpl.entitlements.count = 0;
@@ -1538,6 +1540,8 @@ mama_closeCount (unsigned int* count)
 
         /* Once the libraries have been unloaded, clear down the wtable. */
         wtable_clear (gImpl.payloads.table);
+        wtable_destroy(gImpl.payloads.table);
+        gImpl.payloads.table = NULL;
 
         /* This will shutdown all plugins */
         mama_shutdownPlugins();
@@ -1599,6 +1603,8 @@ mama_closeCount (unsigned int* count)
 
         /* Once the libraries have been unloaded, clear the middlewareTable. */
         wtable_clear (gImpl.middlewares.table);
+        wtable_destroy(gImpl.middlewares.table);
+        gImpl.middlewares.table = NULL;
 
         /* Reset the count of loaded middlewares */
         gImpl.middlewares.count = 0;
@@ -1627,6 +1633,8 @@ mama_closeCount (unsigned int* count)
         mama_freeAppContext(&appContext);
 
     }
+    wInterlocked_decrement(&gImpl.init);
+
     if (count)
         *count = gImpl.myRefCount;
     wthread_static_mutex_unlock (&gImpl.myLock);


### PR DESCRIPTION
# wtable destroy
## Summary
De-allocate memory used by wtables when mama_close is called

## Areas Affected
*Place an 'x' within the braces to check the box*
- [ X] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
Memory allocated by wtables is currently not released when mama_close is called and it shows as memory leak when profiling an OpenMAMA client app.  This change will release the memory.


