### PR TITLE
need to synchronize timer create/destroy 

### DIFF
--- a/common/c_cpp/src/c/timers.c
+++ b/common/c_cpp/src/c/timers.c
@@ -124,7 +124,7 @@ static void* dispatchEntry (void *closure)
         struct timeval timeout, now, *timeptr;
 
         wthread_mutex_lock (&heap->mLock);
-        ele = RB_MIN (orderedTimeRBTree_, &heap->mTimeTree);        
+        ele = RB_MIN (orderedTimeRBTree_, &heap->mTimeTree);
 
         while (1)
         {
@@ -133,7 +133,7 @@ static void* dispatchEntry (void *closure)
             else
             {
                 timeptr = &timeout;
-                gettimeofday (&now, NULL); 
+                gettimeofday (&now, NULL);
                 if (!timercmp(&ele->mTimeout, &now, >))
                     timerclear (&timeout);
                 else
@@ -144,7 +144,7 @@ static void* dispatchEntry (void *closure)
             /* Sit on Select as it has the best resolution */
             FD_ZERO(&wakeUpDes);
             FD_SET(heap->mSockPair[0], &wakeUpDes);
-        
+
             selectReturn = select(heap->mSockPair[0] + 1, &wakeUpDes, NULL, NULL, timeptr);
 
             wthread_mutex_lock (&heap->mLock);
@@ -196,7 +196,7 @@ endLoop:
     }
     return NULL;
 }
-        
+
 int startDispatchTimerHeap (timerHeap heap)
 {
     if (heap == NULL)
@@ -247,8 +247,8 @@ writeagain:
 
             default:
                 perror ("write()");
-                return -1; 
-            }    
+                return -1;
+            }
         }
 
         wthread_mutex_lock   (&heapImpl->mEndingLock);
@@ -348,7 +348,7 @@ writeagain:
     }
     return 0;
 }
-    
+
 int destroyTimer (timerHeap heap, timerElement timer)
 {
     if ((heap == NULL) || (timer == NULL))
@@ -400,3 +400,24 @@ int resetTimer (timerHeap heap, timerElement timer, struct timeval* timeout)
     }
     return 0;
 }
+
+
+int lockTimerHeap (timerHeap heap)
+{
+    if (heap == NULL)
+        return -1;
+    timerHeapImpl* heapImpl = (timerHeapImpl*)heap;
+
+    return wthread_mutex_lock (&heapImpl->mLock);
+}
+
+
+int unlockTimerHeap (timerHeap heap)
+{
+    if (heap == NULL)
+        return -1;
+    timerHeapImpl* heapImpl = (timerHeapImpl*)heap;
+
+    return wthread_mutex_unlock (&heapImpl->mLock);
+}
+

--- a/common/c_cpp/src/c/timers.h
+++ b/common/c_cpp/src/c/timers.h
@@ -42,6 +42,11 @@ COMMONExpDLL int createTimer (timerElement* timer, timerHeap heap, timerFireCb c
 COMMONExpDLL int destroyTimer (timerHeap heap, timerElement timer);
 COMMONExpDLL int resetTimer (timerHeap heap, timerElement timer, struct timeval* timeout);
 
+
+COMMONExpDLL int lockTimerHeap (timerHeap heap);
+COMMONExpDLL int unlockTimerHeap (timerHeap heap);
+
+
 #if defined(__cplusplus)
 }
 #endif /* __cplusplus */


### PR DESCRIPTION
# need to synchronize timer create/destroy 

## Areas Affected
*Place an 'x' within the braces to check the box*
- [x] MAMAC

## Details
- need to synchronize timer create/destroy -- see https://github.com/nyfix/OZ:

- fix race condition between timer destroy and reset - expose lock/unlock on timer heap (needed to avoid deadlock)	74e7803	wtorpey <bill.torpey@ullink.com>	Dec 12, 2017 at 10:35 AM

