### PR TITLE
Update Payload Bridge functions for transcode message support

### DIFF
--- a/mama/c_cpp/src/c/msg.c
+++ b/mama/c_cpp/src/c/msg.c
@@ -1332,7 +1332,7 @@ mamaMsg_addMsg(
     return impl->mPayloadBridge->msgPayloadAddMsg (impl->mPayload,
                                                    name,
                                                    fid,
-                                                   subMsg->mPayload);
+                                                   subMsg);
 
 
 }

--- a/mama/c_cpp/src/c/payload/qpidmsg/payload.c
+++ b/mama/c_cpp/src/c/payload/qpidmsg/payload.c
@@ -4062,7 +4062,14 @@ qpidmsgPayloadImpl_addFieldToPayload (msgPayload                 msg,
     {
         /* Get the message implementation from the field's array */
         qpidmsgPayloadImpl* impl = (qpidmsgPayloadImpl*)field->mDataVector[0];
-        return qpidmsgPayload_addMsg (msg, name, fid, impl);
+        mamaMsg tmpMsg = NULL;
+        mama_status status = qpidmsgPayloadImpl_payloadToMamaMsg (impl,  
+                     &tmpMsg);
+        if (status != MAMA_STATUS_OK) return status;
+        
+        status = qpidmsgPayload_addMsg (msg, name, fid, tmpMsg);
+        mamaMsg_destroy (tmpMsg);
+        return status;
         break;
     }
     case MAMA_FIELD_TYPE_OPAQUE:

--- a/mama/c_cpp/src/c/payload/qpidmsg/payload.c
+++ b/mama/c_cpp/src/c/payload/qpidmsg/payload.c
@@ -1617,11 +1617,10 @@ mama_status
 qpidmsgPayload_addMsg (msgPayload  msg,
                        const char* name,
                        mama_fid_t  fid,
-                       msgPayload  value)
+                       mamaMsg  value)
 {
     qpidmsgPayloadImpl* impl        = (qpidmsgPayloadImpl*) msg;
     mama_status         status      = MAMA_STATUS_OK;
-    mamaMsg             tmpMsg      = NULL;
 
     if (NULL == impl || NULL == value)
     {
@@ -1650,18 +1649,7 @@ qpidmsgPayload_addMsg (msgPayload  msg,
     pn_data_put_list   (impl->mBody);
     pn_data_enter      (impl->mBody);
 
-    /*
-     * addBareMsg expects a mamaMsg, so we must detach payload to create one
-     * here
-     */
-
-    status = qpidmsgPayloadImpl_payloadToMamaMsg ((qpidmsgPayloadImpl*) value,
-		             &tmpMsg);
-
-    qpidmsgPayloadImpl_addBareMsg (msg, tmpMsg);
-
-    /* finished with the temporary message - destroy */
-    mamaMsg_destroy (tmpMsg);
+    qpidmsgPayloadImpl_addBareMsg (msg, value);
 
     /* Exit list */
     pn_data_exit (impl->mBody);
@@ -2368,12 +2356,9 @@ mama_status
 qpidmsgPayload_updateSubMsg (msgPayload          msg,
                              const char*         name,
                              mama_fid_t          fid,
-                             const msgPayload    subMsg)
+                             const mamaMsg       subMsg)
 {
     qpidmsgPayloadImpl* impl    = (qpidmsgPayloadImpl*) msg;
-
-    /* Despite the prototype, subMsg seems to be a mamaMsg, so treat as such */
-    mamaMsg             valMsg  = (mamaMsg) subMsg;
     mama_status         status  = MAMA_STATUS_OK;
 
     if (NULL == impl)
@@ -2398,7 +2383,7 @@ qpidmsgPayload_updateSubMsg (msgPayload          msg,
     pn_data_put_list (impl->mBody);
     pn_data_enter    (impl->mBody);
 
-    status = qpidmsgPayloadImpl_addBareMsg (msg, valMsg);
+    status = qpidmsgPayloadImpl_addBareMsg (msg, subMsg);
 
     pn_data_exit     (impl->mBody);
 

--- a/mama/c_cpp/src/c/payload/qpidmsg/qpidpayloadfunctions.h
+++ b/mama/c_cpp/src/c/payload/qpidmsg/qpidpayloadfunctions.h
@@ -536,7 +536,7 @@ mama_status
 qpidmsgPayload_addMsg           (msgPayload          msg,
                                  const char*         name,
                                  mama_fid_t          fid,
-                                 msgPayload          value);
+                                 mamaMsg          value);
 
 /*=========================================================================
   =                   Payload Add Vector Field Methods                    =
@@ -831,7 +831,7 @@ mama_status
 qpidmsgPayload_updateSubMsg     (msgPayload          msg,
                                  const char*         fname,
                                  mama_fid_t          fid,
-                                 const msgPayload    subMsg);
+                                 const mamaMsg       subMsg);
 
 
 /*=========================================================================

--- a/mama/c_cpp/src/c/payloadbridge.h
+++ b/mama/c_cpp/src/c/payloadbridge.h
@@ -218,7 +218,7 @@ typedef mama_status
 (*msgPayload_addMsg)           (msgPayload          msg,
                                 const char*         name,
                                 mama_fid_t          fid,
-                                msgPayload          value);
+                                mamaMsg             value);
 typedef mama_status
 (*msgPayload_addVectorBool)    (msgPayload          msg,
                                 const char*         name,
@@ -405,7 +405,7 @@ typedef mama_status
 (*msgPayload_updateSubMsg)     (msgPayload          msg,
                                 const char*         fname,
                                 mama_fid_t          fid,
-                                const msgPayload    subMsg);
+                                const mamaMsg       subMsg);
 typedef mama_status
 (*msgPayload_updateVectorMsg)  (msgPayload          msg,
                                 const char*         fname,

--- a/mama/c_cpp/src/gunittest/c/mamamsg/msggeneraltests.cpp
+++ b/mama/c_cpp/src/gunittest/c/mamamsg/msggeneraltests.cpp
@@ -232,7 +232,7 @@ TEST_F (MsgGeneralTestsC, msgCreateFromByteBufferValid)
     mamaMsg_destroy (newMsg);
 }
 
-TEST_F (MsgGeneralTestsC, msgCreateFromByteBufferInValidMsg)
+TEST_F (MsgGeneralTestsC, DISABLED_msgCreateFromByteBufferInValidMsg)
 {
     const void*   buffer       = NULL;
     mama_size_t   bufferLength = 0;
@@ -249,7 +249,7 @@ TEST_F (MsgGeneralTestsC, msgCreateFromByteBufferInValidMsg)
     ASSERT_EQ (mamaMsg_createFromByteBuffer(NULL, buffer, bufferLength), MAMA_STATUS_NULL_ARG);
 }
 
-TEST_F (MsgGeneralTestsC, msgCreateFromByteBufferInValidBuffer)
+TEST_F (MsgGeneralTestsC, DISABLED_msgCreateFromByteBufferInValidBuffer)
 {
     mama_size_t   bufferLength = 0;
     mamaMsg       newMsg       = NULL;
@@ -369,7 +369,7 @@ TEST_F (MsgGeneralTestsC, msgImplSetMessageOwnerValid)
     ASSERT_EQ (mamaMsgImpl_setMessageOwner(mMsg, owner), MAMA_STATUS_OK);
 }
 
-TEST_F (MsgGeneralTestsC, msgImplSetMessageOwnerInValidMsg)
+TEST_F (MsgGeneralTestsC, DISABLED_msgImplSetMessageOwnerInValidMsg)
 {
     const char*  testString = "test"; 
     short        owner      = (short) NULL;
@@ -381,7 +381,7 @@ TEST_F (MsgGeneralTestsC, msgImplSetMessageOwnerInValidMsg)
     ASSERT_EQ (mamaMsgImpl_setMessageOwner(NULL, owner), MAMA_STATUS_NULL_ARG);
 }
 
-TEST_F (MsgGeneralTestsC, msgImplSetMessageOwnerInValidOwner)
+TEST_F (MsgGeneralTestsC, DISABLED_msgImplSetMessageOwnerInValidOwner)
 {
     const char*  testString = "test";
 
@@ -392,7 +392,7 @@ TEST_F (MsgGeneralTestsC, msgImplSetMessageOwnerInValidOwner)
     ASSERT_EQ (mamaMsgImpl_setMessageOwner(mMsg, 0), MAMA_STATUS_NULL_ARG);
 }
 
-TEST_F (MsgGeneralTestsC, msgIterateFieldsValid)
+TEST_F (MsgGeneralTestsC, DISABLED_msgIterateFieldsValid)
 {
     mamaMsgIteratorCb    callback = NULL;
     const mamaDictionary dict     = NULL;
@@ -678,7 +678,7 @@ TEST_F (MsgGeneralTestsC, msgGetDateTimeMSecValid)
     mamaDateTime_destroy(dateTime);
 }
 
-TEST_F (MsgGeneralTestsC, msgGetDateTimeMSecInValidMsg)
+TEST_F (MsgGeneralTestsC, DISABLED_msgGetDateTimeMSecInValidMsg)
 {
     mamaMsg              mMsg         = NULL;
     const char*          name         = "";
@@ -786,7 +786,7 @@ TEST_F (MsgGeneralTestsC, msgGetEntitleCodeInValidMsg)
     ASSERT_EQ (mamaMsg_getEntitleCode(NULL, &entitleCode), MAMA_STATUS_NULL_ARG);
 }
 
-TEST_F (MsgGeneralTestsC, msgGetEntitleCodeInValidEntitleCode)
+TEST_F (MsgGeneralTestsC, DISABLED_msgGetEntitleCodeInValidEntitleCode)
 {
     //add fields to msg
     mamaMsg_addString (mMsg, "name", 100, "test");
@@ -1341,7 +1341,7 @@ TEST_F(MsgCopyTests, CopySameMsg)
     ASSERT_EQ (mStatus, MAMA_STATUS_INVALID_ARG);
 }
 
-TEST_F(MsgCopyTests, CopyNullCopy)
+TEST_F(MsgCopyTests, DISABLED_CopyNullCopy)
 {
     /* This cores as we always dereference copy */
     mStatus = mamaMsg_copy (mMsg, NULL);
@@ -1358,14 +1358,14 @@ TEST_F(MsgCopyTests, TempCopy)
     ASSERT_EQ (mStatus, MAMA_STATUS_OK);
 }
 
-TEST_F(MsgCopyTests, TempCopyNullMsg)
+TEST_F(MsgCopyTests, DISABLED_TempCopyNullMsg)
 {
     /* Cores as there is no NULL checking on src */
     mStatus = mamaMsg_getTempCopy (NULL, &mCopy);
     ASSERT_EQ (mStatus, MAMA_STATUS_NULL_ARG);
 }
 
-TEST_F(MsgCopyTests, TempCopyNullCopy)
+TEST_F(MsgCopyTests, DISABLED_TempCopyNullCopy)
 {
     /* Cores as there is no NULL checking on copy */
     mStatus = mamaMsg_getTempCopy (mMsg, NULL);
@@ -1464,7 +1464,7 @@ TEST_F(MsgApplyMsgTests, ApplyMsgNullMsg)
     ASSERT_EQ (mStatus, MAMA_STATUS_NULL_ARG);
 }
 
-TEST_F(MsgApplyMsgTests, ApplyMsgNullApply)
+TEST_F(MsgApplyMsgTests, DISABLED_ApplyMsgNullApply)
 {
     /* Cores as there is no NULL checking on src */
     mStatus = mamaMsg_applyMsg (mMsg, NULL);

--- a/mama/c_cpp/src/gunittest/c/mamamsg/msggeneraltests.cpp
+++ b/mama/c_cpp/src/gunittest/c/mamamsg/msggeneraltests.cpp
@@ -45,22 +45,24 @@ protected:
     {
         mama_loadPayloadBridge (&mPayloadBridge, getPayload());
         mama_loadBridge (&mMiddlewareBridge, getMiddleware());
-        mama_open();
+
     }
 
     virtual ~MsgGeneralTestsC(void)
     {
-        mama_close();
+
     };
 
     virtual void SetUp(void) 
     {
+        mama_open();
         mamaMsg_create (&mMsg);
     };
 
     virtual void TearDown(void) 
     {
         mamaMsg_destroy(mMsg);
+        mama_close();
     };
     
     mamaMsg            mMsg;
@@ -230,7 +232,7 @@ TEST_F (MsgGeneralTestsC, msgCreateFromByteBufferValid)
     mamaMsg_destroy (newMsg);
 }
 
-TEST_F (MsgGeneralTestsC, DISABLED_msgCreateFromByteBufferInValidMsg)
+TEST_F (MsgGeneralTestsC, msgCreateFromByteBufferInValidMsg)
 {
     const void*   buffer       = NULL;
     mama_size_t   bufferLength = 0;
@@ -247,7 +249,7 @@ TEST_F (MsgGeneralTestsC, DISABLED_msgCreateFromByteBufferInValidMsg)
     ASSERT_EQ (mamaMsg_createFromByteBuffer(NULL, buffer, bufferLength), MAMA_STATUS_NULL_ARG);
 }
 
-TEST_F (MsgGeneralTestsC, DISABLED_msgCreateFromByteBufferInValidBuffer)
+TEST_F (MsgGeneralTestsC, msgCreateFromByteBufferInValidBuffer)
 {
     mama_size_t   bufferLength = 0;
     mamaMsg       newMsg       = NULL;
@@ -338,6 +340,7 @@ TEST_F (MsgGeneralTestsC, msgGetNumFieldsSubMessage)
     EXPECT_EQ (addedFields, numFields);
 
     ASSERT_EQ (MAMA_STATUS_OK, mamaMsg_destroy (submsg));
+    submsg = NULL;
 }
 
 TEST_F (MsgGeneralTestsC, msgGetPayloadTypeValid)
@@ -366,7 +369,7 @@ TEST_F (MsgGeneralTestsC, msgImplSetMessageOwnerValid)
     ASSERT_EQ (mamaMsgImpl_setMessageOwner(mMsg, owner), MAMA_STATUS_OK);
 }
 
-TEST_F (MsgGeneralTestsC, DISABLED_msgImplSetMessageOwnerInValidMsg)
+TEST_F (MsgGeneralTestsC, msgImplSetMessageOwnerInValidMsg)
 {
     const char*  testString = "test"; 
     short        owner      = (short) NULL;
@@ -378,7 +381,7 @@ TEST_F (MsgGeneralTestsC, DISABLED_msgImplSetMessageOwnerInValidMsg)
     ASSERT_EQ (mamaMsgImpl_setMessageOwner(NULL, owner), MAMA_STATUS_NULL_ARG);
 }
 
-TEST_F (MsgGeneralTestsC, DISABLED_msgImplSetMessageOwnerInValidOwner)
+TEST_F (MsgGeneralTestsC, msgImplSetMessageOwnerInValidOwner)
 {
     const char*  testString = "test";
 
@@ -389,7 +392,7 @@ TEST_F (MsgGeneralTestsC, DISABLED_msgImplSetMessageOwnerInValidOwner)
     ASSERT_EQ (mamaMsgImpl_setMessageOwner(mMsg, 0), MAMA_STATUS_NULL_ARG);
 }
 
-TEST_F (MsgGeneralTestsC, DISABLED_msgIterateFieldsValid)
+TEST_F (MsgGeneralTestsC, msgIterateFieldsValid)
 {
     mamaMsgIteratorCb    callback = NULL;
     const mamaDictionary dict     = NULL;
@@ -415,7 +418,7 @@ TEST_F (MsgGeneralTestsC, msgIterateFieldsInValidMsg)
     ASSERT_EQ (mamaMsg_iterateFields (NULL, callback, dict, closure), MAMA_STATUS_NULL_ARG);
 }
 
-TEST_F (MsgGeneralTestsC, DISABLED_msgIterateFieldsInValidCallback)
+TEST_F (MsgGeneralTestsC, msgIterateFieldsInValidCallback)
 {
     const mamaDictionary dict     = NULL;
     void*                closure  = 0;
@@ -427,7 +430,7 @@ TEST_F (MsgGeneralTestsC, DISABLED_msgIterateFieldsInValidCallback)
     ASSERT_EQ (mamaMsg_iterateFields (mMsg, NULL, dict, closure), MAMA_STATUS_NULL_ARG);
 }
 
-TEST_F (MsgGeneralTestsC, DISABLED_msgIterateFieldsInValidDict)
+TEST_F (MsgGeneralTestsC, msgIterateFieldsInValidDict)
 {
     mamaMsgIteratorCb    callback = NULL;
     void*                closure  = 0;
@@ -439,7 +442,7 @@ TEST_F (MsgGeneralTestsC, DISABLED_msgIterateFieldsInValidDict)
     ASSERT_EQ (mamaMsg_iterateFields (mMsg, callback, NULL, closure), MAMA_STATUS_NULL_ARG);
 }
 
-TEST_F (MsgGeneralTestsC, DISABLED_msgIterateFieldsInValidClosure)
+TEST_F (MsgGeneralTestsC, msgIterateFieldsInValidClosure)
 {
     mamaMsgIteratorCb    callback = NULL;
     const mamaDictionary dict     = NULL;
@@ -485,7 +488,7 @@ TEST_F (MsgGeneralTestsC, msgImplSetQueueInValidQueue)
 }
 
 /*
-TEST_F (MsgGeneralTestsC, DISABLED_msgImplSetDqStrategyContextValid)
+TEST_F (MsgGeneralTestsC, msgImplSetDqStrategyContextValid)
 {
     mamaMsg          mMsg               = NULL;
     //mamaDqContext    dqStrategyContext  = NULL;
@@ -499,7 +502,7 @@ TEST_F (MsgGeneralTestsC, DISABLED_msgImplSetDqStrategyContextValid)
     ASSERT_EQ (mamaMsgImpl_setDqStrategyContext(mMsg, &dqStrategyContext), MAMA_STATUS_OK);
 }
 
-TEST_F (MsgGeneralTestsC, DISABLED_msgImplSetDqStrategyContextInValidMsg)
+TEST_F (MsgGeneralTestsC, msgImplSetDqStrategyContextInValidMsg)
 {
     mamaMsg        mMsg               = NULL;
     //mamaDqContext  dqStrategyContext  = NULL;
@@ -513,7 +516,7 @@ TEST_F (MsgGeneralTestsC, DISABLED_msgImplSetDqStrategyContextInValidMsg)
     ASSERT_EQ (mamaMsgImpl_setDqStrategyContext(NULL, &dqStrategyContext), MAMA_STATUS_NULL_ARG);
 }
 
-TEST_F (MsgGeneralTestsC, DISABLED_msgImplSetDqStrategyContextInValidDq)
+TEST_F (MsgGeneralTestsC, msgImplSetDqStrategyContextInValidDq)
 {
     mamaMsg        mMsg               = NULL;
     //mamaDqContext  dqStrategyContext  = NULL;
@@ -675,7 +678,7 @@ TEST_F (MsgGeneralTestsC, msgGetDateTimeMSecValid)
     mamaDateTime_destroy(dateTime);
 }
 
-TEST_F (MsgGeneralTestsC, DISABLED_msgGetDateTimeMSecInValidMsg)
+TEST_F (MsgGeneralTestsC, msgGetDateTimeMSecInValidMsg)
 {
     mamaMsg              mMsg         = NULL;
     const char*          name         = "";
@@ -783,7 +786,7 @@ TEST_F (MsgGeneralTestsC, msgGetEntitleCodeInValidMsg)
     ASSERT_EQ (mamaMsg_getEntitleCode(NULL, &entitleCode), MAMA_STATUS_NULL_ARG);
 }
 
-TEST_F (MsgGeneralTestsC, DISABLED_msgGetEntitleCodeInValidEntitleCode)
+TEST_F (MsgGeneralTestsC, msgGetEntitleCodeInValidEntitleCode)
 {
     //add fields to msg
     mamaMsg_addString (mMsg, "name", 100, "test");
@@ -957,7 +960,7 @@ TEST_F (MsgGeneralTestsC, msgSetNewBufferInValidMsg)
     ASSERT_EQ (mamaMsg_setNewBuffer(NULL, &buffer, size), MAMA_STATUS_NULL_ARG);
 }
 
-TEST_F (MsgGeneralTestsC, DISABLED_msgSetNewBufferInValidBuffer)
+TEST_F (MsgGeneralTestsC, msgSetNewBufferInValidBuffer)
 {
     mamaMsg              mMsg         = NULL;
     const void*          buffer       = NULL;
@@ -1338,7 +1341,7 @@ TEST_F(MsgCopyTests, CopySameMsg)
     ASSERT_EQ (mStatus, MAMA_STATUS_INVALID_ARG);
 }
 
-TEST_F(MsgCopyTests, DISABLED_CopyNullCopy)
+TEST_F(MsgCopyTests, CopyNullCopy)
 {
     /* This cores as we always dereference copy */
     mStatus = mamaMsg_copy (mMsg, NULL);
@@ -1355,14 +1358,14 @@ TEST_F(MsgCopyTests, TempCopy)
     ASSERT_EQ (mStatus, MAMA_STATUS_OK);
 }
 
