### PR TITLE
Added docker integration scripts and configs for qpid

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Currently C, C++, C# and Java are all supported languages and Linux and Windows 
 
 You can find more details on supported platforms here [here](https://github.com/OpenMAMA/OpenMAMA/wiki/Platforms)
 
+Docker
+--------------------------------------------------------------------------------
+For docker support for OpenMAMA, please see [our docker guide](docker/README.md).
+
 Downloading the Software
 --------------------------------------------------------------------------------
 You can find the latest stable releases [on the our github releases page](https://github.com/OpenMAMA/OpenMAMA/releases)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,21 @@
+FROM centos:centos7.6.1810
+
+# Set up cloudsmith repository
+RUN curl -1sLf \
+  'https://dl.cloudsmith.io/public/openmama/openmama/cfg/setup/bash.rpm.sh' \
+  | bash
+
+# Go ahead and install openmama. Note config will be in /opt/openmama/config.
+RUN yum install -y openmama
+
+# Add profile script for setting PATHs etc
+ADD profile.openmama.sh /etc/profile.d/
+
+# Add mama.properties with environment variable overrides
+ADD mama.docker.properties /opt/openmama/config/mama.properties
+
+# Add entrypoint script to image
+ADD docker-entrypoint.sh /
+
+# Defer to entrypoint bash script to figure out how to proceed
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,74 @@
+# Official OpenMAMA Docker Image
+
+The OpenMAMA docker image is a CentOS 7 based image containing a default installation
+of OpenMAMA. It may be used to run OpenMAMA based applications within isolated
+containers.
+
+## Setting up docker for communications
+
+If you are using docker compose or already have a docker network defined you can skip
+this part. Docker recommend that user-defined networks are used to facilitate communications
+between docker instances. This provides the primary benefit of automatic DNS resolution
+for your docker images. The simplest way to do this is:
+
+    docker network create openmama-demo
+
+## Using the Docker Image
+
+To run the OpenMAMA image directly with defaults, you can run any OpenMAMA based application:
+
+    docker run --net=openmama-demo --rm --name demo-sub -it openmama/openmama:latest mamalistenc -?
+
+Note that addressing will be done within the docker network itself though,
+so double-connection based messaging middlewares like qpid may struggle
+resolving appropriate request / reply addressing when working from outside
+of the docker network (since the `reply_url` host may not be accessible
+from within the docker network).
+
+There are also a few demo commands you can run. Note that for all these commands,
+the use of `--name` determines the DNS name inside the docker network which
+is used in the default properties, so it must remain unchanged.
+
+To run a basic demo publisher:
+
+    docker run --net=openmama-demo --rm --name demo-basic-pub -it openmama/openmama:latest demo-basic-pub
+
+To run a basic demo subscriber:
+
+    docker run --net=openmama-demo --rm --name demo-basic-sub -it openmama/openmama:latest demo-basic-sub
+
+To run a market data demo subscriber:
+
+    docker run --net=openmama-demo --rm --name demo-pub -it openmama/openmama:latest demo-pub
+
+To run a market data demo subscriber:
+
+    docker run --net=openmama-demo --rm --name demo-sub -it openmama/openmama:latest demo-sub
+
+### Mount Points
+
+The image ships with a default `mama.docker.properties`, but you can provide your own by
+providing a docker mount containing your own configuration files to the environment.
+
+## Extending the OpenMAMA Image
+
+You may inherit this image and run whatever software you like:
+
+```
+FROM openmama:latest
+
+ADD yourappname /
+
+ENTRYPOINT ["/yourappname"]
+```
+
+This allows you to use OpenMAMA's public release without providing your own
+OpenMAMA build.
+
+## Building Docker Images
+
+If you want to build this docker image yourself rather than using the ones from
+dockerhub, you can build from the `docker` subdirectory in the `OpenMAMA`
+repository using:
+
+    docker build -t your-tag-name .

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,60 @@
+#!/bin/bash -l
+# Note that we use -l with the shebang to ensure login scripts are parsed for environment setup
+
+
+# Host names for the demo transports
+export DEMO_PUBLISHER_HOST=${DEMO_PUBLISHER_HOST:-demo-pub}
+export DEMO_SUBSCRIBER_HOST=${DEMO_SUBSCRIBER_HOST:-demo-sub}
+export DEMO_BASIC_PUBLISHER_HOST=${DEMO_BASIC_PUBLISHER_HOST:-demo-basic-pub}
+export DEMO_BASIC_SUBSCRIBER_HOST=${DEMO_BASIC_SUBSCRIBER_HOST:-demo-basic-sub}
+
+# Defaults for demo
+OM_DICTIONARY_FILE=${OM_DICTIONARY_FILE:-/opt/openmama/data/dictionaries/data.dict}
+OM_PLAYBACK_FILE=${OM_PLAYBACK_FILE:-/opt/openmama/data/playbacks/openmama_utpcasheuro_capture.5000.10.qpid.mplay}
+OM_SYMBOL=${OM_SYMBOL:-DE000CM95AU4.EUR.XPAR}
+OM_MIDDLEWARE=${OM_MIDDLEWARE:-qpid}
+OM_SOURCE=${OM_SOURCE:-OM}
+OM_BASIC_SYMBOL=${OM_BASIC_SYMBOL:-DEMO_TOPIC}
+
+# Run demo commands or allow caller to provide their own
+if [ -z "$1" ] || [ "$1" = "demo-pub" ]; then
+    # Market data publisher
+    set -x
+    capturereplayc \
+        -dictionary $OM_DICTIONARY_FILE \
+        -m $OM_MIDDLEWARE \
+        -S $OM_SOURCE \
+        -tport demo_pub \
+        -f $OM_PLAYBACK_FILE \
+        -v -v -v -v
+elif [ "$1" = "demo-sub" ]; then
+    # Market data subscriber
+    set -x
+    mamalistenc \
+        -m $OM_MIDDLEWARE \
+        -S $OM_SOURCE \
+        -tport demo_sub \
+        -s $OM_SYMBOL \
+        -v -v -v -v
+elif [ "$1" = "demo-basic-pub" ]; then
+    # Basic publisher
+    set -x
+    mamapublisherc \
+        -s $OM_BASIC_SYMBOL \
+        -tport demo_basic_pub \
+        -m $OM_MIDDLEWARE \
+        -v -v -v -v
+elif [ "$1" = "demo-basic-sub" ]; then
+    # Basic subscriber
+    set -x
+    mamasubscriberc \
+        -s $OM_BASIC_SYMBOL \
+        -tport demo_basic_sub \
+        -m $OM_MIDDLEWARE \
+        -v -v -v -v
+else
+    # Just run the arguments provided
+    echo "Running $@..."
+    exec "$@"
+fi
+

--- a/docker/mama.docker.properties
+++ b/docker/mama.docker.properties
@@ -1,0 +1,23 @@
+# Where qpid is going to listen to for data to be pushed to
+mama.qpid.transport.demo_basic_pub.incoming_url=amqp://~0.0.0.0:7777
+# Where qpid publisher is to send data to once subscription is created
+mama.qpid.transport.demo_basic_pub.reply_url=amqp://$(DEMO_BASIC_PUBLISHER_HOST):7777
+
+# Source which you are going to consume from
+mama.qpid.transport.demo_basic_sub.outgoing_url=amqp://$(DEMO_BASIC_PUBLISHER_HOST):7777
+# Where qpid is going to listen to for data to be pushed to
+mama.qpid.transport.demo_basic_sub.incoming_url=amqp://~0.0.0.0:6666
+# Where qpid publisher is to send data to once subscription is created
+mama.qpid.transport.demo_basic_sub.reply_url=amqp://$(DEMO_BASIC_SUBSCRIBER_HOST):6666
+
+# Where qpid is going to listen to for data to be pushed to
+mama.qpid.transport.demo_pub.incoming_url=amqp://~0.0.0.0:7777
+# Where qpid publisher is to send data to once subscription is created
+mama.qpid.transport.demo_pub.reply_url=amqp://$(DEMO_PUBLISHER_HOST):7777
+
+# Source which you are going to consume from
+mama.qpid.transport.demo_sub.outgoing_url=amqp://$(DEMO_PUBLISHER_HOST):7777
+# Where qpid is going to listen to for data to be pushed to
+mama.qpid.transport.demo_sub.incoming_url=amqp://~0.0.0.0:6666
+# Where qpid publisher is to send data to once subscription is created
+mama.qpid.transport.demo_sub.reply_url=amqp://$(DEMO_SUBSCRIBER_HOST):6666

--- a/docker/profile.openmama.sh
+++ b/docker/profile.openmama.sh
@@ -1,0 +1,3 @@
+export PATH=/opt/openmama/bin:$PATH
+export LD_LIBRARY_PATH=/opt/openmama/lib:$LD_LIBRARY_PATH
+export WOMBAT_PATH=/opt/openmama/config


### PR DESCRIPTION
This is the code used to produce openmama/openmama on dockerhub. This
allows users to provide applications using only their binary and run
demo apps with and easily swap out components for different
configuration / middlewares etc.

Signed-off-by: Frank Quinn <fquinn@cascadium.io>