### PR TITLE
Include system platform headers on windows

### DIFF
--- a/common/c_cpp/src/c/CMakeLists.txt
+++ b/common/c_cpp/src/c/CMakeLists.txt
@@ -46,6 +46,9 @@ if(WIN32)
 endif()
 
 file(GLOB wombat_inst_includes wombat/*.h ${system}/wombat/*.h)
+if(WIN32)
+    file(GLOB wombat_platform_inst_includes ${system}/*.h)
+endif()
 list(APPEND inst_includes
      destroyHandle.h
      list.h
@@ -64,7 +67,10 @@ install(TARGETS wombatcommon wombatcommonstatic
 
 install(FILES ${wombat_inst_includes}
 	DESTINATION include/wombat)
-
+if(WIN32)
+    install(FILES ${wombat_platform_inst_includes}
+        DESTINATION include/${system})
+endif()
 install(FILES ${inst_includes}
 	DESTINATION include)
 


### PR DESCRIPTION
Signed-off-by: Chris Morgan <Christopher.Morgan@solacesystems.com>

# Include system platform headers on windows
## Summary
This is an attempt to fix issue #398 

## Areas Affected
*Place an 'x' within the braces to check the box*
- [X] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
The cmake list will now install the windows platform header files.