-TEST_F(MsgCopyTests, DISABLED_TempCopyNullMsg)
+TEST_F(MsgCopyTests, TempCopyNullMsg)
 {
     /* Cores as there is no NULL checking on src */
     mStatus = mamaMsg_getTempCopy (NULL, &mCopy);
     ASSERT_EQ (mStatus, MAMA_STATUS_NULL_ARG);
 }
 
-TEST_F(MsgCopyTests, DISABLED_TempCopyNullCopy)
+TEST_F(MsgCopyTests, TempCopyNullCopy)
 {
     /* Cores as there is no NULL checking on copy */
     mStatus = mamaMsg_getTempCopy (mMsg, NULL);
@@ -1461,7 +1464,7 @@ TEST_F(MsgApplyMsgTests, ApplyMsgNullMsg)
     ASSERT_EQ (mStatus, MAMA_STATUS_NULL_ARG);
 }
 
-TEST_F(MsgApplyMsgTests, DISABLED_ApplyMsgNullApply)
+TEST_F(MsgApplyMsgTests, ApplyMsgNullApply)
 {
     /* Cores as there is no NULL checking on src */
     mStatus = mamaMsg_applyMsg (mMsg, NULL);

--- a/mama/c_cpp/src/gunittest/c/payload/payloadgeneraltests.cpp
+++ b/mama/c_cpp/src/gunittest/c/payload/payloadgeneraltests.cpp
@@ -159,13 +159,16 @@ TEST_F(PayloadGeneralTests, SerializeRoundtrip)
         --fid;
 
     // Create an populate a submessage...
-    msgPayload subMsg = NULL;
-    ret = aBridge->msgPayloadCreate (&subMsg);
+    mamaMsg    subMsg = NULL;
+    msgPayload subMsgPayload = NULL;
+    ret = mamaMsg_create(&subMsg);
+    EXPECT_EQ (MAMA_STATUS_OK, ret);
+    ret = mamaMsgImpl_getPayload(subMsg, &subMsgPayload);
     EXPECT_EQ (MAMA_STATUS_OK, ret);
 
-    ret = aBridge->msgPayloadAddU32 (subMsg, NULL, 101, 123);
+    ret = aBridge->msgPayloadAddU32 (subMsgPayload, NULL, 101, 123);
     EXPECT_EQ (MAMA_STATUS_OK, ret);
-    ret = aBridge->msgPayloadAddString (subMsg, NULL, 102, str);
+    ret = aBridge->msgPayloadAddString (subMsgPayload, NULL, 102, str);
     EXPECT_EQ (MAMA_STATUS_OK, ret);
 
     ret = aBridge->msgPayloadAddMsg (testPayload, NULL, ++fid, subMsg);
@@ -312,7 +315,7 @@ TEST_F(PayloadGeneralTests, SerializeRoundtrip)
 
     EXPECT_EQ (MAMA_STATUS_OK, aBridge->msgPayloadDestroy (testPayload));
     EXPECT_EQ (MAMA_STATUS_OK, aBridge->msgPayloadDestroy (testPayloadIn));
-    EXPECT_EQ (MAMA_STATUS_OK, aBridge->msgPayloadDestroy (subMsg));
+    EXPECT_EQ (MAMA_STATUS_OK, mamaMsg_destroy (subMsg));
 }
 
 /* OPTIONAL TEST:


### PR DESCRIPTION
# Update Payload Bridge functions for transcode message support 
## Summary
Updated payload bridge function definitions to pass mamaMsg types to payload bridges instead of msgPayload.

## Areas Affected
*Place an 'x' within the braces to check the box*
- [x] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [x] Unit Tests
- [ ] Examples

## Details
Issue #297 found that the payload bridge functions where inconsistent passing mamaMsg for the msg modifiers, mamaMsg_addMsg and mamaMsg_updateSubMsg, where mamaMsg_addMsg would pass a msgPayload and mamaMsg_updateSubMsg a mamaMsg for the value. #297 determined that mamaMsg should be pass to the payload bridge instead of msgPayload to allow a payload bridge to transcode messages from different bridges. This pull request should update the two payload bridge function definitions msgPayload_addMsg and msgPayload_updateSubMsg and all references to them in the tests and the smaple bridge qpid.

## Testing
The updated tests should pass.
I verified the tests pass on linux_x64 and Win64 systems, however not using the qpid bridges.
