### PR TITLE
provide option to keep payload library loaded even after mama_close

### DIFF
--- a/mama/c_cpp/src/c/mamainternal.h
+++ b/mama/c_cpp/src/c/mamainternal.h
@@ -53,6 +53,9 @@ typedef struct mamaPayloadLib_
 
     /* Indcates if the bridge was allocated by MAMA or the bridge */
     mama_bool_t       mamaAllocated;
+
+    /* Indcates whether to keep the library loaded */
+    mama_bool_t       keepLoaded;
 } mamaPayloadLib;
 
 

--- a/mama/c_cpp/src/c/msg.c
+++ b/mama/c_cpp/src/c/msg.c
@@ -135,8 +135,8 @@ typedef struct mamaMsgImpl_
     mamaBridgeImpl*         mBridgeImpl;
     /*The bridge specific message*/
     msgBridge               mBridgeMessage;
-    /*If we have detached the middleware message we will own it
-     and are responsible for destroying it*/
+    /*If set to 1, mamaMsg_destroy will also call the
+     payload bridge's destroy function*/
     int                     mMessageOwner;
 
     /*The context if this is a msg from the dqStrategy cache*/

--- a/mama/c_cpp/src/c/payloadbridge.h
+++ b/mama/c_cpp/src/c/payloadbridge.h
@@ -1120,8 +1120,6 @@ typedef struct mamaPayloadBridgeImpl_
     msgPayloadIter_associate            msgPayloadIterAssociate;
     msgPayloadIter_destroy              msgPayloadIterDestroy;
 
-    void*                               closure;
-
     /* Back reference to parent library itself */
     mamaPayloadLib*                     payloadLib;
 


### PR DESCRIPTION
# provide option to keep payload library loaded even after mama_close

## Summary
- helps w/RAII-style designs where mamaMsgs may be used outside the bounds of mama_open/mama_close

## Areas Affected
- [x] MAMAC
