### PR TITLE
multiple_open_close

### DIFF
--- a/mama/c_cpp/src/c/dqstrategyplugin/dqstrategyplugin.c
+++ b/mama/c_cpp/src/c/dqstrategyplugin/dqstrategyplugin.c
@@ -927,7 +927,10 @@ checkSeqNum(dqStrategy strategy, mamaMsg msg, int msgType, mamaDqContext* ctx)
 
 mama_status dqstrategyMamaPlugin_shutdownHook(mamaPluginInfo pluginInfo)
 {
+
     free(pluginInfo);
+    pluginInfo = NULL;
+
     return MAMA_STATUS_OK;
 }
 

--- a/mama/c_cpp/src/c/mama.c
+++ b/mama/c_cpp/src/c/mama.c
@@ -1367,9 +1367,11 @@ mama_closeCount (unsigned int* count)
             }
         }
 
-        /* Once the libraries have been unloaded, destroy the wtable. */
+        /* Once the libraries have been unloaded, clear and destroy the wtable. */
+        wtable_clear (gImpl.entitlements.table);
         wtable_destroy (gImpl.entitlements.table);
         gImpl.entitlements.table = NULL;
+
         /* Reset the count of loaded entitlements libraries */
         gImpl.entitlements.count = 0;
 
@@ -1536,9 +1538,11 @@ mama_closeCount (unsigned int* count)
 
         }
 
-        /* Once the libraries have been unloaded, destroy the wtable. */
+        /* Once the libraries have been unloaded, clear and destroy the wtable. */
+        wtable_clear (gImpl.payloads.table);
         wtable_destroy (gImpl.payloads.table);
         gImpl.payloads.table = NULL;
+
         /* This will shutdown all plugins */
         mama_shutdownPlugins();
 
@@ -1597,9 +1601,11 @@ mama_closeCount (unsigned int* count)
             }
         }
 
-        /* Once the libraries have been unloaded, clear the middlewareTable. */
+        /* Once the libraries have been unloaded, clear and destroy the middlewareTable. */
+        wtable_clear(gImpl.middlewares.table);
         wtable_destroy(gImpl.middlewares.table);
         gImpl.middlewares.table = NULL;
+
         /* Reset the count of loaded middlewares */
         gImpl.middlewares.count = 0;
 

--- a/mama/c_cpp/src/c/mama.c
+++ b/mama/c_cpp/src/c/mama.c
@@ -959,7 +959,7 @@ mama_openWithPropertiesCount (const char* path,
     {
         mama_log (MAMA_LOG_LEVEL_WARN, "%s (non entitled)",mama_version);
     }
-    
+
     /* Iterate the currently loaded middleware bridges, log their version, and
      * increment the count of open bridges.
      */
@@ -1367,9 +1367,9 @@ mama_closeCount (unsigned int* count)
             }
         }
 
-        /* Once the libraries have been unloaded, clear down the wtable. */
-        wtable_clear (gImpl.entitlements.table);
-
+        /* Once the libraries have been unloaded, destroy the wtable. */
+        wtable_destroy (gImpl.entitlements.table);
+        gImpl.entitlements.table = NULL;
         /* Reset the count of loaded entitlements libraries */
         gImpl.entitlements.count = 0;
 
@@ -1536,9 +1536,9 @@ mama_closeCount (unsigned int* count)
 
         }
 
-        /* Once the libraries have been unloaded, clear down the wtable. */
-        wtable_clear (gImpl.payloads.table);
-
+        /* Once the libraries have been unloaded, destroy the wtable. */
+        wtable_destroy (gImpl.payloads.table);
+        gImpl.payloads.table = NULL;
         /* This will shutdown all plugins */
         mama_shutdownPlugins();
 
@@ -1598,8 +1598,8 @@ mama_closeCount (unsigned int* count)
         }
 
         /* Once the libraries have been unloaded, clear the middlewareTable. */
-        wtable_clear (gImpl.middlewares.table);
-
+        wtable_destroy(gImpl.middlewares.table);
+        gImpl.middlewares.table = NULL;
         /* Reset the count of loaded middlewares */
         gImpl.middlewares.count = 0;
 
@@ -1629,7 +1629,13 @@ mama_closeCount (unsigned int* count)
     }
     if (count)
         *count = gImpl.myRefCount;
+
+    if(wInterlocked_read (&gImpl.init) > 0)
+    {
+        wInterlocked_decrement (&gImpl.init);
+    }
     wthread_static_mutex_unlock (&gImpl.myLock);
+
     return result;
 }
 

--- a/mama/c_cpp/src/c/plugin.c
+++ b/mama/c_cpp/src/c/plugin.c
@@ -352,7 +352,10 @@ mama_shutdownPlugins (void)
                 /* Fire the user shutdown hook first - if one is present */
                 if (gPlugins[plugin]->mamaPluginShutdownHook != NULL)
                 {
-                    gPlugins[plugin]->mamaPluginShutdownHook (gPlugins[plugin]->mPluginInfo);
+                    if (gPlugins[plugin]->mPluginInfo != NULL)
+                    {
+                        gPlugins[plugin]->mamaPluginShutdownHook (gPlugins[plugin]->mPluginInfo);
+                    }
                 }
 
                 ret = closeSharedLib (gPlugins[plugin]->mPluginHandle);
@@ -379,6 +382,7 @@ mama_shutdownPlugins (void)
     free(gPlugins);
     gPlugins  = NULL;
     gPluginNo = 0;
+    gCurrentPluginSize = 0;
 
     return status;
 }


### PR DESCRIPTION
Fixed issue whereby calling mama_open() and mama_close() several times could result in a core on a subsequent close.

# multiple_open_close
## Summary
Destroys tables on shutdown and decrements variable so that they are repopulated on mama_open(), also includes guarding and freeing of pluginInfo

## Areas Affected
*Place an 'x' within the braces to check the box*
- [X] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Testing
Tested this with an application which allows mama_open() and mama_close() to be called several times in any order

Signed-off-by: Aaron Sneddon <asneddon@velatt.com>
